### PR TITLE
Properly closes connections, and fixes race condition.

### DIFF
--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -355,7 +355,6 @@ class TCPConnection
     _pending.size() != 0
 
   fun ref event_notify(event: AsioEventID, flags: U32, arg: U32) =>
-    if (PonyAsio.event_fd(_event) != _fd) then return end
     if event is _event then
       if AsioEvent.writeable(flags) then
         writeable()


### PR DESCRIPTION
Firstly, we replaced the `PonyTCP.shutdown()` with `PonyTCP.close()`.  The shutdown(3) stops reading and writing to a socket, it does not close the file descriptor.  As such, we run out after a sufficient number of connections.

Secondly, the race-condition exists in `TCPConnection.read()`:

The function is split into two main sections:

Section 1: Purpose - evaluate what's in the existing buffer, and call the user-provided _on_received() until the existing buffer is empty:

https://github.com/ponylang/lori/blob/7c5b715e81dccc6132b9b06d1507c40d413b683d/lori/tcp_connection.pony#L192-L211

Section 2: Purpose - To read new data into the buffer:

https://github.com/ponylang/lori/blob/7c5b715e81dccc6132b9b06d1507c40d413b683d/lori/tcp_connection.pony#L215-L226

# Race Condition:

When the end-user calls close() in their `_on_received()` callback, the following race condition can occur:

| Actor A (inside a single read() call) | TCPListener | Actor B |
|---------|-------------|---------|
| Executes "section1" as described above. The user's _on_received() calls close() | | |
| The file descriptor is released | | |
| | New connection is received, PonyTCP.accept() returns the same file descriptor (U32) that Actor A gave up, and spawns Actor B and passes said file descriptor | |
| The `read()` function continues to execute with "section2" as described above. Calls PonyTCP.receive(), which reads from the file descriptor that it no longer "owns".  If it hadn't been reallocated then it would quietly fail and life would continue.  However, since it has been reallocated, it reads the data which should have been destined for Actor B | |
| | | The receive buffer has been errantly read from under me by Actor A, so I block - waiting for data to read |

In order to address the race-condition, we have made the following changes:

1. We have reordered `PonyAsio.unsubscribe()` before `PonyTCP.close()`. This prevents an additional event being called that we don't need to see which sometimes caused issues.
2. We check `is_closed()` before we make the actual `PonyTCP.receive()` call.  If we are closed, then we `break` out of the loop so that we never execute the `PonyTCP.receive()` call.





