### PR TITLE
Add callback for when a server accepts a connection

### DIFF
--- a/.release-notes/accepted.md
+++ b/.release-notes/accepted.md
@@ -1,0 +1,3 @@
+## Add callback for when a server accepts a connection
+
+We've added a callback for when a server accepts a connection. This callback is called after the server has accepted a connection and before the server starts processing the request. This allows you to perform any necessary setup before the server starts processing the request.

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -52,6 +52,15 @@ class TCPConnection
       PonyAsio.set_writeable(_event)
     end
     _writeable = true
+
+    match _enclosing
+    | let s: TCPServerActor ref =>
+      s._on_accepted()
+    else
+      // TODO blow up here
+      None
+    end
+
     _readable = true
     // Queue up reads as we are now connected
     // But might have been in a race with ASIO

--- a/lori/tcp_connection_actor.pony
+++ b/lori/tcp_connection_actor.pony
@@ -12,6 +12,11 @@ trait tag TCPClientActor is TCPConnectionActor
     None
 
 trait tag TCPServerActor is TCPConnectionActor
+  fun ref _on_accepted() =>
+    """
+    Called when a connection is accepted
+    """
+    None
 
 trait tag TCPConnectionActor is AsioEventNotify
   fun ref _connection(): TCPConnection


### PR DESCRIPTION
This allows for setting up of additional information at the time when a connection is accepted. This will be required for implementing things like SSL where the server needs to execute a handshake when the connection is initiated.