### PR TITLE
Fix bug in TCPListener

### DIFF
--- a/.release-notes/fix-listener-bug.md
+++ b/.release-notes/fix-listener-bug.md
@@ -1,0 +1,3 @@
+## Listener startup bug fixed
+
+There was a bug in the lifecycle handling for `TCPListener` that could cause errors if you called certain methods from the `_on_listening()` and `_on_listen_failed()` callbacks. This has been fixed.

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -587,6 +587,8 @@ class TCPConnection
       end
     end
 
+  // TODO this should be private but...
+  // https://github.com/ponylang/ponyc/issues/4613
   fun ref finish_initialization() =>
     match _lifecycle_event_receiver
     | let s: ServerLifecycleEventReceiver ref =>

--- a/lori/tcp_listener_actor.pony
+++ b/lori/tcp_listener_actor.pony
@@ -38,3 +38,6 @@ trait tag TCPListenerActor is AsioEventNotify
 
   be _connection_closed(conn: TCPConnection tag) =>
     _listener().connection_closed(conn)
+
+  be _finish_initialization() =>
+    _listener().finish_initialization()


### PR DESCRIPTION
Triggering a callback in the constructor can fail as the enclosing actor won't have had a chance to set its `listener` to our constructed listener.

Any methods called during callbacks from a constructor will be called on the `none()` version of the listener. This is known as "not good".