### PR TITLE
Clean up TCPListener's state field

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -64,3 +64,10 @@ The return type is the `NetAddress` class from the `net` package in the Pony sta
 
 There was a bug in the lifecycle handling for `TCPListener` that could cause errors if you called certain methods from the `_on_listening()` and `_on_listen_failed()` callbacks. This has been fixed.
 
+## Remove `TCPConnectionState`
+
+We've removed the TCPConnectionState union type and the associated primitives `Open` and `Closed`. They are no longer used.
+
+## Make `TCPListener.state` private
+
+Previously, for reasons we don't remember, the `state` property of `TCPListener` was public. It is now private.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes to this project will be documented in this file. This projec
 - An SSL library now required to build Lori ([PR #105](https://github.com/ponylang/lori/pull/105))
 - Several breaking API changes introduced ([PR #105](https://github.com/ponylang/lori/pull/105))
 - Several breaking API changes introduced ([PR #115](https://github.com/ponylang/lori/pull/115))
+- Remove `TCPConnectionState` ([PR #121](https://github.com/ponylang/lori/pull/121))
+- Make `TCPListener.state` private ([PR #121](https://github.com/ponylang/lori/pull/121))
 
 ## [0.5.1] - 2025-02-13
 

--- a/lori/connection_state.pony
+++ b/lori/connection_state.pony
@@ -1,4 +1,0 @@
-primitive Open
-primitive Closed
-
-type TCPConnectionState is (Open | Closed)


### PR DESCRIPTION
It is now called `_listening` and is a Bool instead of a union type. `TCPConnectionState` is no longer used and has been removed.