### PR TITLE
Make `TCPListenerActor.on_closed` private

### DIFF
--- a/.release-notes/xx.md
+++ b/.release-notes/xx.md
@@ -1,0 +1,5 @@
+## Make `TCPListenerActor.on_closed` private
+
+This method is not intended to be called by users of the library, so it should be made private.
+
+Any listener's that you've implemented that implemented `on_closed` need to be updated to override `_on_closed` instead. Failing to do so will result in programs that hang.

--- a/examples/echo-server/echo-server.pony
+++ b/examples/echo-server/echo-server.pony
@@ -25,7 +25,7 @@ actor EchoServer is TCPListenerActor
   fun ref _on_accept(fd: U32): Echoer =>
     Echoer(_server_auth, fd, _out)
 
-  fun ref on_closed() =>
+  fun ref _on_closed() =>
     _out.print("Echo server shut down.")
 
   fun ref _on_listen_failure() =>

--- a/examples/net-ssl-echo-server/net-ssl-echo-server.pony
+++ b/examples/net-ssl-echo-server/net-ssl-echo-server.pony
@@ -57,7 +57,7 @@ actor EchoServer is TCPListenerActor
       error
     end
 
-  fun ref on_closed() =>
+  fun ref _on_closed() =>
     _out.print("Echo server shut down.")
 
   fun ref _on_listen_failure() =>

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -235,7 +235,7 @@ actor \nodoc\ _TestPongerListener is TCPListenerActor
       error
     end
 
-  fun ref on_closed() =>
+  fun ref _on_closed() =>
     try
       (_pinger as _TestPinger).dispose()
     end
@@ -316,7 +316,7 @@ actor \nodoc\ _TestBasicExpectListener is TCPListenerActor
   fun ref _on_accept(fd: U32): _TestBasicExpectServer =>
     _TestBasicExpectServer(_server_auth, fd, _h)
 
-  fun ref on_closed() =>
+  fun ref _on_closed() =>
     try (_client as _TestBasicExpectClient).dispose() end
 
   fun ref _on_listening() =>

--- a/lori/tcp_listener.pony
+++ b/lori/tcp_listener.pony
@@ -38,7 +38,7 @@ class TCPListener
           PonyAsio.unsubscribe(_event)
           PonyTCP.close(_fd)
           _fd = -1
-          e.on_closed()
+          e._on_closed()
         end
       end
     | None =>

--- a/lori/tcp_listener_actor.pony
+++ b/lori/tcp_listener_actor.pony
@@ -6,7 +6,7 @@ trait tag TCPListenerActor is AsioEventNotify
     Called when a connection is accepted
     """
 
-  fun ref on_closed() =>
+  fun ref _on_closed() =>
     """
     Called after the listener is closed
     """


### PR DESCRIPTION
This method is not intended to be called by users of the library, so it should be made private.