### PR TITLE
Undo workaround for ponyc bug

### DIFF
--- a/examples/echo-server/echo-server.pony
+++ b/examples/echo-server/echo-server.pony
@@ -46,7 +46,7 @@ actor Echoer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ServerLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
   fun ref on_closed() =>

--- a/examples/infinite-ping-pong/infinite-ping-pong.pony
+++ b/examples/infinite-ping-pong/infinite-ping-pong.pony
@@ -44,7 +44,7 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ServerLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
   fun ref on_received(data: Array[U8] iso) =>
@@ -67,7 +67,7 @@ actor Client is (TCPConnectionActor & ClientLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ClientLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
   fun ref on_connected() =>

--- a/examples/net-ssl-echo-server/net-ssl-echo-server.pony
+++ b/examples/net-ssl-echo-server/net-ssl-echo-server.pony
@@ -82,7 +82,7 @@ actor Echoer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ServerLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
   fun ref on_closed() =>

--- a/examples/net-ssl-infinite-ping-pong/net-ssl-infinite-ping-pong.pony
+++ b/examples/net-ssl-infinite-ping-pong/net-ssl-infinite-ping-pong.pony
@@ -81,7 +81,7 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ServerLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
   fun ref on_received(data: Array[U8] iso) =>
@@ -106,7 +106,7 @@ actor Client is (TCPConnectionActor & ClientLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ClientLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
   fun ref on_connected() =>

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -47,7 +47,7 @@ actor \nodoc\ _TestOutgoingFailure is (TCPConnectionActor & ClientLifecycleEvent
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ClientLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
   fun ref on_connected() =>
@@ -133,7 +133,7 @@ actor \nodoc\ _TestPinger is (TCPConnectionActor & ClientLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ClientLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
   fun ref on_connected() =>
@@ -183,7 +183,7 @@ actor \nodoc\ _TestPonger is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ServerLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
   fun ref on_received(data: Array[U8] iso) =>
@@ -291,7 +291,7 @@ actor \nodoc\ _TestBasicExpectClient is (TCPConnectionActor & ClientLifecycleEve
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ClientLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
   fun ref on_connected() =>
@@ -347,7 +347,7 @@ actor \nodoc\ _TestBasicExpectServer is (TCPConnectionActor & ServerLifecycleEve
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ServerLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
   fun ref on_received(data: Array[U8] iso) =>
@@ -422,7 +422,7 @@ actor \nodoc\ _TestDoNothingServerActor is (TCPConnectionActor & ServerLifecycle
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ServerLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
  class \nodoc\ iso _TestMute is UnitTest
@@ -513,7 +513,7 @@ actor \nodoc\ _TestMuteClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ClientLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
   fun ref on_connected() =>
@@ -542,7 +542,7 @@ actor \nodoc\ _TestMuteServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ServerLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
   fun ref on_started() =>
@@ -642,7 +642,7 @@ actor \nodoc\ _TestUnmuteClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ClientLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
   fun ref on_connected() =>
@@ -671,7 +671,7 @@ actor \nodoc\ _TestUnmuteServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ServerLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
   fun ref on_started() =>

--- a/lori/net_ssl_connection.pony
+++ b/lori/net_ssl_connection.pony
@@ -43,7 +43,7 @@ class NetSSLClientConnection is ClientLifecycleEventReceiver
   fun ref _connection(): TCPConnection =>
     _lifecycle_event_receiver._connection()
 
-  fun ref _next_lifecycle_event_receiver(): (ClientLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): ClientLifecycleEventReceiver =>
     _lifecycle_event_receiver
 
   fun ref on_connected() =>
@@ -190,7 +190,7 @@ class NetSSLServerConnection is ServerLifecycleEventReceiver
   fun ref _connection(): TCPConnection =>
     _lifecycle_event_receiver._connection()
 
-  fun ref _next_lifecycle_event_receiver(): (ServerLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): ServerLifecycleEventReceiver =>
     _lifecycle_event_receiver
 
   fun ref on_started() =>

--- a/stress-tests/open-close/open-close-stress-test.pony
+++ b/stress-tests/open-close/open-close-stress-test.pony
@@ -117,7 +117,7 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ServerLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
   fun ref on_received(data: Array[U8] iso) =>
@@ -253,7 +253,7 @@ actor Client is (TCPConnectionActor & ClientLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
-  fun ref _next_lifecycle_event_receiver(): (ClientLifecycleEventReceiver | None) =>
+  fun ref _next_lifecycle_event_receiver(): None =>
     None
 
   fun ref on_connected() =>


### PR DESCRIPTION
With https://github.com/ponylang/ponyc/issues/4612 fixed in nightlies, these workarounds with expanding the type in various classes is no longer needed.