### PR TITLE
Fix memory leak

### DIFF
--- a/.release-notes/133.md
+++ b/.release-notes/133.md
@@ -1,0 +1,5 @@
+## Fix possible memory leak
+
+When hard closing a connection, we weren't clearing the list of pending data to send. By not doing that, if there was pending data to send, a lot of objects would be kept live and many things would not get garbage collected. This would result in "a memory leak".
+
+It wasn't actually a leak. Everything in the Pony runtime was working as it should, we just were "doing a bad bad thing".

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -156,6 +156,8 @@ class TCPConnection
     _shutdown = true
     _shutdown_peer = true
 
+    _pending.clear()
+
     PonyAsio.unsubscribe(_event)
     _readable = false
     _writeable = false


### PR DESCRIPTION
Make sure we clear pending send data when hard closing. Failure to do so could result in many things not getting garbage collected.