### PR TITLE
Add epoch to open connection tokens

### DIFF
--- a/lori/tcp_connection_actor.pony
+++ b/lori/tcp_connection_actor.pony
@@ -18,7 +18,7 @@ trait tag TCPConnectionActor is AsioEventNotify
       _connection()._read()
     end
 
-  be _register_spawner(listener: TCPListenerActor, token: USize) =>
+  be _register_spawner(listener: TCPListenerActor, token: _OpenConnectionToken) =>
     """
     Register the listener as the spawner of this connection
     """

--- a/lori/tcp_listener_actor.pony
+++ b/lori/tcp_listener_actor.pony
@@ -33,10 +33,10 @@ trait tag TCPListenerActor is AsioEventNotify
   be _event_notify(event: AsioEventID, flags: U32, arg: U32) =>
     _listener()._event_notify(event, flags, arg)
 
-  be _connection_opened(token: USize) =>
+  be _connection_opened(token: _OpenConnectionToken) =>
     _listener()._connection_opened(token)
 
-  be _connection_closed(token: USize) =>
+  be _connection_closed(token: _OpenConnectionToken) =>
     _listener()._connection_closed(token)
 
   be _finish_initialization() =>


### PR DESCRIPTION
This should handle "many many connections have been opened" better for the unlikely scenario that an id was to wrap around while some "early token holders" are still open.

Now, we need to go through not just USize tokens but USize epochs before we hit a conflict with overlapping ids.