### PR TITLE
Make connection limit more accurate

### DIFF
--- a/.release-notes/limit.md
+++ b/.release-notes/limit.md
@@ -1,0 +1,3 @@
+## Make connection limit more accurate
+
+The previous implementation of connnection limiting could be inaccurate under high-load conditions. This has been updated to us a more accurate method.


### PR DESCRIPTION
Keeping a count across _accept calls for opens we haven't seen yet should be much more accurate. The tricky bit is if we get a close for an open we never saw, we should drop the unseen opens number but if we have seen the connection come back to us then we already have dropped it.