### PR TITLE
Add an extra 50% for runtime of stress tests

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build
         run: make stress-tests config=debug ssl=0.9.0
       - name: Run
-        run: build/debug/open-close 10000000
+        run: build/debug/open-close 15000000
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
@@ -49,7 +49,7 @@ jobs:
           export PATH=/Users/runner/.local/share/ponyup/bin/:$PATH
           make ci config=debug ssl=0.9.0
       - name: Run
-        run: build/debug/open-close 2500000
+        run: build/debug/open-close 3750000
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5
@@ -89,7 +89,7 @@ jobs:
       - name: Run
         run: |
           $env:PATH = 'C:\ponyc\bin;' + $env:PATH;
-          .\build\debug\open-close 1000
+          .\build\debug\open-close 1500
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5


### PR DESCRIPTION
This would take us to the "about 30 minutes mark" from the current "about 20 minutes". Over time this gives us a better chance of hitting an issue without tying up our rate limited GitHub resources "too much".