### PR TITLE
Use 127.0.0.2 in OutgoingFails test to avoid WSL2 mirrored networking bug

### DIFF
--- a/.release-notes/fix-outgoing-fails-wsl2.md
+++ b/.release-notes/fix-outgoing-fails-wsl2.md
@@ -1,0 +1,3 @@
+## Fix OutgoingFails test hanging on WSL2 with mirrored networking
+
+The `OutgoingFails` test would hang on WSL2 when using mirrored networking mode due to a [WSL2 bug](https://github.com/microsoft/WSL/issues/10855) where RST packets for connections to closed ports on `127.0.0.1` have a corrupted destination port. On Linux, the test now connects to `127.0.0.2` instead, which stays within the Linux kernel and gets an immediate connection refusal.

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -36,9 +36,10 @@ actor \nodoc\ _TestOutgoingFailure is (TCPConnectionActor & ClientLifecycleEvent
 
   new create(h: TestHelper) =>
     _h = h
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
     _tcp_connection = TCPConnection.client(
       TCPConnectAuth(_h.env.root),
-      "localhost",
+      host,
       "3245",
       "",
       this,


### PR DESCRIPTION
The `OutgoingFails` test connects to a port where nothing is listening, expecting a quick connection refusal. On WSL2 with mirrored networking, this hangs because of a [WSL2 bug](https://github.com/microsoft/WSL/issues/10855) where RST packets for closed ports on `127.0.0.1` have a corrupted destination port. The kernel drops the misaddressed RST, and the connection sits in SYN-SENT until TCP timeout (~130s).

Switches the test to `127.0.0.2`, which is valid loopback on all POSIX systems and stays within the Linux kernel, getting an immediate ECONNREFUSED.

Closes #152