### PR TITLE
Redesign send system for fallible sends and completion tracking

### DIFF
--- a/.release-notes/redesign-send-system.md
+++ b/.release-notes/redesign-send-system.md
@@ -1,0 +1,41 @@
+## Redesign send system for fallible sends and completion tracking
+
+### Fallible send
+
+`send()` now returns `(SendToken | SendError)` instead of silently accepting data. On failure, a `SendError` tells you why:
+
+- `SendErrorNotConnected` — connection not open (permanent)
+- `SendErrorNotWriteable` — socket under backpressure (wait for `_on_unthrottled`)
+- `SendErrorNotReady` — interceptor handshake in progress (wait for `_on_connected` / `_on_started`)
+
+The library no longer queues data on the application's behalf during backpressure. When `send()` returns `SendErrorNotWriteable`, the application decides what to do — queue the data, drop it, or close the connection.
+
+`is_writeable()` lets you check whether the connection can accept a `send()` call before attempting one.
+
+Existing code that calls `send()` as a fire-and-forget statement still compiles — Pony allows discarding return values. To take advantage of the new API:
+
+```pony
+match _tcp_connection.send(data)
+| let token: SendToken =>
+  // Data accepted; _on_sent(token) fires when handed to OS
+  None
+| let _: SendErrorNotConnected =>
+  // Connection is down
+  None
+| let _: SendErrorNotWriteable =>
+  // Backpressured; queue or drop (your decision)
+  None
+| let _: SendErrorNotReady =>
+  // Interceptor handshake not complete
+  None
+end
+```
+
+### Send completion tracking
+
+On success, `send()` returns a `SendToken` that is later delivered to the new `_on_sent(token)` callback when the data has been fully handed to the OS. Implement `_on_sent` on your lifecycle event receiver to track completion:
+
+```pony
+fun ref _on_sent(token: SendToken) =>
+  // Data identified by token has been fully handed to the OS
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. This projec
 
 - Update ponylang/ssl dependency ([PR #147](https://github.com/ponylang/lori/pull/147))
 - Separate data interception from lifecycle events ([PR #151](https://github.com/ponylang/lori/pull/151))
+- Redesign send system for fallible sends and completion tracking ([PR #154](https://github.com/ponylang/lori/pull/154))
 
 ## [0.6.2] - 2025-07-16
 

--- a/lori/lifecycle_event_receiver.pony
+++ b/lori/lifecycle_event_receiver.pony
@@ -35,6 +35,17 @@ trait ServerLifecycleEventReceiver
     """
     None
 
+  fun ref _on_sent(token: SendToken) =>
+    """
+    Called when data from a successful send() has been fully handed to the
+    OS. The token matches the one returned by send().
+
+    Always fires in a subsequent behavior turn, never synchronously during
+    send(). This guarantees the caller has received and processed the
+    SendToken return value before the callback arrives.
+    """
+    None
+
 trait ClientLifecycleEventReceiver
   """
   Application-level callbacks for client-side TCP connections.
@@ -88,6 +99,17 @@ trait ClientLifecycleEventReceiver
   fun ref _on_unthrottled() =>
     """
     Called when backpressure is released.
+    """
+    None
+
+  fun ref _on_sent(token: SendToken) =>
+    """
+    Called when data from a successful send() has been fully handed to the
+    OS. The token matches the one returned by send().
+
+    Always fires in a subsequent behavior turn, never synchronously during
+    send(). This guarantees the caller has received and processed the
+    SendToken return value before the callback arrives.
     """
     None
 

--- a/lori/send_token.pony
+++ b/lori/send_token.pony
@@ -1,0 +1,41 @@
+class val SendToken is Equatable[SendToken]
+  """
+  Identifies a send operation. Returned by `send()` on success and delivered
+  to `_on_sent()` when the data has been fully handed to the OS.
+
+  Tokens use structural equality based on their ID, which is scoped per
+  connection. Applications managing multiple connections should pair tokens
+  with connection identity to avoid ambiguity.
+  """
+  let id: USize
+
+  new val _create(id': USize) =>
+    id = id'
+
+  fun eq(that: box->SendToken): Bool =>
+    id == that.id
+
+  fun ne(that: box->SendToken): Bool =>
+    not eq(that)
+
+primitive SendErrorNotConnected
+  """
+  The connection is not yet established or has already been closed.
+  """
+
+primitive SendErrorNotWriteable
+  """
+  The socket is not writeable. This happens during backpressure (a previous
+  send is still pending) or when the socket's send buffer is full.
+  Wait for `_on_unthrottled` before retrying.
+  """
+
+primitive SendErrorNotReady
+  """
+  A data interceptor (e.g., SSL) is not ready for application data. This
+  typically means a handshake is still in progress.
+  Wait for `_on_connected` / `_on_started` before retrying.
+  """
+
+type SendError is
+  (SendErrorNotConnected | SendErrorNotWriteable | SendErrorNotReady)

--- a/lori/tcp_connection_actor.pony
+++ b/lori/tcp_connection_actor.pony
@@ -24,5 +24,11 @@ trait tag TCPConnectionActor is AsioEventNotify
     """
     _connection()._register_spawner(listener)
 
+  be _notify_sent(token: SendToken) =>
+    """
+    Deferred delivery of _on_sent to the lifecycle event receiver.
+    """
+    _connection()._fire_on_sent(token)
+
   be _finish_initialization() =>
     _connection()._finish_initialization()


### PR DESCRIPTION
`send()` now returns `(SendToken | SendError)` instead of silently dropping data. Three error types cover distinct failure modes: `SendErrorNotConnected` (permanent), `SendErrorNotWriteable` (backpressure), and `SendErrorNotReady` (interceptor handshake pending). `SendToken` is delivered to the new `_on_sent()` callback when data is fully handed to the OS.

`_on_sent` is always deferred to a subsequent behavior turn via `_notify_sent` on `TCPConnectionActor`, avoiding re-entrancy hazards during `_send_pending_writes`.

`is_writeable()` added for pre-send writeability checks.

SSL interceptors: removed dead `_pending` list that buffered pre-handshake sends (now rejected at the `send()` level with `SendErrorNotReady`).

Design: #150
Closes #136