### PR TITLE
Add docstrings to older examples

### DIFF
--- a/examples/echo-server/echo-server.pony
+++ b/examples/echo-server/echo-server.pony
@@ -1,3 +1,14 @@
+"""
+Minimal echo server demonstrating lori's core pattern.
+
+A listener accepts TCP connections and hands each one to an Echoer actor that
+sends received data back to the client. Shows the three building blocks of a
+lori server: TCPListenerActor for accepting connections, TCPConnectionActor for
+event plumbing, and ServerLifecycleEventReceiver for application callbacks.
+
+Connect with any TCP client (e.g. `netcat localhost 7669`) and type to see
+your input echoed back.
+"""
 use "../../lori"
 
 actor Main

--- a/examples/infinite-ping-pong/infinite-ping-pong.pony
+++ b/examples/infinite-ping-pong/infinite-ping-pong.pony
@@ -1,3 +1,13 @@
+"""
+Client and server exchanging messages in an endless loop.
+
+A listener starts a server, then launches a client that connects and sends
+"Ping". The server prints each message and replies with "Pong". The client
+prints each reply and sends "Ping" again, producing an infinite back-and-forth.
+
+Shows both sides of a TCP conversation: ServerLifecycleEventReceiver for the
+server and ClientLifecycleEventReceiver for the client.
+"""
 use "../../lori"
 
 actor Main

--- a/examples/net-ssl-echo-server/net-ssl-echo-server.pony
+++ b/examples/net-ssl-echo-server/net-ssl-echo-server.pony
@@ -1,3 +1,14 @@
+"""
+SSL version of the echo server.
+
+Follows the same structure as the plain echo server, adding SSLContext setup
+and using TCPConnection.ssl_server instead of TCPConnection.server. The SSL
+handshake happens transparently inside TCPConnection.
+
+Must be run from the project root so the relative certificate paths resolve
+correctly. Connect with an SSL client (e.g. `openssl s_client -connect
+localhost:7669`) to test.
+"""
 use "files"
 use "ssl/net"
 use "../../lori"

--- a/examples/net-ssl-infinite-ping-pong/net-ssl-infinite-ping-pong.pony
+++ b/examples/net-ssl-infinite-ping-pong/net-ssl-infinite-ping-pong.pony
@@ -1,3 +1,11 @@
+"""
+SSL version of infinite ping-pong.
+
+Same Ping/Pong exchange as the plain infinite-ping-pong example, but over SSL.
+Shows both TCPConnection.ssl_server and TCPConnection.ssl_client in the same
+program. Must be run from the project root so the relative certificate paths
+resolve correctly.
+"""
 use "files"
 use "ssl/net"
 use "../../lori"


### PR DESCRIPTION
The backpressure and framed-protocol examples had file-level docstrings explaining what they demonstrate; the four older examples (echo-server, infinite-ping-pong, net-ssl-echo-server, net-ssl-infinite-ping-pong) did not. This adds matching docstrings to all four for consistency.