### PR TITLE
Fix premature _on_unthrottled in Happy Eyeballs connect path

### DIFF
--- a/.release-notes/fix-premature-unthrottled.md
+++ b/.release-notes/fix-premature-unthrottled.md
@@ -1,0 +1,7 @@
+## Fix premature _on_unthrottled during Happy Eyeballs connect
+
+When a client connection succeeded via Happy Eyeballs and the application sent data in `_on_connected` that triggered backpressure (partial write), `_on_unthrottled` was delivered immediately even though the socket was still not writeable and pending data remained unsent. Subsequent `send()` calls would return `SendErrorNotWriteable` despite the application having just been told backpressure was released.
+
+The connection recovers when the next writeable event fires and drains the pending data, but no second `_on_unthrottled` is delivered since the throttle flag was already cleared.
+
+Workaround for older versions: defer sends from `_on_connected` to a subsequent behavior turn so backpressure goes through the normal event path.

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -792,7 +792,6 @@ class TCPConnection
                 _read()
                 if _has_pending_writes() then
                   _send_pending_writes()
-                  _release_backpressure()
                 end
               end
             else


### PR DESCRIPTION
The Happy Eyeballs success path in `_event_notify` called `_release_backpressure()` unconditionally after `_send_pending_writes()`. If a partial write during `_on_connected` triggered `_apply_backpressure()`, `_send_pending_writes()` couldn't drain the pending list (socket not writeable), but `_release_backpressure()` fired anyway — delivering `_on_unthrottled` while the socket was still under backpressure.

`_send_pending_writes()` already calls `_release_backpressure()` internally when the pending list actually drains, matching the normal ASIO event path. Remove the redundant unconditional call.

Closes #163