### PR TITLE
Fix SSL host verification not disabled by set_client_verify(false)

### DIFF
--- a/.release-notes/fix-ssl-host-verification.md
+++ b/.release-notes/fix-ssl-host-verification.md
@@ -1,0 +1,7 @@
+## Fix SSL host verification not disabled by set_client_verify(false)
+
+We've updated the ponylang/ssl dependency to 1.0.2 to pick up a bug fix for SSL host verification.
+
+When `set_client_verify(false)` was called on an `SSLContext`, peer certificate verification was correctly disabled, but hostname verification still ran when a hostname was passed to `SSLContext.client(hostname)`. This meant connections would fail if the server certificate didn't have a SAN or CN matching the hostname, even with verification explicitly disabled.
+
+Hostname verification is now correctly skipped when `set_client_verify(false)` is set.

--- a/corral.json
+++ b/corral.json
@@ -5,7 +5,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/ssl.git",
-      "version": "1.0.1"
+      "version": "1.0.2"
     },
     {
       "locator": "github.com/ponylang/logger.git",


### PR DESCRIPTION
Picks up a fix for `set_client_verify(false)` not disabling hostname verification. Connections would fail if the server certificate didn't have a matching SAN or CN, even with verification explicitly disabled.