### PR TITLE
Add TLS upgrade support (STARTTLS)

### DIFF
--- a/.release-notes/add-tls-upgrade-support.md
+++ b/.release-notes/add-tls-upgrade-support.md
@@ -1,0 +1,37 @@
+## Add TLS upgrade support (STARTTLS)
+
+Lori now supports upgrading an established plaintext TCP connection to TLS mid-stream via `start_tls()`. This enables protocols like PostgreSQL, SMTP, and LDAP that negotiate TLS after an initial plaintext exchange.
+
+```pony
+actor MyClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _sslctx: SSLContext val
+
+  new create(auth: TCPConnectAuth, sslctx: SSLContext val,
+    host: String, port: String)
+  =>
+    _sslctx = sslctx
+    _tcp_connection = TCPConnection.client(auth, host, port, "", this, this)
+
+  fun ref _connection(): TCPConnection => _tcp_connection
+
+  fun ref _on_connected() =>
+    // Negotiate upgrade over plaintext
+    _tcp_connection.send("STARTTLS")
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    if String.from_array(consume data) == "OK" then
+      // Server agreed — initiate TLS handshake
+      _tcp_connection.start_tls(_sslctx, "localhost")
+    end
+
+  fun ref _on_tls_ready() =>
+    // Handshake complete — connection is now encrypted
+    _tcp_connection.send("encrypted payload")
+
+  fun ref _on_tls_failure() =>
+    // Handshake failed — _on_closed will follow
+    None
+```
+
+`start_tls()` returns `None` when the handshake has been started, or a `StartTLSError` if the upgrade cannot proceed (connection not open, already TLS, muted, buffered read data, or pending writes). During the handshake, `send()` returns `SendErrorNotConnected`. When the handshake completes, `_on_tls_ready()` fires. If it fails, `_on_tls_failure()` fires followed by `_on_closed()`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,3 +25,7 @@ SSL version of the echo server. Demonstrates how to set up an `SSLContext` and u
 ## [net-ssl-infinite-ping-pong](net-ssl-infinite-ping-pong/)
 
 SSL version of infinite ping-pong. Shows both `TCPConnection.ssl_server` and `TCPConnection.ssl_client` in the same example.
+
+## [starttls-ping-pong](starttls-ping-pong/)
+
+STARTTLS upgrade from plaintext to TLS mid-connection. The client connects over plain TCP, negotiates a TLS upgrade, and then exchanges Ping/Pong messages over the encrypted connection. Shows `start_tls()` on both client and server, `_on_tls_ready` for post-handshake notification, and the negotiation pattern used by protocols like PostgreSQL and SMTP.

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -19,6 +19,8 @@ actor \nodoc\ Main is TestList
     test(_TestUnmute)
     test(_TestSendToken)
     test(_TestSendAfterClose)
+    test(_TestStartTLSPingPong)
+    test(_TestStartTLSPreconditions)
 
 class \nodoc\ iso _TestOutgoingFails is UnitTest
   """
@@ -927,3 +929,369 @@ actor \nodoc\ _TestSSLPongerListener is TCPListenerActor
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to open _TestSSLPongerListener")
+
+class \nodoc\ iso _TestStartTLSPingPong is UnitTest
+  """
+  Test STARTTLS: connect plain, exchange negotiation, upgrade to TLS, then
+  send encrypted data. Client sends "STARTTLS", server replies "OK" and
+  upgrades, client upgrades, then client sends "Ping" over TLS and server
+  echoes "Pong".
+  """
+  fun name(): String => "StartTLSPingPong"
+
+  fun apply(h: TestHelper) ? =>
+    let port = "9733"
+    let file_auth = FileAuth(h.env.root)
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(file_auth, "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(file_auth, "assets/cert.pem"),
+            FilePath(file_auth, "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    h.expect_action("client tls ready")
+    h.expect_action("server tls ready")
+    h.expect_action("client got pong")
+
+    let listener = _TestStartTLSListener(
+      port, consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestStartTLSClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _sslctx: SSLContext val
+  let _h: TestHelper
+
+  new create(port: String,
+    sslctx: SSLContext val,
+    h: TestHelper)
+  =>
+    _sslctx = sslctx
+    _h = h
+
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(h.env.root),
+      "localhost",
+      port,
+      "",
+      this,
+      this)
+    try _tcp_connection.expect(2)? end
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _tcp_connection.send("STARTTLS")
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    let msg = String.from_array(consume data)
+    if msg == "OK" then
+      match _tcp_connection.start_tls(_sslctx, "localhost")
+      | let _: StartTLSError =>
+        _h.fail("Client start_tls failed")
+        _h.complete(false)
+      end
+    elseif msg == "Pong" then
+      _h.complete_action("client got pong")
+    else
+      _h.fail("Client got unexpected: " + msg)
+    end
+
+  fun ref _on_tls_ready() =>
+    _h.complete_action("client tls ready")
+    try _tcp_connection.expect(4)? end
+    _tcp_connection.send("Ping")
+
+  fun ref _on_tls_failure() =>
+    _h.fail("Client TLS handshake failed")
+
+actor \nodoc\ _TestStartTLSServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _sslctx: SSLContext val
+  let _h: TestHelper
+
+  new create(sslctx: SSLContext val,
+    fd: U32,
+    h: TestHelper)
+  =>
+    _sslctx = sslctx
+    _h = h
+
+    _tcp_connection = TCPConnection.server(
+      TCPServerAuth(_h.env.root),
+      fd,
+      this,
+      this)
+    try _tcp_connection.expect(8)? end
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    let msg = String.from_array(consume data)
+    if msg == "STARTTLS" then
+      _tcp_connection.send("OK")
+      match _tcp_connection.start_tls(_sslctx)
+      | let _: StartTLSError =>
+        _h.fail("Server start_tls failed")
+        _h.complete(false)
+      end
+    elseif msg == "Ping" then
+      _tcp_connection.send("Pong")
+    else
+      _h.fail("Server got unexpected: " + msg)
+    end
+
+  fun ref _on_tls_ready() =>
+    _h.complete_action("server tls ready")
+    try _tcp_connection.expect(4)? end
+
+  fun ref _on_tls_failure() =>
+    _h.fail("Server TLS handshake failed")
+
+actor \nodoc\ _TestStartTLSListener is TCPListenerActor
+  let _port: String
+  let _sslctx: SSLContext val
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _client: (_TestStartTLSClient | None) = None
+
+  new create(port: String,
+    sslctx: SSLContext val,
+    h: TestHelper)
+  =>
+    _port = port
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      _port,
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestStartTLSServer =>
+    _TestStartTLSServer(_sslctx, fd, _h)
+
+  fun ref _on_closed() =>
+    try
+      (_client as _TestStartTLSClient).dispose()
+    end
+
+  fun ref _on_listening() =>
+    _client = _TestStartTLSClient(
+      _port, _sslctx, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestStartTLSListener")
+
+class \nodoc\ iso _TestStartTLSPreconditions is UnitTest
+  """
+  Test that start_tls() returns the correct error for each precondition
+  violation: not connected, already TLS, and not ready (muted).
+  """
+  fun name(): String => "StartTLSPreconditions"
+
+  fun apply(h: TestHelper) ? =>
+    let file_auth = FileAuth(h.env.root)
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(file_auth, "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(file_auth, "assets/cert.pem"),
+            FilePath(file_auth, "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    h.expect_action("not connected verified")
+    h.expect_action("already tls verified")
+    h.expect_action("not ready verified")
+
+    let listener = _TestStartTLSPreconditionsListener(
+      consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestStartTLSPreconditionsNotConnectedClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  """
+  Tests StartTLSNotConnected by calling start_tls on a closed connection.
+  """
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _sslctx: SSLContext val
+  let _h: TestHelper
+
+  new create(port: String,
+    sslctx: SSLContext val,
+    h: TestHelper)
+  =>
+    _sslctx = sslctx
+    _h = h
+
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(h.env.root),
+      "localhost",
+      port,
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _tcp_connection.close()
+    match _tcp_connection.start_tls(_sslctx)
+    | StartTLSNotConnected =>
+      _h.complete_action("not connected verified")
+    else
+      _h.fail("Expected StartTLSNotConnected")
+    end
+
+actor \nodoc\ _TestStartTLSPreconditionsAlreadyTLSClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  """
+  Tests StartTLSAlreadyTLS by calling start_tls on a connection that already
+  has an SSL session. Connects plain, calls start_tls (which sets _ssl), then
+  immediately calls start_tls again to get StartTLSAlreadyTLS.
+  """
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _sslctx: SSLContext val
+  let _h: TestHelper
+
+  new create(port: String,
+    sslctx: SSLContext val,
+    h: TestHelper)
+  =>
+    _sslctx = sslctx
+    _h = h
+
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(h.env.root),
+      "localhost",
+      port,
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    // First start_tls sets _ssl
+    match _tcp_connection.start_tls(_sslctx, "localhost")
+    | None =>
+      // _ssl is now set, second call should fail
+      match _tcp_connection.start_tls(_sslctx, "localhost")
+      | StartTLSAlreadyTLS =>
+        _h.complete_action("already tls verified")
+      else
+        _h.fail("Expected StartTLSAlreadyTLS on second call")
+      end
+    else
+      _h.fail("First start_tls should have succeeded")
+    end
+
+actor \nodoc\ _TestStartTLSPreconditionsNotReadyClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  """
+  Tests StartTLSNotReady by calling start_tls on a muted connection.
+  """
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _sslctx: SSLContext val
+  let _h: TestHelper
+
+  new create(port: String,
+    sslctx: SSLContext val,
+    h: TestHelper)
+  =>
+    _sslctx = sslctx
+    _h = h
+
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(h.env.root),
+      "localhost",
+      port,
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _tcp_connection.mute()
+    match _tcp_connection.start_tls(_sslctx)
+    | StartTLSNotReady =>
+      _h.complete_action("not ready verified")
+    else
+      _h.fail("Expected StartTLSNotReady")
+    end
+
+actor \nodoc\ _TestStartTLSPreconditionsListener is TCPListenerActor
+  let _sslctx: SSLContext val
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _not_connected_client:
+    (_TestStartTLSPreconditionsNotConnectedClient | None) = None
+  var _already_tls_client:
+    (_TestStartTLSPreconditionsAlreadyTLSClient | None) = None
+  var _not_ready_client:
+    (_TestStartTLSPreconditionsNotReadyClient | None) = None
+
+  new create(sslctx: SSLContext val, h: TestHelper) =>
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      "9734",
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestDoNothingServerActor =>
+    _TestDoNothingServerActor(fd, _h)
+
+  fun ref _on_closed() =>
+    try
+      (_not_connected_client
+        as _TestStartTLSPreconditionsNotConnectedClient).dispose()
+    end
+    try
+      (_already_tls_client
+        as _TestStartTLSPreconditionsAlreadyTLSClient).dispose()
+    end
+    try
+      (_not_ready_client
+        as _TestStartTLSPreconditionsNotReadyClient).dispose()
+    end
+
+  fun ref _on_listening() =>
+    let port = "9734"
+    _not_connected_client =
+      _TestStartTLSPreconditionsNotConnectedClient(port, _sslctx, _h)
+    _already_tls_client =
+      _TestStartTLSPreconditionsAlreadyTLSClient(port, _sslctx, _h)
+    _not_ready_client =
+      _TestStartTLSPreconditionsNotReadyClient(port, _sslctx, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestStartTLSPreconditionsListener")

--- a/lori/lifecycle_event_receiver.pony
+++ b/lori/lifecycle_event_receiver.pony
@@ -67,6 +67,24 @@ trait ServerLifecycleEventReceiver
     """
     None
 
+  fun ref _on_tls_ready() =>
+    """
+    Called when a TLS handshake initiated by `start_tls()` completes
+    successfully. The connection is now encrypted and ready for
+    application data over TLS.
+    """
+    None
+
+  fun ref _on_tls_failure() =>
+    """
+    Called when a TLS handshake initiated by `start_tls()` fails. Fires
+    synchronously during `hard_close()`, immediately before `_on_closed()`.
+    The connection was already established (the application received
+    `_on_started` earlier), so `_on_closed` always follows to signal
+    connection teardown.
+    """
+    None
+
 trait ClientLifecycleEventReceiver
   """
   Application-level callbacks for client-side TCP connections.
@@ -143,6 +161,24 @@ trait ClientLifecycleEventReceiver
     Always fires in a subsequent behavior turn, never synchronously during
     hard_close(). Always arrives after _on_closed, which fires synchronously
     during hard_close().
+    """
+    None
+
+  fun ref _on_tls_ready() =>
+    """
+    Called when a TLS handshake initiated by `start_tls()` completes
+    successfully. The connection is now encrypted and ready for
+    application data over TLS.
+    """
+    None
+
+  fun ref _on_tls_failure() =>
+    """
+    Called when a TLS handshake initiated by `start_tls()` fails. Fires
+    synchronously during `hard_close()`, immediately before `_on_closed()`.
+    The connection was already established (the application received
+    `_on_connected` earlier), so `_on_closed` always follows to signal
+    connection teardown.
     """
     None
 

--- a/lori/start_tls_error.pony
+++ b/lori/start_tls_error.pony
@@ -1,0 +1,32 @@
+primitive StartTLSNotConnected
+  """
+  The connection is not open. `start_tls()` requires an established plaintext
+  connection.
+  """
+
+primitive StartTLSAlreadyTLS
+  """
+  The connection already has an SSL session. TLS upgrade can only be performed
+  on a plaintext connection.
+  """
+
+primitive StartTLSNotReady
+  """
+  The connection is not in a state suitable for TLS upgrade. This can happen
+  when the connection is muted, has unprocessed data in the read buffer, or
+  has pending writes. Buffered read data is rejected to prevent a
+  man-in-the-middle from injecting pre-TLS data that the application would
+  process as post-TLS (CVE-2021-23222).
+  """
+
+primitive StartTLSSessionFailed
+  """
+  The SSL session could not be created from the provided `SSLContext`. The
+  connection is unchanged and remains a plaintext connection.
+  """
+
+type StartTLSError is
+  ( StartTLSNotConnected
+  | StartTLSAlreadyTLS
+  | StartTLSNotReady
+  | StartTLSSessionFailed )


### PR DESCRIPTION
Add `start_tls()` method to `TCPConnection` for upgrading an established plaintext connection to TLS mid-stream, as needed by PostgreSQL, SMTP, LDAP, and other STARTTLS protocols.

New API surface:
- `TCPConnection.start_tls(ssl_ctx, host)` — initiate TLS handshake on a plaintext connection
- `_on_tls_ready()` callback on both lifecycle receiver traits — handshake completed
- `_on_tls_failure()` callback on both lifecycle receiver traits — handshake failed (followed by `_on_closed`)
- `StartTLSError` union type with four error primitives (`StartTLSNotConnected`, `StartTLSAlreadyTLS`, `StartTLSNotReady`, `StartTLSSessionFailed`)

The read buffer precondition check prevents CVE-2021-23222 style injection attacks.

Design: ponylang/postgres#76