### PR TITLE
Fix infinite-ping-pong examples treating TCP as message-oriented

### DIFF
--- a/examples/infinite-ping-pong/infinite-ping-pong.pony
+++ b/examples/infinite-ping-pong/infinite-ping-pong.pony
@@ -6,7 +6,9 @@ A listener starts a server, then launches a client that connects and sends
 prints each reply and sends "Ping" again, producing an infinite back-and-forth.
 
 Shows both sides of a TCP conversation: ServerLifecycleEventReceiver for the
-server and ClientLifecycleEventReceiver for the client.
+server and ClientLifecycleEventReceiver for the client. Both sides use
+`expect(4)` so that each `_on_received` callback delivers exactly one
+4-byte message ("Ping" or "Pong").
 """
 use "../../lori"
 
@@ -50,6 +52,7 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   new create(auth: TCPServerAuth, fd: U32, out: OutStream) =>
     _out = out
     _tcp_connection =  TCPConnection.server(auth, fd, this, this)
+    try _tcp_connection.expect(4)? end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -70,6 +73,7 @@ actor Client is (TCPConnectionActor & ClientLifecycleEventReceiver)
   =>
     _out = out
     _tcp_connection = TCPConnection.client(auth, host, port, from, this, this)
+    try _tcp_connection.expect(4)? end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection

--- a/examples/net-ssl-infinite-ping-pong/net-ssl-infinite-ping-pong.pony
+++ b/examples/net-ssl-infinite-ping-pong/net-ssl-infinite-ping-pong.pony
@@ -3,8 +3,9 @@ SSL version of infinite ping-pong.
 
 Same Ping/Pong exchange as the plain infinite-ping-pong example, but over SSL.
 Shows both TCPConnection.ssl_server and TCPConnection.ssl_client in the same
-program. Must be run from the project root so the relative certificate paths
-resolve correctly.
+program. Both sides use `expect(4)` so that each `_on_received` callback
+delivers exactly one 4-byte message. Must be run from the project root so the
+relative certificate paths resolve correctly.
 """
 use "files"
 use "ssl/net"
@@ -76,6 +77,7 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   =>
     _out = out
     _tcp_connection = TCPConnection.ssl_server(auth, sslctx, fd, this, this)
+    try _tcp_connection.expect(4)? end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -98,6 +100,7 @@ actor Client is (TCPConnectionActor & ClientLifecycleEventReceiver)
     _out = out
     _tcp_connection = TCPConnection.ssl_client(auth, sslctx, host, port, from,
       this, this)
+    try _tcp_connection.expect(4)? end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection


### PR DESCRIPTION
Add `expect(4)` to both Server and Client actors in `infinite-ping-pong` and `net-ssl-infinite-ping-pong` so that each `_on_received` callback delivers exactly one 4-byte message. Without this, data could arrive concatenated (e.g. "PongPong") and be treated as a single receive, silently breaking the 1:1 message correspondence.

Closes #172