### PR TITLE
Update Future Work to reference state machine design

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ POSIX and Windows (IOCP) have distinct code paths throughout `TCPConnection`, gu
 
 ## Future Work
 
-- **TCPConnection refactoring**: `tcp_connection.pony` has multiple interleaved state machines encoded as boolean flags (`_connected`, `_closed`, `_shutdown`, `_shutdown_peer`, `_ssl_ready`, `_ssl_failed`, `_throttled`, `_readable`, `_writeable`, `_muted`). Valid state combinations aren't obvious and invalid combinations aren't prevented. `_event_notify` is particularly dense — it handles own-event vs Happy Eyeballs events with nested platform and SSL branching. Potential improvements: explicit state types instead of boolean flags, breaking `_event_notify` into smaller dispatch methods, grouping platform-specific paths. Pony's reference capabilities may constrain sub-object extraction.
+- **TCPConnection refactoring**: `tcp_connection.pony` has multiple interleaved state machines encoded as boolean flags (`_connected`, `_closed`, `_shutdown`, `_shutdown_peer`, `_ssl_ready`, `_ssl_failed`, `_throttled`, `_readable`, `_writeable`, `_muted`). Valid state combinations aren't obvious and invalid combinations aren't prevented. `_event_notify` is particularly dense — it handles own-event vs Happy Eyeballs events with nested platform and SSL branching. Design: Discussion #174 — proposes explicit connection lifecycle state objects (inspired by ponylang/postgres) to replace the lifecycle boolean flags. Decisions recorded as comments on the discussion. Readable/writeable/throttled remain as flags (flow control, not lifecycle gates). SSL state deferred to a future iteration.
 
 
 ## Conventions


### PR DESCRIPTION
Updates the TCPConnection refactoring entry in CLAUDE.md to reference Discussion #174, which contains the full design for explicit connection lifecycle state objects and the decisions made.