### PR TITLE
Update ponylang/ssl dependency to 2.0.0

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -17,9 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: config=debug
-        run: make ci config=debug ssl=0.9.0
+        run: make ci config=debug ssl=libressl
       - name: config=release
-        run: make ci config=release ssl=0.9.0
+        run: make ci config=release ssl=libressl
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,9 +39,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4.1.1
       - name: config=debug
-        run: make ci config=debug ssl=0.9.0
+        run: make ci config=debug ssl=libressl
       - name: config=release
-        run: make ci config=release ssl=0.9.0
+        run: make ci config=release ssl=libressl
       - name: open/close stress test
         run: build/debug/open-close 1000000
 
@@ -57,11 +57,11 @@ jobs:
       - name: config=debug
         run: |
           export PATH=/Users/runner/.local/share/ponyup/bin/:$PATH
-          make ci config=debug ssl=0.9.0
+          make ci config=debug ssl=libressl
       - name: config=release
         run: |
           export PATH=/Users/runner/.local/share/ponyup/bin/:$PATH
-          make ci config=release ssl=0.9.0
+          make ci config=release ssl=libressl
       - name: open/close stress test
         run: build/debug/open-close 250000
 

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4.1.1
       - name: Build
-        run: make stress-tests config=debug ssl=0.9.0
+        run: make stress-tests config=debug ssl=libressl
       - name: Run
         run: build/debug/open-close 15000000
       - name: Send alert on failure
@@ -47,7 +47,7 @@ jobs:
       - name: Build
         run: |
           export PATH=/Users/runner/.local/share/ponyup/bin/:$PATH
-          make ci config=debug ssl=0.9.0
+          make ci config=debug ssl=libressl
       - name: Run
         run: build/debug/open-close 3750000
       - name: Send alert on failure

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,13 @@
+## Add first-class LibreSSL support
+
+LibreSSL is now a first-class supported SSL library. LibreSSL users previously had to build with `ssl=0.9.0`, which forced LibreSSL through a code path designed for ancient OpenSSL. This silently disabled ALPN negotiation, PBKDF2 key derivation, and the modern EVP/init APIs that LibreSSL supports.
+
+Projects that build against LibreSSL should switch from `ssl=0.9.0` to `ssl=libressl`.
+
+This change comes via an update to ponylang/ssl 2.0.0.
+
+## Drop OpenSSL 0.9.0 support
+
+OpenSSL 0.9.0 is no longer supported. The `ssl=0.9.0` build option and the `-Dopenssl_0.9.0` define have been removed. LibreSSL users who previously used `ssl=0.9.0` should switch to `ssl=libressl`.
+
+This change comes via an update to ponylang/ssl 2.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Added
 
+- Add first-class LibreSSL support ([PR #177](https://github.com/ponylang/lori/pull/177))
 
 ### Changed
 
+- Drop OpenSSL 0.9.0 support ([PR #177](https://github.com/ponylang/lori/pull/177))
 
 ## [0.7.2] - 2026-02-10
 

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ ifeq (,$(filter $(MAKECMDGOALS),clean docs realclean TAGS))
           SSL = -Dopenssl_3.0.x
   else ifeq ($(ssl), 1.1.x)
           SSL = -Dopenssl_1.1.x
-  else ifeq ($(ssl), 0.9.0)
-          SSL = -Dopenssl_0.9.0
+  else ifeq ($(ssl), libressl)
+          SSL = -Dlibressl
   else
     $(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
   endif

--- a/corral.json
+++ b/corral.json
@@ -5,7 +5,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/ssl.git",
-      "version": "1.0.2"
+      "version": "2.0.0"
     },
     {
       "locator": "github.com/ponylang/logger.git",

--- a/make.ps1
+++ b/make.ps1
@@ -32,7 +32,7 @@ else
 
 $libsDir = Join-Path -Path $rootDir -ChildPath "build/libs"
 
-$ponyArgs = "--define openssl_0.9.0  --path $rootDir"
+$ponyArgs = "--define libressl  --path $rootDir"
 
 function BuildTest
 {


### PR DESCRIPTION
Updates ponylang/ssl from 1.0.2 to 2.0.0. This brings two user-facing changes:

- **Added**: First-class LibreSSL support via the new `-Dlibressl` define, replacing the old `-Dopenssl_0.9.0` workaround that silently disabled modern APIs
- **Changed**: OpenSSL 0.9.0 support removed — LibreSSL users should use `ssl=libressl` instead of `ssl=0.9.0`

Updates Makefile, make.ps1, and all CI workflows accordingly.