### PR TITLE
Fix hard_close() being a no-op during connecting phase

### DIFF
--- a/.release-notes/fix-hard-close-connecting.md
+++ b/.release-notes/fix-hard-close-connecting.md
@@ -1,0 +1,5 @@
+## Fix hard_close() being a no-op during connecting phase
+
+`hard_close()` was silently ignored when called during the Happy Eyeballs connecting phase (before any connection attempt succeeded). If a connection attempt later succeeded, the connection would go live as if `hard_close()` was never called.
+
+`hard_close()` now properly cancels the connecting attempt. It marks the connection as closed so that any subsequent Happy Eyeballs successes are cleaned up instead of establishing a live connection, and fires `_on_connection_failure()` to notify the application.

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -21,6 +21,7 @@ actor \nodoc\ Main is TestList
     test(_TestSendAfterClose)
     test(_TestStartTLSPingPong)
     test(_TestStartTLSPreconditions)
+    test(_TestHardCloseWhileConnecting)
 
 class \nodoc\ iso _TestOutgoingFails is UnitTest
   """
@@ -1295,3 +1296,74 @@ actor \nodoc\ _TestStartTLSPreconditionsListener is TCPListenerActor
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to open _TestStartTLSPreconditionsListener")
+
+class \nodoc\ iso _TestHardCloseWhileConnecting is UnitTest
+  """
+  Test that hard_close() during the connecting phase fires
+  _on_connection_failure() and prevents the connection from going live.
+  """
+  fun name(): String => "HardCloseWhileConnecting"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("connection failure")
+
+    let listener = _TestHardCloseWhileConnectingListener(h)
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestHardCloseWhileConnectingClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(_h.env.root),
+      "localhost",
+      "9735",
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connecting(count: U32) =>
+    _tcp_connection.hard_close()
+
+  fun ref _on_connected() =>
+    _h.fail("_on_connected should not fire after hard_close")
+    _h.complete(false)
+
+  fun ref _on_connection_failure() =>
+    _h.complete_action("connection failure")
+
+actor \nodoc\ _TestHardCloseWhileConnectingListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _client: (_TestHardCloseWhileConnectingClient | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      "9735",
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestDoNothingServerActor =>
+    _TestDoNothingServerActor(fd, _h)
+
+  fun ref _on_closed() =>
+    try (_client as _TestHardCloseWhileConnectingClient).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestHardCloseWhileConnectingClient(_h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestHardCloseWhileConnectingListener")


### PR DESCRIPTION
`hard_close()` guarded on `if not _connected then return end`, making it a no-op during Happy Eyeballs. If a connection attempt later succeeded, the connection went live as if `hard_close()` was never called.

Adds connecting-phase handling: sets `_closed`/`_shutdown`/`_shutdown_peer`, disposes SSL, fires `_on_connection_failure()`. Straggler Happy Eyeballs events now hit the cleanup path instead of establishing a connection.

Also cleans up two internal call sites where `hard_close()` was called during connecting but was always a no-op: removes the dead call in the individual-attempt-failure path, and removes the redundant `_on_connection_failure()` from `_connecting_callback()` since `hard_close()` now handles it.

Closes #175