### PR TITLE
Add missing stress-tests command to make.ps1 error message

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -251,6 +251,6 @@ switch ($Command.ToLower())
 
   default
   {
-      throw "Unknown command '$Command'; must be one of (libs, test, examples)."
+      throw "Unknown command '$Command'; must be one of (libs, test, examples, stress-tests)."
   }
 }


### PR DESCRIPTION
The error message for unknown commands in make.ps1 listed only `libs, test, examples` but the script also handles `stress-tests`. Added it to the error message.

Closes #180