### PR TITLE
Add local_address() to TCPListener

### DIFF
--- a/.release-notes/add-listener-local-address.md
+++ b/.release-notes/add-listener-local-address.md
@@ -1,0 +1,9 @@
+## Add local_address() to TCPListener
+
+`TCPListener` now exposes `local_address()`, returning the `net.NetAddress` of the bound socket. This is essential when binding to port `"0"` (OS-assigned port) — without it, there's no way to discover the actual port the listener is using.
+
+```pony
+fun ref _on_listening() =>
+  let addr = _listener().local_address()
+  env.out.print("Listening on port " + addr.port().string())
+```

--- a/lori/tcp_listener.pony
+++ b/lori/tcp_listener.pony
@@ -1,4 +1,5 @@
 use "collections"
+use net = "net"
 
 type MaxSpawn is (U32 | None)
 
@@ -43,6 +44,15 @@ class TCPListener
     | None =>
       _Unreachable()
     end
+
+  fun local_address(): net.NetAddress =>
+    """
+    Return the local IP address. If this TCPListener is closed then the
+    address returned is invalid.
+    """
+    let ip = recover net.NetAddress end
+    PonyTCP.sockname(_fd, ip)
+    ip
 
   fun ref _event_notify(event: AsioEventID, flags: U32, arg: U32) =>
     if event isnt _event then


### PR DESCRIPTION
Downstream consumers (e.g. lori_http_server#15) need to discover the actual bound address, which is essential when binding to port "0" (OS-assigned). `TCPConnection` already had `local_address()` but `TCPListener` did not, despite holding the fd.

Mirrors the existing `TCPConnection.local_address()` implementation using `PonyTCP.sockname()`.