### PR TITLE
Widen send() to accept multiple buffers via writev

### DIFF
--- a/.release-notes/sendv.md
+++ b/.release-notes/sendv.md
@@ -1,0 +1,13 @@
+## Widen send() to accept multiple buffers via writev
+
+`send()` now accepts `(ByteSeq | ByteSeqIter)`, allowing multiple buffers to be sent in a single writev syscall. This avoids both the per-buffer syscall overhead of calling `send()` multiple times and the cost of copying into a contiguous buffer.
+
+```pony
+// Single buffer — same as before
+_tcp_connection.send("Hello, world!")
+
+// Multiple buffers — one writev syscall
+_tcp_connection.send(recover val [as ByteSeq: header; payload] end)
+```
+
+Internally, all writes now use writev, including single-buffer sends.

--- a/lori/lifecycle_event_receiver.pony
+++ b/lori/lifecycle_event_receiver.pony
@@ -37,24 +37,24 @@ trait ServerLifecycleEventReceiver
 
   fun ref _on_sent(token: SendToken) =>
     """
-    Called when data from a successful send() has been fully handed to the
-    OS. The token matches the one returned by send().
+    Called when data from a successful `send()` has been fully handed to
+    the OS. The token matches the one returned by the `send()` call.
 
     Always fires in a subsequent behavior turn, never synchronously during
-    send(). This guarantees the caller has received and processed the
-    SendToken return value before the callback arrives.
+    `send()`. This guarantees the caller has received and processed the
+    `SendToken` return value before the callback arrives.
     """
     None
 
   fun ref _on_send_failed(token: SendToken) =>
     """
-    Called when data from a successful send() could not be delivered to the
-    OS. The token matches the one returned by send(). This happens when a
-    connection closes while a partial write is still pending.
+    Called when data from a successful `send()` could not be delivered to
+    the OS. The token matches the one returned by the `send()` call. This
+    happens when a connection closes while a partial write is still pending.
 
     Always fires in a subsequent behavior turn, never synchronously during
-    hard_close(). Always arrives after _on_closed, which fires synchronously
-    during hard_close().
+    `hard_close()`. Always arrives after `_on_closed`, which fires
+    synchronously during `hard_close()`.
     """
     None
 
@@ -143,24 +143,24 @@ trait ClientLifecycleEventReceiver
 
   fun ref _on_sent(token: SendToken) =>
     """
-    Called when data from a successful send() has been fully handed to the
-    OS. The token matches the one returned by send().
+    Called when data from a successful `send()` has been fully handed to
+    the OS. The token matches the one returned by the `send()` call.
 
     Always fires in a subsequent behavior turn, never synchronously during
-    send(). This guarantees the caller has received and processed the
-    SendToken return value before the callback arrives.
+    `send()`. This guarantees the caller has received and processed the
+    `SendToken` return value before the callback arrives.
     """
     None
 
   fun ref _on_send_failed(token: SendToken) =>
     """
-    Called when data from a successful send() could not be delivered to the
-    OS. The token matches the one returned by send(). This happens when a
-    connection closes while a partial write is still pending.
+    Called when data from a successful `send()` could not be delivered to
+    the OS. The token matches the one returned by the `send()` call. This
+    happens when a connection closes while a partial write is still pending.
 
     Always fires in a subsequent behavior turn, never synchronously during
-    hard_close(). Always arrives after _on_closed, which fires synchronously
-    during hard_close().
+    `hard_close()`. Always arrives after `_on_closed`, which fires
+    synchronously during `hard_close()`.
     """
     None
 


### PR DESCRIPTION
Adds `sendv(data: ByteSeqIter)` to `TCPConnection` for sending multiple buffers in a single writev syscall. This avoids both the per-buffer syscall overhead of calling `send()` multiple times and the cost of copying into a contiguous buffer.

Internally, replaces the old `List[(ByteSeq, USize)]` pending-write system with writev-based I/O on both POSIX and Windows. `PonyTCP.writev` takes `Array[ByteSeq] box` and builds the platform-specific IOV array (iovec/WSABUF) internally. Both `send()` and `sendv()` use the same `_enqueue` + flush machinery.

Also fixes the existing Windows `_write_completed` TODO — IOCP completion tracking now works properly via `_pending_sent`, enabling `_on_sent`/`_on_send_failed` on Windows.

Closes #83
Design: #150