### PR TITLE
Fix FFI declarations for exit() and pony_os_stderr()

### DIFF
--- a/.release-notes/fix-ffi-declarations.md
+++ b/.release-notes/fix-ffi-declarations.md
@@ -1,0 +1,4 @@
+## Fix FFI declarations for exit() and pony_os_stderr()
+
+The FFI declarations for `exit()` and `pony_os_stderr()` used incorrect types (`U8` instead of `I32` for the exit status, `Pointer[U8]` instead of `Pointer[None]` for the `FILE*` stream pointer). This caused compilation failures when lori was used alongside other packages that declare the same FFI functions with the correct C types.
+

--- a/lori/_panics.pony
+++ b/lori/_panics.pony
@@ -1,6 +1,6 @@
-use @exit[None](status: U8)
-use @fprintf[I32](stream: Pointer[U8] tag, fmt: Pointer[U8] tag, ...)
-use @pony_os_stderr[Pointer[U8]]()
+use @exit[None](status: I32)
+use @fprintf[I32](stream: Pointer[None] tag, fmt: Pointer[U8] tag, ...)
+use @pony_os_stderr[Pointer[None]]()
 
 primitive _Unreachable
   """

--- a/stress-tests/open-close/open-close-stress-test.pony
+++ b/stress-tests/open-close/open-close-stress-test.pony
@@ -4,9 +4,9 @@ use "time"
 use "../../lori"
 use ll = "logger"
 
-use @exit[None](status: U8)
-use @fprintf[I32](stream: Pointer[U8] tag, fmt: Pointer[U8] tag, ...)
-use @pony_os_stderr[Pointer[U8]]()
+use @exit[None](status: I32)
+use @fprintf[I32](stream: Pointer[None] tag, fmt: Pointer[U8] tag, ...)
+use @pony_os_stderr[Pointer[None]]()
 
 actor Main
   new create(env: Env) =>


### PR DESCRIPTION
The FFI declarations for `exit()` and `pony_os_stderr()` used incorrect types (`U8` instead of `I32` for the exit status, `Pointer[U8]` instead of `Pointer[None]` for the `FILE*` stream pointer). This caused compilation failures when lori was used alongside other packages that declare the same FFI functions with the correct C types.