### PR TITLE
Add per-connection idle timeout

### DIFF
--- a/.release-notes/add-per-connection-idle-timeout.md
+++ b/.release-notes/add-per-connection-idle-timeout.md
@@ -1,0 +1,16 @@
+## Add per-connection idle timeout
+
+`idle_timeout()` sets a per-connection timer that fires `_on_idle_timeout()` when no data is sent or received for the configured duration. The duration is an `IdleTimeout` constrained type (constructed via `MakeIdleTimeout`) that guarantees a non-zero millisecond value. The timer resets on every successful `send()` and every received data event, and automatically re-arms after each firing.
+
+```pony
+fun ref _on_started() =>
+  match MakeIdleTimeout(30_000) // 30 seconds
+  | let t: IdleTimeout =>
+    _tcp_connection.idle_timeout(t)
+  end
+
+fun ref _on_idle_timeout() =>
+  _tcp_connection.close()
+```
+
+Uses a per-connection ASIO timer event — no extra actors or shared state needed. Call `idle_timeout(None)` to disable.

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,12 @@ Client and server exchanging messages in a loop. Adds a `ClientLifecycleEventRec
 
 Length-prefixed message framing with `expect()`. Each message has a 4-byte big-endian length header followed by a variable-length payload. Both sides use `expect()` to switch between reading the header and reading the payload, demonstrating how to build a protocol parser on top of lori's read chunking.
 
+## [idle-timeout](idle-timeout/)
+
+Server that closes connections after 10 seconds of inactivity. Demonstrates
+`idle_timeout()` for setting a per-connection timer and `_on_idle_timeout()`
+for handling the expiration — no extra actors or shared timers needed.
+
 ## [backpressure](backpressure/)
 
 Handling `send()` errors and throttle/unthrottle callbacks. A flood client sends 200 chunks of 64KB as fast as possible, demonstrating what happens when the OS send buffer fills: `send()` returns `SendErrorNotWriteable`, `_on_throttled` fires, and the client waits for `_on_unthrottled` to resume. Also shows `_on_sent` for tracking write completion.

--- a/examples/idle-timeout/idle-timeout.pony
+++ b/examples/idle-timeout/idle-timeout.pony
@@ -1,0 +1,75 @@
+"""
+Echo server that closes idle connections after 10 seconds.
+
+Demonstrates `idle_timeout()` for setting a per-connection inactivity timer
+and `_on_idle_timeout()` for handling the expiration. The idle timer uses a
+per-connection ASIO timer event — no extra actors or shared `Timers` needed.
+
+Start the server and connect with a TCP client (e.g. `netcat localhost 7672`).
+Type to see input echoed back. Stop typing for 10 seconds and the server
+closes the connection.
+"""
+use "../../lori"
+
+actor Main
+  new create(env: Env) =>
+    IdleTimeoutServer(TCPListenAuth(env.root), "", "7672", env.out)
+
+actor IdleTimeoutServer is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _out: OutStream
+  let _server_auth: TCPServerAuth
+
+  new create(listen_auth: TCPListenAuth,
+    host: String,
+    port: String,
+    out: OutStream)
+  =>
+    _out = out
+    _server_auth = TCPServerAuth(listen_auth)
+    _tcp_listener = TCPListener(listen_auth, host, port, this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): IdleTimeoutEchoer =>
+    IdleTimeoutEchoer(_server_auth, fd, _out)
+
+  fun ref _on_closed() =>
+    _out.print("Server shut down.")
+
+  fun ref _on_listen_failure() =>
+    _out.print("Couldn't start server. Perhaps try another port?")
+
+  fun ref _on_listening() =>
+    _out.print("Idle-timeout echo server started on port 7672.")
+
+actor IdleTimeoutEchoer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _out: OutStream
+
+  new create(auth: TCPServerAuth, fd: U32, out: OutStream) =>
+    _out = out
+    _tcp_connection = TCPConnection.server(auth, fd, this, this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    _out.print("Connection established. 10-second idle timeout active.")
+    match MakeIdleTimeout(10_000)
+    | let t: IdleTimeout =>
+      _tcp_connection.idle_timeout(t)
+    end
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    _out.print("Data received. Echoing it back.")
+    _tcp_connection.send(consume data)
+
+  fun ref _on_idle_timeout() =>
+    _out.print("Connection idle for 10 seconds. Closing.")
+    _tcp_connection.close()
+
+  fun ref _on_closed() =>
+    _out.print("Connection closed.")

--- a/lori/idle_timeout.pony
+++ b/lori/idle_timeout.pony
@@ -1,0 +1,29 @@
+use "constrained_types"
+
+primitive IdleTimeoutValidator is Validator[U64]
+  """
+  Validates that an idle timeout duration is greater than zero milliseconds.
+  Used by `MakeIdleTimeout` to construct `IdleTimeout` values.
+  """
+  fun apply(value: U64): ValidationResult =>
+    if value == 0 then
+      recover val
+        ValidationFailure(
+          "idle timeout must be greater than zero")
+      end
+    else
+      ValidationSuccess
+    end
+
+type IdleTimeout is Constrained[U64, IdleTimeoutValidator]
+  """
+  A validated idle timeout duration in milliseconds, guaranteed to be greater
+  than zero. Construct with `MakeIdleTimeout(milliseconds)`, which returns
+  `(IdleTimeout | ValidationFailure)`. Pass to `idle_timeout()` to set the
+  timeout, or pass `None` to disable it.
+  """
+
+type MakeIdleTimeout is MakeConstrained[U64, IdleTimeoutValidator]
+  """
+  Factory for `IdleTimeout` values. Returns `(IdleTimeout | ValidationFailure)`.
+  """

--- a/lori/lifecycle_event_receiver.pony
+++ b/lori/lifecycle_event_receiver.pony
@@ -85,6 +85,19 @@ trait ServerLifecycleEventReceiver
     """
     None
 
+  fun ref _on_idle_timeout() =>
+    """
+    Called when no successful send or receive has occurred for the duration
+    configured by `idle_timeout()`. This measures application-level inactivity,
+    not wire-level: pending OS write buffer drains and failed sends
+    (`SendErrorNotWriteable`) do not count as activity.
+
+    The timer automatically re-arms after each firing. Call
+    `idle_timeout(None)` to disable it. The application decides what action
+    to take — close the connection, send a keepalive, log a warning, etc.
+    """
+    None
+
 trait ClientLifecycleEventReceiver
   """
   Application-level callbacks for client-side TCP connections.
@@ -179,6 +192,19 @@ trait ClientLifecycleEventReceiver
     The connection was already established (the application received
     `_on_connected` earlier), so `_on_closed` always follows to signal
     connection teardown.
+    """
+    None
+
+  fun ref _on_idle_timeout() =>
+    """
+    Called when no successful send or receive has occurred for the duration
+    configured by `idle_timeout()`. This measures application-level inactivity,
+    not wire-level: pending OS write buffer drains and failed sends
+    (`SendErrorNotWriteable`) do not count as activity.
+
+    The timer automatically re-arms after each firing. Call
+    `idle_timeout(None)` to disable it. The application decides what action
+    to take — close the connection, send a keepalive, log a warning, etc.
     """
     None
 

--- a/lori/pony_asio.pony
+++ b/lori/pony_asio.pony
@@ -7,6 +7,7 @@ use @pony_asio_event_resubscribe_read[None](event: AsioEventID)
 use @pony_asio_event_resubscribe_write[None](event: AsioEventID)
 use @pony_asio_event_set_readable[None](event: AsioEventID, readable: Bool)
 use @pony_asio_event_set_writeable[None](event: AsioEventID, writeable: Bool)
+use @pony_asio_event_setnsec[U32](event: AsioEventID, nsec: U64)
 use @pony_asio_event_unsubscribe[None](event: AsioEventID)
 
 primitive PonyAsio
@@ -45,6 +46,12 @@ primitive PonyAsio
 
   fun set_unwriteable(event: AsioEventID) =>
     @pony_asio_event_set_writeable(event, false)
+
+  fun create_timer_event(the_actor: AsioEventNotify, nsec: U64): AsioEventID =>
+    @pony_asio_event_create(the_actor, 0, AsioEvent.timer(), nsec, true)
+
+  fun set_timer(event: AsioEventID, nsec: U64) =>
+    @pony_asio_event_setnsec(event, nsec)
 
   fun unsubscribe(event: AsioEventID) =>
     @pony_asio_event_unsubscribe(event)


### PR DESCRIPTION
Per-connection ASIO timer fires `_on_idle_timeout()` when no successful send or receive occurs for the configured duration. Avoids the muting-livelock problem with shared `Timers` actors under backpressure (ponylang/lori_http_server#46).

- `idle_timeout(nsec)` public API on `TCPConnection` — stores duration, arms timer on connection establishment
- `_on_idle_timeout()` callback on both `ServerLifecycleEventReceiver` and `ClientLifecycleEventReceiver`
- Timer resets on `_read()`/`_read_completed()` entry and successful `send()`
- Re-arms after each firing until disabled via `idle_timeout(0)` or connection closes
- Cancelled timers cleaned up synchronously; stale disposable events route through existing catch-all
- Three tests: basic firing, reset on activity, disable
- Idle-timeout example, package docstring, release notes, CLAUDE.md updates

Design: #193