### PR TITLE
Add structured failure reasons to connection callbacks

### DIFF
--- a/.release-notes/failure-reasons.md
+++ b/.release-notes/failure-reasons.md
@@ -1,0 +1,41 @@
+## Add structured failure reasons to connection callbacks
+
+The failure callbacks `_on_connection_failure`, `_on_start_failure`, and `_on_tls_failure` now carry a reason parameter that identifies why the failure occurred. This is a breaking change — all implementations of these callbacks must be updated to accept the new parameter.
+
+### Before
+
+```pony
+fun ref _on_connection_failure() =>
+  // No way to know what went wrong
+  None
+
+fun ref _on_start_failure() =>
+  None
+
+fun ref _on_tls_failure() =>
+  None
+```
+
+### After
+
+```pony
+fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+  match reason
+  | ConnectionFailedDNS => // Name resolution failed
+  | ConnectionFailedTCP => // All TCP attempts failed
+  | ConnectionFailedSSL => // SSL handshake failed
+  end
+
+fun ref _on_start_failure(reason: StartFailureReason) =>
+  match reason
+  | StartFailedSSL => // SSL session or handshake failed
+  end
+
+fun ref _on_tls_failure(reason: TLSFailureReason) =>
+  match reason
+  | TLSAuthFailed => // Certificate/auth error
+  | TLSGeneralError => // Protocol error
+  end
+```
+
+The reason types are union type aliases of primitives, following the same pattern as `StartTLSError` and `SendError`. Applications that don't need the reason can add the parameter and ignore it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,9 @@ lori/
   lifecycle_event_receiver.pony -- Client/ServerLifecycleEventReceiver traits
   send_token.pony           -- SendToken class, SendError primitives and type alias
   start_tls_error.pony      -- StartTLSError primitives and type alias
+  connection_failure_reason.pony -- ConnectionFailureReason primitives and type alias
+  start_failure_reason.pony -- StartFailureReason primitive and type alias
+  tls_failure_reason.pony   -- TLSFailureReason primitives and type alias
   idle_timeout.pony         -- IdleTimeout constrained type and validator
   auth.pony                 -- Auth primitives (NetAuth, TCPAuth, TCPListenAuth, etc.)
   pony_tcp.pony             -- FFI wrappers for pony_os_* TCP functions
@@ -65,7 +68,7 @@ Lori separates connection logic (class) from actor scheduling (trait):
 
 1. **`TCPConnection`** (class) — All TCP state and I/O logic including SSL. Created with `TCPConnection.client(...)`, `TCPConnection.server(...)`, `TCPConnection.ssl_client(...)`, or `TCPConnection.ssl_server(...)`. Existing plaintext connections can be upgraded to TLS via `start_tls()`. Not an actor itself.
 2. **`TCPConnectionActor`** (trait) — The actor trait users implement. Requires `fun ref _connection(): TCPConnection`. Provides behaviors that delegate to the TCPConnection: `_event_notify`, `_read_again`, `dispose`, etc.
-3. **Lifecycle event receivers** — `ClientLifecycleEventReceiver` (callbacks: `_on_connected`, `_on_connecting`, `_on_connection_failure`, `_on_received`, `_on_closed`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure`, etc.) and `ServerLifecycleEventReceiver` (callbacks: `_on_started`, `_on_start_failure`, `_on_received`, `_on_closed`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure`, etc.). Both share common callbacks like `_on_received`, `_on_closed`, `_on_throttled`/`_on_unthrottled`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure`, `_on_idle_timeout`.
+3. **Lifecycle event receivers** — `ClientLifecycleEventReceiver` (callbacks: `_on_connected`, `_on_connecting`, `_on_connection_failure(reason)`, `_on_received`, `_on_closed`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure(reason)`, etc.) and `ServerLifecycleEventReceiver` (callbacks: `_on_started`, `_on_start_failure(reason)`, `_on_received`, `_on_closed`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure(reason)`, etc.). Both share common callbacks like `_on_received`, `_on_closed`, `_on_throttled`/`_on_unthrottled`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure`, `_on_idle_timeout`.
 
 ### How to implement a server
 
@@ -126,17 +129,17 @@ actor MySSLClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
   fun ref _on_connected() => // SSL handshake complete, ready for data
 ```
 
-SSL is handled internally by `TCPConnection`. The `ssl_client`/`ssl_server` constructors create an `SSL` session from the provided `SSLContext val`, perform the handshake transparently, and deliver `_on_connected`/`_on_started` only after the handshake completes. If SSL session creation fails, `_on_connection_failure()` (client) or `_on_start_failure()` (server) fires asynchronously. If the handshake fails, `hard_close()` triggers the same failure callbacks.
+SSL is handled internally by `TCPConnection`. The `ssl_client`/`ssl_server` constructors create an `SSL` session from the provided `SSLContext val`, perform the handshake transparently, and deliver `_on_connected`/`_on_started` only after the handshake completes. If SSL session creation fails, `_on_connection_failure(ConnectionFailedSSL)` (client) or `_on_start_failure(StartFailedSSL)` (server) fires asynchronously. If the handshake fails, `hard_close()` triggers the same failure callbacks.
 
 ### SSL internals
 
-SSL state lives directly in `TCPConnection` (fields `_ssl`, `_ssl_ready`, `_ssl_failed`, `_ssl_expect`). Key behaviors:
+SSL state lives directly in `TCPConnection` (fields `_ssl`, `_ssl_ready`, `_ssl_failed`, `_ssl_expect`, `_ssl_auth_failed`). Key behaviors:
 
 - **0-to-N output per input on both sides:** Both read and write can produce zero, one, or many output chunks per input chunk. During handshake, output may be zero (buffered). A single TCP read containing multiple SSL records produces multiple decrypted chunks.
 - **`_ssl_poll()` pump:** Called after `ssl.receive()` in `_deliver_received()`. Checks SSL state, delivers decrypted data to the lifecycle event receiver, and flushes encrypted protocol data (handshake responses, etc.) via `_ssl_flush_sends()`.
 - **Client handshake initiation:** When TCP connects, `_ssl_flush_sends()` sends the ClientHello. The handshake proceeds via `_deliver_received()` → `ssl.receive()` → `_ssl_poll()`.
 - **Ready signaling:** `_ssl_ready` is set when `ssl.state()` returns `SSLReady`, which triggers `_on_connected`/`_on_started` delivery.
-- **Error handling:** `SSLAuthFail` or `SSLError` states trigger `hard_close()`. If the handshake never completed, clients get `_on_connection_failure()` and servers get `_on_start_failure()`.
+- **Error handling:** `SSLAuthFail` sets `_ssl_auth_failed = true` then triggers `hard_close()`. `SSLError` triggers `hard_close()` directly. `hard_close()` reads `_ssl_auth_failed` to pass `TLSAuthFailed` vs `TLSGeneralError` to `_on_tls_failure` (for TLS upgrades), or `ConnectionFailedSSL`/`StartFailedSSL` to `_on_connection_failure`/`_on_start_failure` (for initial SSL). If the handshake never completed, clients get `_on_connection_failure(ConnectionFailedSSL)` and servers get `_on_start_failure(StartFailedSSL)`.
 - **Expect handling:** The application's `expect()` value is stored in `_ssl_expect` and used when chunking decrypted data via `ssl.read()`. The TCP read layer uses 0 (read all available) since SSL record framing doesn't align with application framing.
 
 ### TLS upgrade (STARTTLS)
@@ -144,7 +147,7 @@ SSL state lives directly in `TCPConnection` (fields `_ssl`, `_ssl_ready`, `_ssl_
 `start_tls(ssl_ctx, host)` upgrades an established plaintext connection to TLS. It creates an SSL session, migrates expect state (`_ssl_expect = _expect; _expect = 0`), sets `_tls_upgrade = true`, and flushes the ClientHello. The `_tls_upgrade` flag distinguishes "initial SSL from constructor" vs "upgraded SSL from start_tls()":
 
 - **`_ssl_poll()`**: When `SSLReady` is reached and `_tls_upgrade` is true, calls `_on_tls_ready()` instead of `_on_connected()`/`_on_started()`.
-- **`hard_close()`**: When SSL handshake is incomplete and `_tls_upgrade` is true, calls `_on_tls_failure()` then `_on_closed()` (the application already knew about the plaintext connection). Without `_tls_upgrade`, the initial-SSL path fires `_on_connection_failure()`/`_on_start_failure()` instead.
+- **`hard_close()`**: When SSL handshake is incomplete and `_tls_upgrade` is true, calls `_on_tls_failure(reason)` (where `reason` is `TLSAuthFailed` or `TLSGeneralError` based on `_ssl_auth_failed`) then `_on_closed()` (the application already knew about the plaintext connection). Without `_tls_upgrade`, the initial-SSL path fires `_on_connection_failure(ConnectionFailedSSL)`/`_on_start_failure(StartFailedSSL)` instead.
 
 Preconditions enforced synchronously: connection must be open, not already TLS, not muted, no buffered read data (CVE-2021-23222), no pending writes. Returns `StartTLSError` on failure (connection unchanged). The "no pending writes" check is platform-aware: on POSIX it checks `_has_pending_writes()` (any unconfirmed bytes); on Windows IOCP it checks for un-submitted data only (`_pending_data.size() > _pending_sent`), since submitted-but-unconfirmed writes are already in the kernel's send buffer.
 
@@ -183,6 +186,16 @@ The write path uses an enqueue-then-flush pattern:
 `PonyTCP.writev` takes `Array[ByteSeq] box` and builds `iovec` (POSIX) or `WSABUF` (Windows) arrays internally, hiding the platform-specific tuple layout. Returns bytes sent (POSIX) or buffer count submitted (Windows).
 
 Design: Discussion #150.
+
+### Failure reason types
+
+Failure callbacks carry a reason parameter identifying the failure cause. Three type aliases, each following the `start_tls_error.pony` pattern (primitives + type alias):
+
+- **`ConnectionFailureReason`** (`_on_connection_failure`): `ConnectionFailedDNS` (name resolution failed, no TCP attempts), `ConnectionFailedTCP` (resolved but all TCP connections failed), `ConnectionFailedSSL` (TCP connected but SSL handshake failed). The DNS/TCP distinction uses `_had_inflight` (set after `PonyTCP.connect` returns > 0).
+- **`StartFailureReason`** (`_on_start_failure`): `StartFailedSSL` (SSL session creation or handshake failure). Currently a single-variant type — future reasons (e.g. resource limits) can be added without breaking the type alias.
+- **`TLSFailureReason`** (`_on_tls_failure`): `TLSAuthFailed` (certificate/auth error), `TLSGeneralError` (protocol error). The distinction uses `_ssl_auth_failed` (set by `_ssl_poll()` on `SSLAuthFail` before calling `hard_close()`).
+
+Design: Discussion #201.
 
 ### Idle timeout
 

--- a/examples/backpressure/backpressure.pony
+++ b/examples/backpressure/backpressure.pony
@@ -150,7 +150,7 @@ actor Flood is (TCPConnectionActor & ClientLifecycleEventReceiver)
   fun ref _on_send_failed(token: SendToken) =>
     _out.print("Flood: send failed (connection closed with pending write)")
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
     _out.print("Flood: connection failed")
 
   fun ref _on_closed() =>

--- a/examples/framed-protocol/framed-protocol.pony
+++ b/examples/framed-protocol/framed-protocol.pony
@@ -183,7 +183,7 @@ actor FramedClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
       end
     end
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
     _out.print("Client: connection failed")
 
   fun ref _on_closed() =>

--- a/examples/starttls-ping-pong/starttls-ping-pong.pony
+++ b/examples/starttls-ping-pong/starttls-ping-pong.pony
@@ -115,7 +115,7 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _on_tls_ready() =>
     _out.print("Server: TLS handshake complete")
 
-  fun ref _on_tls_failure() =>
+  fun ref _on_tls_failure(reason: TLSFailureReason) =>
     _out.print("Server: TLS handshake failed")
 
 actor Client is (TCPConnectionActor & ClientLifecycleEventReceiver)
@@ -158,5 +158,5 @@ actor Client is (TCPConnectionActor & ClientLifecycleEventReceiver)
     _out.print("Client: TLS handshake complete, sending first Ping")
     _tcp_connection.send("Ping")
 
-  fun ref _on_tls_failure() =>
+  fun ref _on_tls_failure(reason: TLSFailureReason) =>
     _out.print("Client: TLS handshake failed")

--- a/examples/yield-read/yield-read.pony
+++ b/examples/yield-read/yield-read.pony
@@ -103,7 +103,7 @@ actor Client is (TCPConnectionActor & ClientLifecycleEventReceiver)
       i = i + 1
     end
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
     _out.print("Client: connection failed")
 
   fun ref _on_closed() =>

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -68,7 +68,7 @@ actor \nodoc\ _TestOutgoingFailure is (TCPConnectionActor & ClientLifecycleEvent
     _h.fail("_on_connected for a connection that should have failed")
     _h.complete(false)
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
     _h.complete(true)
 
 class \nodoc\ iso _TestPingPong is UnitTest
@@ -484,7 +484,7 @@ actor \nodoc\ _TestMuteClient
   fun ref _on_connected() =>
     _h.complete_action("client connected")
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
     _h.fail("client connect failed")
 
   fun ref _on_received(data: Array[U8] iso) =>
@@ -607,7 +607,7 @@ actor \nodoc\ _TestUnmuteClient
   fun ref _on_connected() =>
     _h.complete_action("client connected")
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
     _h.fail("client connect failed")
 
   fun ref _on_received(data: Array[U8] iso) =>
@@ -1065,7 +1065,7 @@ actor \nodoc\ _TestStartTLSClient
     try _tcp_connection.expect(4)? end
     _tcp_connection.send("Ping")
 
-  fun ref _on_tls_failure() =>
+  fun ref _on_tls_failure(reason: TLSFailureReason) =>
     _h.fail("Client TLS handshake failed")
 
 actor \nodoc\ _TestStartTLSServer
@@ -1110,7 +1110,7 @@ actor \nodoc\ _TestStartTLSServer
     _h.complete_action("server tls ready")
     try _tcp_connection.expect(4)? end
 
-  fun ref _on_tls_failure() =>
+  fun ref _on_tls_failure(reason: TLSFailureReason) =>
     _h.fail("Server TLS handshake failed")
 
 actor \nodoc\ _TestStartTLSListener is TCPListenerActor
@@ -1353,7 +1353,7 @@ actor \nodoc\ _TestStartTLSPreconditionsListener is TCPListenerActor
 class \nodoc\ iso _TestHardCloseWhileConnecting is UnitTest
   """
   Test that hard_close() during the connecting phase fires
-  _on_connection_failure() and prevents the connection from going live.
+  _on_connection_failure and prevents the connection from going live.
   """
   fun name(): String => "HardCloseWhileConnecting"
 
@@ -1390,7 +1390,7 @@ actor \nodoc\ _TestHardCloseWhileConnectingClient
     _h.fail("_on_connected should not fire after hard_close")
     _h.complete(false)
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
     _h.complete_action("connection failure")
 
 actor \nodoc\ _TestHardCloseWhileConnectingListener is TCPListenerActor
@@ -1424,7 +1424,7 @@ actor \nodoc\ _TestHardCloseWhileConnectingListener is TCPListenerActor
 class \nodoc\ iso _TestCloseWhileConnecting is UnitTest
   """
   Test that close() during the connecting phase fires
-  _on_connection_failure() and prevents the connection from going live.
+  _on_connection_failure and prevents the connection from going live.
   """
   fun name(): String => "CloseWhileConnecting"
 
@@ -1461,7 +1461,7 @@ actor \nodoc\ _TestCloseWhileConnectingClient
     _h.fail("_on_connected should not fire after close")
     _h.complete(false)
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
     _h.complete_action("connection failure")
 
 actor \nodoc\ _TestCloseWhileConnectingListener is TCPListenerActor

--- a/lori/connection_failure_reason.pony
+++ b/lori/connection_failure_reason.pony
@@ -1,0 +1,21 @@
+primitive ConnectionFailedDNS
+  """
+  Name resolution failed — no IP addresses could be resolved for the
+  given host. No TCP connections were attempted.
+  """
+
+primitive ConnectionFailedTCP
+  """
+  Name resolution succeeded but all TCP connection attempts failed. At least
+  one IP address was resolved, but no connection could be established.
+  """
+
+primitive ConnectionFailedSSL
+  """
+  The TCP connection was established but the SSL handshake failed. This
+  covers both SSL session creation failures (e.g. bad `SSLContext`) and
+  handshake protocol errors before `_on_connected` would have fired.
+  """
+
+type ConnectionFailureReason is
+  (ConnectionFailedDNS | ConnectionFailedTCP | ConnectionFailedSSL)

--- a/lori/lifecycle_event_receiver.pony
+++ b/lori/lifecycle_event_receiver.pony
@@ -58,12 +58,16 @@ trait ServerLifecycleEventReceiver
     """
     None
 
-  fun ref _on_start_failure() =>
+  fun ref _on_start_failure(reason: StartFailureReason) =>
     """
     Called when a server connection fails to start. This covers failures
     that occur before _on_started would have fired, such as an SSL
     handshake failure. The application was never notified of the connection
     via _on_started.
+
+    The `reason` parameter identifies the cause of the failure. Currently
+    the only reason is `StartFailedSSL` (SSL session creation or handshake
+    failure).
     """
     None
 
@@ -75,13 +79,16 @@ trait ServerLifecycleEventReceiver
     """
     None
 
-  fun ref _on_tls_failure() =>
+  fun ref _on_tls_failure(reason: TLSFailureReason) =>
     """
     Called when a TLS handshake initiated by `start_tls()` fails. Fires
     synchronously during `hard_close()`, immediately before `_on_closed()`.
     The connection was already established (the application received
     `_on_started` earlier), so `_on_closed` always follows to signal
     connection teardown.
+
+    The `reason` parameter distinguishes authentication failures
+    (`TLSAuthFailed`) from other protocol errors (`TLSGeneralError`).
     """
     None
 
@@ -110,7 +117,7 @@ trait ClientLifecycleEventReceiver
     Called if name resolution succeeded for a TCPConnection and we are now
     waiting for a connection to the server to succeed. The count is the number
     of connections we're trying. This callback will be called each time the
-    count changes, until a connection is made or _on_connection_failure() is
+    count changes, until a connection is made or _on_connection_failure is
     called.
     """
     None
@@ -121,12 +128,17 @@ trait ClientLifecycleEventReceiver
     """
     None
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
     """
     Called when a connection fails to open. For SSL connections, this is
     also called when the SSL handshake fails before _on_connected would
     have been delivered, since the application was never notified of the
     connection.
+
+    The `reason` parameter identifies the failure stage:
+    `ConnectionFailedDNS` (name resolution failed), `ConnectionFailedTCP`
+    (resolved but all TCP attempts failed), or `ConnectionFailedSSL`
+    (TCP connected but SSL handshake failed).
     """
     None
 
@@ -185,13 +197,16 @@ trait ClientLifecycleEventReceiver
     """
     None
 
-  fun ref _on_tls_failure() =>
+  fun ref _on_tls_failure(reason: TLSFailureReason) =>
     """
     Called when a TLS handshake initiated by `start_tls()` fails. Fires
     synchronously during `hard_close()`, immediately before `_on_closed()`.
     The connection was already established (the application received
     `_on_connected` earlier), so `_on_closed` always follows to signal
     connection teardown.
+
+    The `reason` parameter distinguishes authentication failures
+    (`TLSAuthFailed`) from other protocol errors (`TLSGeneralError`).
     """
     None
 

--- a/lori/lori.pony
+++ b/lori/lori.pony
@@ -106,7 +106,7 @@ actor MyClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
   fun ref _on_connected() =>
     _tcp_connection.send("Hello, server!")
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
     // All connection attempts failed
     None
 
@@ -119,7 +119,9 @@ Clients use `ClientLifecycleEventReceiver` instead of
 `ServerLifecycleEventReceiver`. The key difference is the connection lifecycle:
 clients get `_on_connecting` (called as connection attempts are in progress),
 `_on_connected` (ready for data), and `_on_connection_failure` (all attempts
-failed). Servers get `_on_started` (ready for data) and `_on_start_failure`.
+failed, with a [`ConnectionFailureReason`](/lori/lori-ConnectionFailureReason/)
+indicating the failure stage). Servers get `_on_started` (ready for data) and
+`_on_start_failure`.
 
 ## Sending Data
 
@@ -189,7 +191,7 @@ actor SSLEchoer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _on_received(data: Array[U8] iso) =>
     _tcp_connection.send(consume data)
 
-  fun ref _on_start_failure() =>
+  fun ref _on_start_failure(reason: StartFailureReason) =>
     // SSL handshake failed
     None
 ```
@@ -197,9 +199,11 @@ actor SSLEchoer is (TCPConnectionActor & ServerLifecycleEventReceiver)
 SSL is handled entirely inside `TCPConnection`. The handshake runs
 transparently after the TCP connection is established, and `_on_connected`
 (client) or `_on_started` (server) fires only after the handshake completes. If
-the handshake fails, clients get `_on_connection_failure` and servers get
-`_on_start_failure`. The rest of the application code (sending, receiving,
-closing) is identical to the non-SSL case.
+the handshake fails, clients get `_on_connection_failure` (with
+[`ConnectionFailedSSL`](/lori/lori-ConnectionFailedSSL/)) and servers get
+`_on_start_failure` (with [`StartFailedSSL`](/lori/lori-StartFailedSSL/)).
+The rest of the application code (sending, receiving, closing) is identical
+to the non-SSL case.
 
 ## TLS Upgrade (STARTTLS)
 
@@ -241,7 +245,7 @@ actor MyStartTLSClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
     // TLS handshake complete — now sending encrypted data
     _tcp_connection.send("encrypted payload")
 
-  fun ref _on_tls_failure() =>
+  fun ref _on_tls_failure(reason: TLSFailureReason) =>
     // TLS handshake failed — _on_closed will follow
     None
 ```
@@ -251,7 +255,9 @@ actor MyStartTLSClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
 connection must be open, not already TLS, not muted, and have no buffered read
 data or pending writes. During the handshake, `send()` returns
 `SendErrorNotConnected`. When the handshake completes, `_on_tls_ready()` fires.
-If it fails, `_on_tls_failure()` fires followed by `_on_closed()`.
+If it fails, `_on_tls_failure` fires (with a
+[`TLSFailureReason`](/lori/lori-TLSFailureReason/) distinguishing
+authentication errors from protocol errors) followed by `_on_closed()`.
 
 ## Idle Timeout
 

--- a/lori/start_failure_reason.pony
+++ b/lori/start_failure_reason.pony
@@ -1,0 +1,8 @@
+primitive StartFailedSSL
+  """
+  The SSL handshake failed before the server connection could start. This
+  covers both SSL session creation failures (e.g. bad `SSLContext`) and
+  handshake protocol errors before `_on_started` would have fired.
+  """
+
+type StartFailureReason is StartFailedSSL

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -45,6 +45,13 @@ class TCPConnection
   // correct callbacks (_on_tls_ready/_on_tls_failure vs
   // _on_connected/_on_started/_on_connection_failure/_on_start_failure).
   var _tls_upgrade: Bool = false
+  // Set when PonyTCP.connect returned > 0, meaning at least one TCP
+  // connection attempt was made. Used by the failure callback to distinguish
+  // DNS failure (no attempts) from TCP failure (all attempts failed).
+  var _had_inflight: Bool = false
+  // Set when _ssl_poll() sees SSLAuthFail before calling hard_close().
+  // hard_close() reads this to pass TLSAuthFailed vs TLSGeneralError.
+  var _ssl_auth_failed: Bool = false
 
   // Per-connection idle timeout via ASIO timer
   var _timer_event: AsioEventID = AsioEvent.none()
@@ -96,7 +103,7 @@ class TCPConnection
     """
     Create a client-side SSL connection. The SSL session is created from the
     provided SSLContext. If session creation fails, the connection reports
-    failure asynchronously via _on_connection_failure().
+    failure asynchronously via _on_connection_failure(ConnectionFailedSSL).
     """
     _lifecycle_event_receiver = ler
     _enclosing = enclosing
@@ -123,7 +130,8 @@ class TCPConnection
     """
     Create a server-side SSL connection. The SSL session is created from the
     provided SSLContext. If session creation fails, the connection reports
-    failure asynchronously via _on_start_failure() and closes the fd.
+    failure asynchronously via _on_start_failure(StartFailedSSL) and closes the
+    fd.
     """
     _fd = fd'
     _lifecycle_event_receiver = ler
@@ -276,7 +284,7 @@ class TCPConnection
     During the connecting phase (Happy Eyeballs in progress), marks the
     connection as closed so straggler events clean up instead of establishing
     a connection. Once all in-flight connections have drained,
-    `_on_connection_failure()` fires.
+    `_on_connection_failure` fires.
 
     If the connection is established and not muted, we won't finish closing
     until we get a zero length read. If the connection is muted, perform a
@@ -306,7 +314,12 @@ class TCPConnection
         end
         match _lifecycle_event_receiver
         | let c: ClientLifecycleEventReceiver ref =>
-          c._on_connection_failure()
+          let reason = if _had_inflight then
+            ConnectionFailedTCP
+          else
+            ConnectionFailedDNS
+          end
+          c._on_connection_failure(reason)
         end
       end
       _cancel_idle_timer()
@@ -361,7 +374,12 @@ class TCPConnection
             // TLS upgrade handshake failed. The application already received
             // _on_connected/_on_started for the original plaintext connection,
             // so _on_closed must follow for cleanup.
-            s._on_tls_failure()
+            let reason = if _ssl_auth_failed then
+              TLSAuthFailed
+            else
+              TLSGeneralError
+            end
+            s._on_tls_failure(reason)
             s._on_closed()
           else
             // Initial SSL handshake never completed. For clients, the
@@ -369,9 +387,9 @@ class TCPConnection
             // the connection never started.
             match s
             | let c: ClientLifecycleEventReceiver ref =>
-              c._on_connection_failure()
+              c._on_connection_failure(ConnectionFailedSSL)
             | let srv: ServerLifecycleEventReceiver ref =>
-              srv._on_start_failure()
+              srv._on_start_failure(StartFailedSSL)
             end
           end
         else
@@ -433,7 +451,7 @@ class TCPConnection
 
     On success, `_on_tls_ready()` fires when the handshake completes. During
     the handshake, `send()` returns `SendErrorNotConnected`. If the handshake
-    fails, `_on_tls_failure()` fires followed by `_on_closed()`.
+    fails, `_on_tls_failure` fires followed by `_on_closed()`.
 
     The `host` parameter is used for SNI (Server Name Indication) on client
     connections. Pass an empty string for server connections or when SNI is
@@ -594,7 +612,12 @@ class TCPConnection
         end
         match _lifecycle_event_receiver
         | let c: ClientLifecycleEventReceiver ref =>
-          c._on_connection_failure()
+          let reason = if _had_inflight then
+            ConnectionFailedTCP
+          else
+            ConnectionFailedDNS
+          end
+          c._on_connection_failure(reason)
         end
         return
       end
@@ -1188,6 +1211,7 @@ class TCPConnection
           end
         end
       | SSLAuthFail =>
+        _ssl_auth_failed = true
         hard_close()
         return
       | SSLError =>
@@ -1360,7 +1384,7 @@ class TCPConnection
     s: ClientLifecycleEventReceiver ref)
   =>
     if _ssl_failed then
-      s._on_connection_failure()
+      s._on_connection_failure(ConnectionFailedSSL)
       return
     end
 
@@ -1373,6 +1397,7 @@ class TCPConnection
       end
 
       _inflight_connections = PonyTCP.connect(e, _host, _port, _from, asio_flags)
+      _had_inflight = _inflight_connections > 0
       _connecting_callback()
     | None =>
       _Unreachable()
@@ -1385,7 +1410,7 @@ class TCPConnection
       PonyTCP.close(_fd)
       _fd = -1
       _closed = true
-      s._on_start_failure()
+      s._on_start_failure(StartFailedSSL)
       return
     end
 

--- a/lori/tls_failure_reason.pony
+++ b/lori/tls_failure_reason.pony
@@ -1,0 +1,13 @@
+primitive TLSAuthFailed
+  """
+  The TLS handshake failed due to an authentication error (certificate
+  validation failure, untrusted CA, hostname mismatch, etc.).
+  """
+
+primitive TLSGeneralError
+  """
+  The TLS handshake failed due to a protocol error other than authentication
+  (unexpected message, unsupported version, internal SSL error, etc.).
+  """
+
+type TLSFailureReason is (TLSAuthFailed | TLSGeneralError)

--- a/stress-tests/open-close/open-close-stress-test.pony
+++ b/stress-tests/open-close/open-close-stress-test.pony
@@ -254,7 +254,7 @@ actor Client is (TCPConnectionActor & ClientLifecycleEventReceiver)
     _logger(ll.Fine) and _logger.log("Client Connected.")
     _tcp_connection.send("Hi there!")
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
     _logger(ll.Fine) and _logger.log("Client Connection Failure.")
     _spawner.failed(this)
 


### PR DESCRIPTION
Failure callbacks (`_on_connection_failure`, `_on_start_failure`, `_on_tls_failure`) now carry a reason parameter identifying why the failure occurred, enabling downstream libraries to report meaningful error types instead of treating all failures identically.

Three new type aliases follow the existing `StartTLSError` pattern:
- `ConnectionFailureReason`: `ConnectionFailedDNS` / `ConnectionFailedTCP` / `ConnectionFailedSSL`
- `StartFailureReason`: `StartFailedSSL`
- `TLSFailureReason`: `TLSAuthFailed` / `TLSGeneralError`

Two internal fields support the reason tracking:
- `_had_inflight` distinguishes DNS failure (no TCP attempts) from TCP failure (all attempts failed)
- `_ssl_auth_failed` distinguishes `SSLAuthFail` from `SSLError` in `_ssl_poll()`, read by `hard_close()` for the TLS reason

Design: #201