### PR TITLE
Split PR CI into hygiene and code workflows

### DIFF
--- a/.github/workflows/pr-repo-hygiene.yml
+++ b/.github/workflows/pr-repo-hygiene.yml
@@ -1,0 +1,36 @@
+name: Repository Hygiene
+
+on: pull_request
+
+concurrency:
+  group: pr-repo-hygiene-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  packages: read
+
+jobs:
+  superlinter:
+    name: Lint bash, docker, markdown, and yaml
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Lint codebase
+        uses: docker://github/super-linter:v3.8.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_BASH: true
+          VALIDATE_DOCKERFILE: true
+          VALIDATE_MD: true
+          VALIDATE_YAML: true
+
+  verify-changelog:
+    name: Verify CHANGELOG is valid
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Verify CHANGELOG
+        uses: docker://ghcr.io/ponylang/changelog-tool:release
+        with:
+          args: changelog-tool verify

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,36 +1,22 @@
 name: PR
 
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - '**'
+      - '!**/*.md'
+      - '!**/*.yml'
+      - '!**/*.yaml'
+      - '.github/workflows/pr.yml'
+
+concurrency:
+  group: pr-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   packages: read
 
 jobs:
-  superlinter:
-    name: Lint bash, docker, markdown, and yaml
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Lint codebase
-        uses: docker://github/super-linter:v3.8.3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: true
-          VALIDATE_BASH: true
-          VALIDATE_DOCKERFILE: true
-          VALIDATE_MD: true
-          VALIDATE_YAML: true
-
-  verify-changelog:
-    name: Verify CHANGELOG is valid
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4.1.1
-      - name: Verify CHANGELOG
-        uses: docker://ghcr.io/ponylang/changelog-tool:release
-        with:
-          args: changelog-tool verify
-
   linux:
     name: Linux
     runs-on: ubuntu-latest


### PR DESCRIPTION
Separate superlinter and verify-changelog into pr-repo-hygiene.yml (always runs) and add path filters to pr.yml so build/test jobs only run on code changes. Markdown-only, YAML-only, or Dockerfile-only PRs now skip the build/test matrix and only run hygiene checks.