### PR TITLE
Add IPv4-only and IPv6-only support

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -8,3 +8,42 @@ The accept loop now exits on any error, letting the ASIO event system re-notify 
 
 The POSIX read loop in `TCPConnection` was missing a `return` after scheduling a deferred `_read_again` when the byte threshold was reached. This meant the loop continued reading from the socket in the same behavior call indefinitely under sustained load, preventing per-actor GC from running (GC only runs between behavior invocations) and queuing redundant `_read_again` messages. The read loop now correctly exits after reaching the threshold, allowing GC and other actors to run before resuming.
 
+## Add IPv4-only and IPv6-only support
+
+Lori now supports restricting connections to a specific IP protocol version. Client constructors (`TCPConnection.client`, `TCPConnection.ssl_client`) and `TCPListener` accept an optional `ip_version` parameter that defaults to `DualStack` (existing behavior).
+
+Pass `IP4` to restrict to IPv4 only or `IP6` for IPv6 only:
+
+```pony
+// IPv4-only listener
+_tcp_listener = TCPListener(listen_auth, "127.0.0.1", "7669", this
+  where ip_version = IP4)
+
+// IPv4-only client
+_tcp_connection = TCPConnection.client(auth, "127.0.0.1", "7669", "", this,
+  this where ip_version = IP4)
+
+// IPv6-only client
+_tcp_connection = TCPConnection.client(auth, "::1", "7669", "", this, this
+  where ip_version = IP6)
+
+// SSL client with IPv4 only
+_tcp_connection = TCPConnection.ssl_client(auth, sslctx, "127.0.0.1", "7669",
+  "", this, this where ip_version = IP4)
+```
+
+Server-side constructors (`server`, `ssl_server`) don't need this parameter — they accept an already-connected fd whose protocol version was determined by the listener.
+
+## Change TCPListener parameter order
+
+The `ip_version` parameter on `TCPListener.create` now comes before `limit`. Since `ip_version` is a hard requirement in many environments while `limit` is rarely set, the more commonly used parameter should come first.
+
+If you were passing `limit` positionally:
+
+```pony
+// Before
+_tcp_listener = TCPListener(listen_auth, host, port, this, 100)
+
+// After
+_tcp_listener = TCPListener(listen_auth, host, port, this where limit = 100)
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Added
 
+- Add IPv4-only and IPv6-only support ([PR #205](https://github.com/ponylang/lori/pull/205))
 
 ### Changed
+
+- Change TCPListener parameter order ([PR #205](https://github.com/ponylang/lori/pull/205))
 
 
 ## [0.9.0] - 2026-03-02

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ lori/
   lori.pony                 -- Package docstring (entry point for API documentation)
   tcp_connection.pony       -- TCPConnection class (core: read/write/connect/close/SSL)
   tcp_connection_actor.pony -- TCPConnectionActor trait (actor wrapper)
-  tcp_listener.pony         -- TCPListener class (accept loop, connection limits)
+  tcp_listener.pony         -- TCPListener class (accept loop, connection limits, ip_version)
   tcp_listener_actor.pony   -- TCPListenerActor trait (actor wrapper)
   lifecycle_event_receiver.pony -- Client/ServerLifecycleEventReceiver traits
   send_token.pony           -- SendToken class, SendError primitives and type alias
@@ -39,6 +39,7 @@ lori/
   start_failure_reason.pony -- StartFailureReason primitive and type alias
   tls_failure_reason.pony   -- TLSFailureReason primitives and type alias
   idle_timeout.pony         -- IdleTimeout constrained type and validator
+  ip_version.pony           -- IP4, IP6, DualStack primitives and IPVersion type alias
   auth.pony                 -- Auth primitives (NetAuth, TCPAuth, TCPListenAuth, etc.)
   pony_tcp.pony             -- FFI wrappers for pony_os_* TCP functions
   pony_asio.pony            -- FFI wrappers for pony_asio_event_* functions
@@ -52,6 +53,7 @@ examples/
   framed-protocol/          -- Length-prefixed framing with expect()
   idle-timeout/             -- Per-connection idle timeout
   infinite-ping-pong/       -- Ping-pong client+server
+  ip-version/               -- IPv4-only echo server
   net-ssl-echo-server/      -- SSL echo server
   net-ssl-infinite-ping-pong/ -- SSL ping-pong
   starttls-ping-pong/       -- STARTTLS upgrade from plaintext to TLS
@@ -66,7 +68,7 @@ stress-tests/
 
 Lori separates connection logic (class) from actor scheduling (trait):
 
-1. **`TCPConnection`** (class) — All TCP state and I/O logic including SSL. Created with `TCPConnection.client(...)`, `TCPConnection.server(...)`, `TCPConnection.ssl_client(...)`, or `TCPConnection.ssl_server(...)`. Existing plaintext connections can be upgraded to TLS via `start_tls()`. Not an actor itself.
+1. **`TCPConnection`** (class) — All TCP state and I/O logic including SSL. Created with `TCPConnection.client(...)`, `TCPConnection.server(...)`, `TCPConnection.ssl_client(...)`, or `TCPConnection.ssl_server(...)`. Client and SSL client constructors accept an optional `ip_version: IPVersion = DualStack` parameter to restrict to IPv4 (`IP4`) or IPv6 (`IP6`). Existing plaintext connections can be upgraded to TLS via `start_tls()`. Not an actor itself.
 2. **`TCPConnectionActor`** (trait) — The actor trait users implement. Requires `fun ref _connection(): TCPConnection`. Provides behaviors that delegate to the TCPConnection: `_event_notify`, `_read_again`, `dispose`, etc.
 3. **Lifecycle event receivers** — `ClientLifecycleEventReceiver` (callbacks: `_on_connected`, `_on_connecting`, `_on_connection_failure(reason)`, `_on_received`, `_on_closed`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure(reason)`, etc.) and `ServerLifecycleEventReceiver` (callbacks: `_on_started`, `_on_start_failure(reason)`, `_on_received`, `_on_closed`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure(reason)`, etc.). Both share common callbacks like `_on_received`, `_on_closed`, `_on_throttled`/`_on_unthrottled`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure`, `_on_idle_timeout`.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,10 @@ Ordered from simplest to most involved. The plain TCP examples come first; the S
 
 Minimal lori server. Shows the `TCPListenerActor` + `TCPConnectionActor` + `ServerLifecycleEventReceiver` pattern: accept a connection, receive data, send it back. Start here to understand how lori's pieces fit together.
 
+## [ip-version](ip-version/)
+
+IPv4-only echo server with a built-in client. Shows how to use the `ip_version` parameter on both `TCPListener` and `TCPConnection.client` to restrict connections to a specific protocol version. The same approach works with `IP6` for IPv6-only connections.
+
 ## [infinite-ping-pong](infinite-ping-pong/)
 
 Client and server exchanging messages in a loop. Adds a `ClientLifecycleEventReceiver` client that connects, sends "Ping", and responds to every "Pong" — showing both sides of a TCP conversation.

--- a/examples/ip-version/ip-version.pony
+++ b/examples/ip-version/ip-version.pony
@@ -1,0 +1,91 @@
+"""
+IPv4-only echo server with a built-in client.
+
+Demonstrates using the `ip_version` parameter to restrict both the listener and
+client to IPv4. The listener binds to `127.0.0.1` with `IP4`, and the client
+connects with `IP4`. The same approach works with `IP6` for IPv6-only
+connections.
+
+The client sends "Hello, IPv4!" and the server echoes it back. The client prints
+the response and closes the connection.
+"""
+use "../../lori"
+
+actor Main
+  new create(env: Env) =>
+    let listen_auth = TCPListenAuth(env.root)
+    let connect_auth = TCPConnectAuth(env.root)
+    IP4EchoListener(listen_auth, connect_auth, env.out)
+
+actor IP4EchoListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _out: OutStream
+  let _server_auth: TCPServerAuth
+  let _connect_auth: TCPConnectAuth
+  var _client: (IP4EchoClient | None) = None
+
+  new create(listen_auth: TCPListenAuth, connect_auth: TCPConnectAuth,
+    out: OutStream)
+  =>
+    _out = out
+    _connect_auth = connect_auth
+    _server_auth = TCPServerAuth(listen_auth)
+    _tcp_listener = TCPListener(listen_auth, "127.0.0.1", "7674", this
+      where ip_version = IP4)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): IP4Echoer =>
+    IP4Echoer(_server_auth, fd, _out)
+
+  fun ref _on_closed() =>
+    try (_client as IP4EchoClient).dispose() end
+
+  fun ref _on_listen_failure() =>
+    _out.print("Couldn't start IPv4 echo server.")
+
+  fun ref _on_listening() =>
+    _out.print("IPv4 echo server started on 127.0.0.1:7674")
+    _client = IP4EchoClient(_connect_auth, _out)
+
+actor IP4Echoer is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _out: OutStream
+
+  new create(auth: TCPServerAuth, fd: U32, out: OutStream) =>
+    _out = out
+    _tcp_connection = TCPConnection.server(auth, fd, this, this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_closed() =>
+    _out.print("Server: connection closed.")
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    _out.print("Server: echoing data back.")
+    _tcp_connection.send(consume data)
+
+actor IP4EchoClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _out: OutStream
+
+  new create(auth: TCPConnectAuth, out: OutStream) =>
+    _out = out
+    _tcp_connection = TCPConnection.client(
+      auth, "127.0.0.1", "7674", "", this, this where ip_version = IP4)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _out.print("Client: connected over IPv4.")
+    _tcp_connection.send("Hello, IPv4!")
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    _out.print("Client: connection failed.")
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    _out.print("Client: received '" + String.from_array(consume data) + "'")
+    _tcp_connection.close()

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -33,6 +33,8 @@ actor \nodoc\ Main is TestList
     test(_TestIdleTimeoutReset)
     test(_TestIdleTimeoutDisable)
     test(_TestYieldRead)
+    test(_TestIP4PingPong)
+    test(_TestIP6PingPong)
 
 class \nodoc\ iso _TestOutgoingFails is UnitTest
   """
@@ -2341,3 +2343,251 @@ actor \nodoc\ _TestYieldReadServer
       _h.complete(true)
       _tcp_connection.close()
     end
+
+class \nodoc\ iso _TestIP4PingPong is UnitTest
+  """
+  Test that IPv4-only connections work for both listener and client.
+  """
+  fun name(): String => "IP4PingPong"
+
+  fun apply(h: TestHelper) =>
+    let port = "7901"
+    let pings_to_send: I32 = 100
+
+    let listener = _TestIP4PongerListener(port, pings_to_send, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestIP4Pinger is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  var _pings_to_send: I32
+  let _h: TestHelper
+
+  new create(port: String,
+    pings_to_send: I32,
+    h: TestHelper)
+  =>
+    _pings_to_send = pings_to_send
+    _h = h
+
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(h.env.root),
+      "127.0.0.1",
+      port,
+      "",
+      this,
+      this where ip_version = IP4)
+    try _tcp_connection.expect(4)? end
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    if _pings_to_send > 0 then
+      _tcp_connection.send("Ping")
+      _pings_to_send = _pings_to_send - 1
+    end
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    if _pings_to_send > 0 then
+      _tcp_connection.send("Ping")
+      _pings_to_send = _pings_to_send - 1
+    elseif _pings_to_send == 0 then
+      _h.complete(true)
+    else
+      _h.fail("Too many pongs received")
+    end
+
+actor \nodoc\ _TestIP4Ponger is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  var _pings_to_receive: I32
+  let _h: TestHelper
+
+  new create(fd: U32,
+    pings_to_receive: I32,
+    h: TestHelper)
+  =>
+    _pings_to_receive = pings_to_receive
+    _h = h
+
+    _tcp_connection = TCPConnection.server(
+      TCPServerAuth(_h.env.root),
+      fd,
+      this,
+      this)
+    try _tcp_connection.expect(4)? end
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    if _pings_to_receive > 0 then
+      _tcp_connection.send("Pong")
+      _pings_to_receive = _pings_to_receive - 1
+    elseif _pings_to_receive == 0 then
+      _tcp_connection.send("Pong")
+    else
+      _h.fail("Too many pings received")
+    end
+
+actor \nodoc\ _TestIP4PongerListener is TCPListenerActor
+  let _port: String
+  var _tcp_listener: TCPListener = TCPListener.none()
+  var _pings_to_receive: I32
+  let _h: TestHelper
+  var _pinger: (_TestIP4Pinger | None) = None
+
+  new create(port: String,
+    pings_to_receive: I32,
+    h: TestHelper)
+  =>
+    _port = port
+    _pings_to_receive = pings_to_receive
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "127.0.0.1",
+      _port,
+      this where ip_version = IP4)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestIP4Ponger =>
+    _TestIP4Ponger(fd, _pings_to_receive, _h)
+
+  fun ref _on_closed() =>
+    try
+      (_pinger as _TestIP4Pinger).dispose()
+    end
+
+  fun ref _on_listening() =>
+    _pinger = _TestIP4Pinger(_port, _pings_to_receive, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestIP4PongerListener")
+
+class \nodoc\ iso _TestIP6PingPong is UnitTest
+  """
+  Test that IPv6-only connections work for both listener and client.
+  """
+  fun name(): String => "IP6PingPong"
+
+  fun apply(h: TestHelper) =>
+    let port = "7902"
+    let pings_to_send: I32 = 100
+
+    let listener = _TestIP6PongerListener(port, pings_to_send, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestIP6Pinger is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  var _pings_to_send: I32
+  let _h: TestHelper
+
+  new create(port: String,
+    pings_to_send: I32,
+    h: TestHelper)
+  =>
+    _pings_to_send = pings_to_send
+    _h = h
+
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(h.env.root),
+      "::1",
+      port,
+      "",
+      this,
+      this where ip_version = IP6)
+    try _tcp_connection.expect(4)? end
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    if _pings_to_send > 0 then
+      _tcp_connection.send("Ping")
+      _pings_to_send = _pings_to_send - 1
+    end
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    if _pings_to_send > 0 then
+      _tcp_connection.send("Ping")
+      _pings_to_send = _pings_to_send - 1
+    elseif _pings_to_send == 0 then
+      _h.complete(true)
+    else
+      _h.fail("Too many pongs received")
+    end
+
+actor \nodoc\ _TestIP6Ponger is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  var _pings_to_receive: I32
+  let _h: TestHelper
+
+  new create(fd: U32,
+    pings_to_receive: I32,
+    h: TestHelper)
+  =>
+    _pings_to_receive = pings_to_receive
+    _h = h
+
+    _tcp_connection = TCPConnection.server(
+      TCPServerAuth(_h.env.root),
+      fd,
+      this,
+      this)
+    try _tcp_connection.expect(4)? end
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    if _pings_to_receive > 0 then
+      _tcp_connection.send("Pong")
+      _pings_to_receive = _pings_to_receive - 1
+    elseif _pings_to_receive == 0 then
+      _tcp_connection.send("Pong")
+    else
+      _h.fail("Too many pings received")
+    end
+
+actor \nodoc\ _TestIP6PongerListener is TCPListenerActor
+  let _port: String
+  var _tcp_listener: TCPListener = TCPListener.none()
+  var _pings_to_receive: I32
+  let _h: TestHelper
+  var _pinger: (_TestIP6Pinger | None) = None
+
+  new create(port: String,
+    pings_to_receive: I32,
+    h: TestHelper)
+  =>
+    _port = port
+    _pings_to_receive = pings_to_receive
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "::1",
+      _port,
+      this where ip_version = IP6)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestIP6Ponger =>
+    _TestIP6Ponger(fd, _pings_to_receive, _h)
+
+  fun ref _on_closed() =>
+    try
+      (_pinger as _TestIP6Pinger).dispose()
+    end
+
+  fun ref _on_listening() =>
+    _pinger = _TestIP6Pinger(_port, _pings_to_receive, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestIP6PongerListener")

--- a/lori/ip_version.pony
+++ b/lori/ip_version.pony
@@ -1,0 +1,21 @@
+primitive IP4
+  """
+  Restrict connections to IPv4 only. The listener or client will use
+  `pony_os_listen_tcp4` or `pony_os_connect_tcp4`, binding or connecting
+  exclusively over IPv4.
+  """
+
+primitive IP6
+  """
+  Restrict connections to IPv6 only. The listener or client will use
+  `pony_os_listen_tcp6` or `pony_os_connect_tcp6`, binding or connecting
+  exclusively over IPv6.
+  """
+
+primitive DualStack
+  """
+  Allow both IPv4 and IPv6 (the default). Listeners bind to both protocol
+  versions. Clients use Happy Eyeballs to try both and pick the fastest.
+  """
+
+type IPVersion is (IP4 | IP6 | DualStack)

--- a/lori/lori.pony
+++ b/lori/lori.pony
@@ -323,11 +323,41 @@ concurrent connections:
 
 ```pony
 // Accept at most 100 connections at a time
-_tcp_listener = TCPListener(listen_auth, host, port, this, 100)
+_tcp_listener = TCPListener(listen_auth, host, port, this where limit = 100)
 ```
 
 When the limit is reached, the listener pauses accepting. As connections close,
 it resumes automatically. The default is no limit.
+
+## IP Version
+
+By default, lori uses dual-stack connections (both IPv4 and IPv6). To restrict
+a client or listener to a specific protocol version, pass an
+[`IPVersion`](/lori/lori-IPVersion/) parameter:
+
+```pony
+// IPv4-only listener
+_tcp_listener = TCPListener(listen_auth, "127.0.0.1", "7669", this
+  where ip_version = IP4)
+
+// IPv6-only client
+_tcp_connection = TCPConnection.client(auth, "::1", "7669", "", this, this
+  where ip_version = IP6)
+```
+
+[`IP4`](/lori/lori-IP4/) restricts to IPv4 only,
+[`IP6`](/lori/lori-IP6/) restricts to IPv6 only, and
+[`DualStack`](/lori/lori-DualStack/) (the default) allows both. The same
+parameter works on `ssl_client`:
+
+```pony
+_tcp_connection = TCPConnection.ssl_client(auth, sslctx, "127.0.0.1", "7669",
+  "", this, this where ip_version = IP4)
+```
+
+Server-side constructors (`server`, `ssl_server`) don't need this parameter —
+they accept an already-connected fd whose protocol version was determined by the
+listener.
 
 ## Auth Hierarchy
 

--- a/lori/pony_tcp.pony
+++ b/lori/pony_tcp.pony
@@ -4,8 +4,24 @@ use @pony_os_connect_tcp[U32](the_actor: AsioEventNotify,
   port: Pointer[U8] tag,
   from: Pointer[U8] tag,
   asio_flags: U32)
+use @pony_os_connect_tcp4[U32](the_actor: AsioEventNotify,
+  host: Pointer[U8] tag,
+  port: Pointer[U8] tag,
+  from: Pointer[U8] tag,
+  asio_flags: U32)
+use @pony_os_connect_tcp6[U32](the_actor: AsioEventNotify,
+  host: Pointer[U8] tag,
+  port: Pointer[U8] tag,
+  from: Pointer[U8] tag,
+  asio_flags: U32)
 use @pony_os_keepalive[None](fd: U32, secs: U32)
 use @pony_os_listen_tcp[AsioEventID](the_actor: AsioEventNotify,
+  host: Pointer[U8] tag,
+  port: Pointer[U8] tag)
+use @pony_os_listen_tcp4[AsioEventID](the_actor: AsioEventNotify,
+  host: Pointer[U8] tag,
+  port: Pointer[U8] tag)
+use @pony_os_listen_tcp6[AsioEventID](the_actor: AsioEventNotify,
   host: Pointer[U8] tag,
   port: Pointer[U8] tag)
 use @pony_os_peername[Bool](fd: U32, ip: net.NetAddress tag)
@@ -31,10 +47,18 @@ use net = "net"
 primitive PonyTCP
   fun listen(the_actor: AsioEventNotify,
     host: String,
-    port: String)
+    port: String,
+    ip_version: IPVersion = DualStack)
     : AsioEventID
   =>
-    @pony_os_listen_tcp(the_actor, host.cstring(), port.cstring())
+    match ip_version
+    | IP4 =>
+      @pony_os_listen_tcp4(the_actor, host.cstring(), port.cstring())
+    | IP6 =>
+      @pony_os_listen_tcp6(the_actor, host.cstring(), port.cstring())
+    | DualStack =>
+      @pony_os_listen_tcp(the_actor, host.cstring(), port.cstring())
+    end
 
   fun accept(event: AsioEventID): I32 =>
     @pony_os_accept(event)
@@ -46,14 +70,30 @@ primitive PonyTCP
     host: String,
     port: String,
     from: String,
-    asio_flags: U32)
+    asio_flags: U32,
+    ip_version: IPVersion = DualStack)
     : U32
   =>
-    @pony_os_connect_tcp(the_actor,
-      host.cstring(),
-      port.cstring(),
-      from.cstring(),
-      asio_flags)
+    match ip_version
+    | IP4 =>
+      @pony_os_connect_tcp4(the_actor,
+        host.cstring(),
+        port.cstring(),
+        from.cstring(),
+        asio_flags)
+    | IP6 =>
+      @pony_os_connect_tcp6(the_actor,
+        host.cstring(),
+        port.cstring(),
+        from.cstring(),
+        asio_flags)
+    | DualStack =>
+      @pony_os_connect_tcp(the_actor,
+        host.cstring(),
+        port.cstring(),
+        from.cstring(),
+        asio_flags)
+    end
 
   fun keepalive(fd: U32, secs: U32) =>
     @pony_os_keepalive(fd, secs)

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -61,19 +61,22 @@ class TCPConnection
   var _host: String = ""
   var _port: String = ""
   var _from: String = ""
+  var _ip_version: IPVersion = DualStack
 
   new client(auth: TCPConnectAuth,
     host: String,
     port: String,
     from: String,
     enclosing: TCPConnectionActor ref,
-    ler: ClientLifecycleEventReceiver ref)
+    ler: ClientLifecycleEventReceiver ref,
+    ip_version: IPVersion = DualStack)
   =>
     _lifecycle_event_receiver = ler
     _enclosing = enclosing
     _host = host
     _port = port
     _from = from
+    _ip_version = ip_version
 
     _resize_read_buffer_if_needed()
 
@@ -98,7 +101,8 @@ class TCPConnection
     port: String,
     from: String,
     enclosing: TCPConnectionActor ref,
-    ler: ClientLifecycleEventReceiver ref)
+    ler: ClientLifecycleEventReceiver ref,
+    ip_version: IPVersion = DualStack)
   =>
     """
     Create a client-side SSL connection. The SSL session is created from the
@@ -110,6 +114,7 @@ class TCPConnection
     _host = host
     _port = port
     _from = from
+    _ip_version = ip_version
 
     try
       _ssl = ssl_ctx.client(host)?
@@ -1400,7 +1405,8 @@ class TCPConnection
         AsioEvent.read_write_oneshot()
       end
 
-      _inflight_connections = PonyTCP.connect(e, _host, _port, _from, asio_flags)
+      _inflight_connections = PonyTCP.connect(e, _host, _port, _from,
+        asio_flags where ip_version = _ip_version)
       _had_inflight = _inflight_connections > 0
       _connecting_callback()
     | None =>

--- a/lori/tcp_listener.pony
+++ b/lori/tcp_listener.pony
@@ -7,6 +7,7 @@ class TCPListener
   let _host: String
   let _port: String
   let _limit: MaxSpawn
+  let _ip_version: IPVersion
   var _open_connections: U32 = 0
   var _paused: Bool = false
   var _event: AsioEventID = AsioEvent.none()
@@ -14,9 +15,13 @@ class TCPListener
   var _listening: Bool = false
   var _enclosing: (TCPListenerActor ref | None)
 
-  new create(auth: TCPListenAuth, host: String, port: String, enclosing: TCPListenerActor ref, limit: MaxSpawn = None) =>
+  new create(auth: TCPListenAuth, host: String, port: String,
+    enclosing: TCPListenerActor ref, ip_version: IPVersion = DualStack,
+    limit: MaxSpawn = None)
+  =>
     _host = host
     _port = port
+    _ip_version = ip_version
     _limit = limit
     _enclosing = enclosing
     enclosing._finish_initialization()
@@ -25,6 +30,7 @@ class TCPListener
     _host = ""
     _port = ""
     _limit = None
+    _ip_version = DualStack
     _enclosing = None
 
   fun ref close() =>
@@ -151,7 +157,7 @@ class TCPListener
   fun ref _finish_initialization() =>
     match \exhaustive\ _enclosing
     | let e: TCPListenerActor ref =>
-      _event = PonyTCP.listen(e, _host, _port)
+      _event = PonyTCP.listen(e, _host, _port where ip_version = _ip_version)
       if not _event.is_null() then
         _fd = PonyAsio.event_fd(_event)
         _listening = true

--- a/stress-tests/open-close/open-close-stress-test.pony
+++ b/stress-tests/open-close/open-close-stress-test.pony
@@ -81,8 +81,7 @@ actor Listener is TCPListenerActor
       _auth,
       host,
       port,
-      this,
-      _max_concurrent_connections)
+      this where limit = _max_concurrent_connections)
 
   be spawner_done() =>
     _tcp_listener.close()


### PR DESCRIPTION
Adds an `ip_version: IPVersion = DualStack` parameter to the client constructors (`TCPConnection.client`, `TCPConnection.ssl_client`) and `TCPListener.create`, where `IPVersion` is `(IP4 | IP6 | DualStack)`. The default preserves existing behavior. Server-side constructors don't need this since they accept an already-connected fd whose protocol version was determined by the listener.

This follows lori's existing pattern for optional configuration (cf. `limit: MaxSpawn = None` on `TCPListener`) rather than adding separate constructors, avoiding multiplicative explosion with future options.

Design: #199