### PR TITLE
Fix accept loop spinning on persistent errors

### DIFF
--- a/.release-notes/fix-accept-spin-loop.md
+++ b/.release-notes/fix-accept-spin-loop.md
@@ -1,0 +1,5 @@
+## Fix accept loop spinning on persistent errors
+
+Previously, when `TCPListener`'s accept loop encountered a non-EWOULDBLOCK error (such as running out of file descriptors), it would retry immediately in a tight loop. Since persistent errors like EMFILE never resolve on their own, this caused the listener to spin indefinitely, consuming CPU without making progress.
+
+The accept loop now exits on any error, letting the ASIO event system re-notify the listener. This gives other actors a chance to run and potentially free resources before the next accept attempt.

--- a/lori/pony_tcp.pony
+++ b/lori/pony_tcp.pony
@@ -1,4 +1,4 @@
-use @pony_os_accept[U32](event: AsioEventID)
+use @pony_os_accept[I32](event: AsioEventID)
 use @pony_os_connect_tcp[U32](the_actor: AsioEventNotify,
   host: Pointer[U8] tag,
   port: Pointer[U8] tag,
@@ -36,7 +36,7 @@ primitive PonyTCP
   =>
     @pony_os_listen_tcp(the_actor, host.cstring(), port.cstring())
 
-  fun accept(event: AsioEventID): U32 =>
+  fun accept(event: AsioEventID): I32 =>
     @pony_os_accept(event)
 
   fun close(fd: U32) =>

--- a/lori/tcp_listener.pony
+++ b/lori/tcp_listener.pony
@@ -99,21 +99,17 @@ class TCPListener
           while not _at_connection_limit() do
             var fd = PonyTCP.accept(_event)
 
-            match fd
-            | -1 =>
-              // Wouldn't block but we got an error. Keep trying.
-              None
-            | 0 =>
-              // Would block. Bail out.
+            // 0: would block, -1: error
+            if fd <= 0 then
               return
+            end
+
+            try
+              let opened = e._on_accept(fd.u32())?
+              opened._register_spawner(e)
+              _open_connections = _open_connections + 1
             else
-              try
-                let opened = e._on_accept(fd)?
-                opened._register_spawner(e)
-                _open_connections = _open_connections + 1
-              else
-                PonyTCP.close(fd)
-              end
+              PonyTCP.close(fd.u32())
             end
           end
 


### PR DESCRIPTION
The POSIX accept loop treated all non-EWOULDBLOCK errors (-1 from pony_os_accept) as transient and retried immediately. Persistent errors like EMFILE (out of file descriptors) caused an infinite tight spin since the error never resolves on its own.

Now the loop exits on any error (fd <= 0), letting ASIO re-notify the listener. This gives other actors a chance to run and free resources.

Also fixes the FFI return type for pony_os_accept from U32 to I32 to match the C signature (int). See ponylang/ponyc#4906 for the same issue in ponyc's stdlib.

Closes #206