### PR TITLE
Fix read loop not yielding after byte threshold

### DIFF
--- a/.release-notes/fix-read-loop-yield.md
+++ b/.release-notes/fix-read-loop-yield.md
@@ -1,0 +1,3 @@
+## Fix read loop not yielding after byte threshold
+
+The POSIX read loop in `TCPConnection` was missing a `return` after scheduling a deferred `_read_again` when the byte threshold was reached. This meant the loop continued reading from the socket in the same behavior call indefinitely under sustained load, preventing per-actor GC from running (GC only runs between behavior invocations) and queuing redundant `_read_again` messages. The read loop now correctly exits after reaching the threshold, allowing GC and other actors to run before resuming.

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -878,8 +878,12 @@ class TCPConnection
               end
             end
 
+            // Yield after reading a buffer's worth of data to allow GC and
+            // other actors to run. _queue_read() schedules _read_again to
+            // resume.
             if total_bytes_read >= _read_buffer_size then
               _queue_read()
+              return
             end
 
             _resize_read_buffer_if_needed()


### PR DESCRIPTION
The POSIX `_read()` loop schedules `_read_again` via `_queue_read()` when `total_bytes_read` crosses the buffer size threshold, but was missing a `return` afterward. The loop continued reading from the socket in the same behavior invocation, preventing per-actor GC from running under sustained load and queuing redundant `_read_again` messages on every subsequent iteration.