### PR TITLE
Make expect() use a constrained type instead of raw USize

### DIFF
--- a/.release-notes/expect-constrained-type.md
+++ b/.release-notes/expect-constrained-type.md
@@ -1,0 +1,19 @@
+## Make expect() use a constrained type instead of raw USize
+
+`expect()` now takes `(Expect | None)` instead of `USize`. `Expect` is a constrained type that guarantees a value of at least 1. `None` replaces the magic value `0` to mean "deliver all available data." This follows the same pattern used by `IdleTimeout`, `ReadBufferSize`, and `MaxSpawn`.
+
+Before:
+
+```pony
+_tcp_connection.expect(4)
+_tcp_connection.expect(0)
+```
+
+After:
+
+```pony
+match MakeExpect(4)
+| let e: Expect => _tcp_connection.expect(e)
+end
+_tcp_connection.expect(None)
+```

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -35,7 +35,9 @@ try _tcp_connection.expect(4)? end
 After:
 
 ```pony
-_tcp_connection.expect(4)
+match MakeExpect(4)
+| let e: Expect => _tcp_connection.expect(e)
+end
 ```
 
 The guard now checks against the read buffer minimum rather than the buffer size, enforcing the `expect <= read_buffer_min` invariant.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ lori/
   send_token.pony           -- SendToken class, SendError primitives and type alias
   read_buffer.pony          -- Read buffer result types (ReadBufferResized, ExpectSet, etc.)
   read_buffer_size.pony     -- ReadBufferSize constrained type, validator, and default
+  expect.pony               -- Expect constrained type and validator
   start_tls_error.pony      -- StartTLSError primitives and type alias
   connection_failure_reason.pony -- ConnectionFailureReason primitives and type alias
   start_failure_reason.pony -- StartFailureReason primitive and type alias
@@ -146,11 +147,11 @@ SSL state lives directly in `TCPConnection` (fields `_ssl`, `_ssl_ready`, `_ssl_
 - **Client handshake initiation:** When TCP connects, `_ssl_flush_sends()` sends the ClientHello. The handshake proceeds via `_deliver_received()` → `ssl.receive()` → `_ssl_poll()`.
 - **Ready signaling:** `_ssl_ready` is set when `ssl.state()` returns `SSLReady`, which triggers `_on_connected`/`_on_started` delivery.
 - **Error handling:** `SSLAuthFail` sets `_ssl_auth_failed = true` then triggers `hard_close()`. `SSLError` triggers `hard_close()` directly. `hard_close()` reads `_ssl_auth_failed` to pass `TLSAuthFailed` vs `TLSGeneralError` to `_on_tls_failure` (for TLS upgrades), or `ConnectionFailedSSL`/`StartFailedSSL` to `_on_connection_failure`/`_on_start_failure` (for initial SSL). If the handshake never completed, clients get `_on_connection_failure(ConnectionFailedSSL)` and servers get `_on_start_failure(StartFailedSSL)`.
-- **Expect handling:** The application's `expect()` value is stored in `_ssl_expect` and used when chunking decrypted data via `ssl.read()`. The TCP read layer uses 0 (read all available) since SSL record framing doesn't align with application framing.
+- **Expect handling:** The application's `expect()` value is stored in `_ssl_expect` as `(Expect | None)` and converted to `USize` at the `ssl.read()` call site (0 for `None`). The TCP read layer uses `None` (read all available) since SSL record framing doesn't align with application framing.
 
 ### TLS upgrade (STARTTLS)
 
-`start_tls(ssl_ctx, host)` upgrades an established plaintext connection to TLS. It creates an SSL session, migrates expect state (`_ssl_expect = _expect; _expect = 0`), sets `_tls_upgrade = true`, and flushes the ClientHello. The `_tls_upgrade` flag distinguishes "initial SSL from constructor" vs "upgraded SSL from start_tls()":
+`start_tls(ssl_ctx, host)` upgrades an established plaintext connection to TLS. It creates an SSL session, migrates expect state (`_ssl_expect = _expect; _expect = None`), sets `_tls_upgrade = true`, and flushes the ClientHello. The `_tls_upgrade` flag distinguishes "initial SSL from constructor" vs "upgraded SSL from start_tls()":
 
 - **`_ssl_poll()`**: When `SSLReady` is reached and `_tls_upgrade` is true, calls `_on_tls_ready()` instead of `_on_connected()`/`_on_started()`.
 - **`hard_close()`**: When SSL handshake is incomplete and `_tls_upgrade` is true, calls `_on_tls_failure(reason)` (where `reason` is `TLSAuthFailed` or `TLSGeneralError` based on `_ssl_auth_failed`) then `_on_closed()` (the application already knew about the plaintext connection). Without `_tls_upgrade`, the initial-SSL path fires `_on_connection_failure(ConnectionFailedSSL)`/`_on_start_failure(StartFailedSSL)` instead.
@@ -231,9 +232,9 @@ API:
 - Constructor parameter `read_buffer_size: ReadBufferSize` (default `DefaultReadBufferSize()`, 16384) sets both `_read_buffer_size` and `_read_buffer_min`.
 - `set_read_buffer_minimum(new_min: ReadBufferSize)` — sets shrink-back floor, grows buffer if needed.
 - `resize_read_buffer(size: ReadBufferSize)` — forces buffer to exact size, lowers minimum if below it.
-- `expect(qty)` — returns `ExpectAboveBufferMinimum` if `qty > _read_buffer_min`.
+- `expect(qty: (Expect | None))` — returns `ExpectAboveBufferMinimum` if `qty` exceeds `_read_buffer_min`. `None` means "deliver all available data."
 
-`_user_expect()` returns `_expect.max(_ssl_expect)` for invariant checks (the user's expect value regardless of SSL state).
+`_user_expect()` returns the unwrapped expect value as `USize` (0 when both `_expect` and `_ssl_expect` are `None`) for invariant checks against buffer sizes.
 
 Shrink-back happens in `_resize_read_buffer_if_needed()` when `_bytes_in_read_buffer == 0` and `_read_buffer_size > _read_buffer_min`. On Windows, a post-loop call to `_resize_read_buffer_if_needed()` was added in `_read_completed()` and `_windows_resume_read()` because the existing calls inside the `while _there_is_buffered_read_data()` loop can never see `_bytes_in_read_buffer == 0`.
 

--- a/examples/framed-protocol/framed-protocol.pony
+++ b/examples/framed-protocol/framed-protocol.pony
@@ -12,6 +12,7 @@ echoed responses.
 Expected output shows the client sending several messages and receiving each
 one echoed back, confirming the framing round-trip.
 """
+use "constrained_types"
 use "../../lori"
 
 actor Main
@@ -59,7 +60,9 @@ actor FramedServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   new create(auth: TCPServerAuth, fd: U32, out: OutStream) =>
     _out = out
     _tcp_connection = TCPConnection.server(auth, fd, this, this)
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -73,7 +76,9 @@ actor FramedServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
           data(3)?.usize()
         _out.print("Server: header says " + len.string() + " byte payload")
         _reading_header = false
-        _tcp_connection.expect(len)
+        match MakeExpect(len)
+        | let e: Expect => _tcp_connection.expect(e)
+        end
       end
     else
       let payload: Array[U8] val = consume data
@@ -92,7 +97,9 @@ actor FramedServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
       _tcp_connection.send(recover val [as ByteSeq: header; payload] end)
 
       _reading_header = true
-      _tcp_connection.expect(4)
+      match MakeExpect(4)
+      | let e: Expect => _tcp_connection.expect(e)
+      end
     end
 
   fun ref _on_closed() =>
@@ -131,7 +138,9 @@ actor FramedClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
     for msg in _messages.values() do
       _send_framed(msg)
     end
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _send_framed(msg: String) =>
     """
@@ -157,7 +166,9 @@ actor FramedClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
           (data(2)?.usize() << 8) or
           data(3)?.usize()
         _reading_header = false
-        _tcp_connection.expect(len)
+        match MakeExpect(len)
+        | let e: Expect => _tcp_connection.expect(e)
+        end
       end
     else
       let payload = String.from_array(consume data)
@@ -174,7 +185,9 @@ actor FramedClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
       end
 
       _reading_header = true
-      _tcp_connection.expect(4)
+      match MakeExpect(4)
+      | let e: Expect => _tcp_connection.expect(e)
+      end
 
       if _messages_received == _messages.size() then
         _out.print("Client: all " + _messages.size().string()

--- a/examples/infinite-ping-pong/infinite-ping-pong.pony
+++ b/examples/infinite-ping-pong/infinite-ping-pong.pony
@@ -7,9 +7,10 @@ prints each reply and sends "Ping" again, producing an infinite back-and-forth.
 
 Shows both sides of a TCP conversation: ServerLifecycleEventReceiver for the
 server and ClientLifecycleEventReceiver for the client. Both sides use
-`expect(4)` so that each `_on_received` callback delivers exactly one
+`expect()` so that each `_on_received` callback delivers exactly one
 4-byte message ("Ping" or "Pong").
 """
+use "constrained_types"
 use "../../lori"
 
 actor Main
@@ -52,7 +53,9 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   new create(auth: TCPServerAuth, fd: U32, out: OutStream) =>
     _out = out
     _tcp_connection =  TCPConnection.server(auth, fd, this, this)
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -73,7 +76,9 @@ actor Client is (TCPConnectionActor & ClientLifecycleEventReceiver)
   =>
     _out = out
     _tcp_connection = TCPConnection.client(auth, host, port, from, this, this)
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection

--- a/examples/net-ssl-infinite-ping-pong/net-ssl-infinite-ping-pong.pony
+++ b/examples/net-ssl-infinite-ping-pong/net-ssl-infinite-ping-pong.pony
@@ -3,10 +3,11 @@ SSL version of infinite ping-pong.
 
 Same Ping/Pong exchange as the plain infinite-ping-pong example, but over SSL.
 Shows both TCPConnection.ssl_server and TCPConnection.ssl_client in the same
-program. Both sides use `expect(4)` so that each `_on_received` callback
+program. Both sides use `expect()` so that each `_on_received` callback
 delivers exactly one 4-byte message. Must be run from the project root so the
 relative certificate paths resolve correctly.
 """
+use "constrained_types"
 use "files"
 use "ssl/net"
 use "../../lori"
@@ -77,7 +78,9 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   =>
     _out = out
     _tcp_connection = TCPConnection.ssl_server(auth, sslctx, fd, this, this)
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -100,7 +103,9 @@ actor Client is (TCPConnectionActor & ClientLifecycleEventReceiver)
     _out = out
     _tcp_connection = TCPConnection.ssl_client(auth, sslctx, host, port, from,
       this, this)
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection

--- a/examples/read-buffer-size/read-buffer-size.pony
+++ b/examples/read-buffer-size/read-buffer-size.pony
@@ -62,7 +62,9 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
     | let _: ValidationFailure =>
       _tcp_connection = TCPConnection.server(auth, fd, this, this)
     end
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -81,7 +83,7 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
           _tcp_connection.resize_read_buffer(rbs)
         end
         // Read all available data in bulk mode
-        _tcp_connection.expect(0)
+        _tcp_connection.expect(None)
         _control_phase = false
       end
     else

--- a/examples/yield-read/yield-read.pony
+++ b/examples/yield-read/yield-read.pony
@@ -11,6 +11,7 @@ traffic and you want to prevent it from monopolizing the Pony scheduler. Unlike
 `mute()`/`unmute()`, `yield_read()` is a one-shot pause — reading resumes on
 its own without explicit action.
 """
+use "constrained_types"
 use "../../lori"
 
 actor Main
@@ -57,7 +58,9 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   new create(auth: TCPServerAuth, fd: U32, out: OutStream) =>
     _out = out
     _tcp_connection = TCPConnection.server(auth, fd, this, this)
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -122,7 +122,9 @@ actor \nodoc\ _TestPinger is (TCPConnectionActor & ClientLifecycleEventReceiver)
       "",
       this,
       this)
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -160,7 +162,9 @@ actor \nodoc\ _TestPonger is (TCPConnectionActor & ServerLifecycleEventReceiver)
       fd,
       this,
       this)
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -291,7 +295,9 @@ actor \nodoc\ _TestBasicExpectServer is (TCPConnectionActor & ServerLifecycleEve
       fd,
       this,
       this)
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -904,7 +910,9 @@ actor \nodoc\ _TestSSLPinger
       "",
       this,
       this)
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -945,7 +953,9 @@ actor \nodoc\ _TestSSLPonger
       fd,
       this,
       this)
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -1055,7 +1065,9 @@ actor \nodoc\ _TestStartTLSClient
       "",
       this,
       this)
-    _tcp_connection.expect(2)
+    match MakeExpect(2)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -1079,7 +1091,9 @@ actor \nodoc\ _TestStartTLSClient
 
   fun ref _on_tls_ready() =>
     _h.complete_action("client tls ready")
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
     _tcp_connection.send("Ping")
 
   fun ref _on_tls_failure(reason: TLSFailureReason) =>
@@ -1103,7 +1117,9 @@ actor \nodoc\ _TestStartTLSServer
       fd,
       this,
       this)
-    _tcp_connection.expect(8)
+    match MakeExpect(8)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -1125,7 +1141,9 @@ actor \nodoc\ _TestStartTLSServer
 
   fun ref _on_tls_ready() =>
     _h.complete_action("server tls ready")
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _on_tls_failure(reason: TLSFailureReason) =>
     _h.fail("Server TLS handshake failed")
@@ -1607,7 +1625,9 @@ actor \nodoc\ _TestSendvServer
       fd,
       this,
       this)
-    _tcp_connection.expect(13)
+    match MakeExpect(13)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -1783,7 +1803,9 @@ actor \nodoc\ _TestSendvMixedEmptyServer
       fd,
       this,
       this)
-    _tcp_connection.expect(10)
+    match MakeExpect(10)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -1923,7 +1945,9 @@ actor \nodoc\ _TestSSLSendvServer
       fd,
       this,
       this)
-    _tcp_connection.expect(15)
+    match MakeExpect(15)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -2345,7 +2369,9 @@ actor \nodoc\ _TestYieldReadServer
       fd,
       this,
       this)
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -2393,7 +2419,9 @@ actor \nodoc\ _TestIP4Pinger is (TCPConnectionActor & ClientLifecycleEventReceiv
       "",
       this,
       this where ip_version = IP4)
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -2431,7 +2459,9 @@ actor \nodoc\ _TestIP4Ponger is (TCPConnectionActor & ServerLifecycleEventReceiv
       fd,
       this,
       this)
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -2517,7 +2547,9 @@ actor \nodoc\ _TestIP6Pinger is (TCPConnectionActor & ClientLifecycleEventReceiv
       "",
       this,
       this where ip_version = IP6)
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -2555,7 +2587,9 @@ actor \nodoc\ _TestIP6Ponger is (TCPConnectionActor & ServerLifecycleEventReceiv
       fd,
       this,
       this)
-    _tcp_connection.expect(4)
+    match MakeExpect(4)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
@@ -2887,7 +2921,9 @@ actor \nodoc\ _TestSetReadBufferMinBelowExpectServer is
 
   fun ref _on_started() =>
     // Set expect to 100
-    _tcp_connection.expect(100)
+    match MakeExpect(100)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
     // Setting minimum below expect should fail
     match MakeReadBufferSize(50)
@@ -3051,7 +3087,9 @@ actor \nodoc\ _TestResizeReadBufferBelowExpectServer is
 
   fun ref _on_started() =>
     // Set expect to 200
-    _tcp_connection.expect(200)
+    match MakeExpect(200)
+    | let e: Expect => _tcp_connection.expect(e)
+    end
 
     // Resize below expect should fail
     match MakeReadBufferSize(100)
@@ -3143,17 +3181,23 @@ actor \nodoc\ _TestResizeReadBufferBelowMinServer is
     end
 
     // Now expect(512) should fail because minimum was lowered to 256
-    match _tcp_connection.expect(512)
-    | ExpectSet =>
-      _h.fail("expect(512) should fail when minimum is 256")
-    | ExpectAboveBufferMinimum => None
+    match MakeExpect(512)
+    | let e: Expect =>
+      match _tcp_connection.expect(e)
+      | ExpectSet =>
+        _h.fail("expect(512) should fail when minimum is 256")
+      | ExpectAboveBufferMinimum => None
+      end
     end
 
     // expect(256) should succeed (at the new minimum)
-    match _tcp_connection.expect(256)
-    | ExpectSet => None
-    | ExpectAboveBufferMinimum =>
-      _h.fail("expect(256) should succeed when minimum is 256")
+    match MakeExpect(256)
+    | let e: Expect =>
+      match _tcp_connection.expect(e)
+      | ExpectSet => None
+      | ExpectAboveBufferMinimum =>
+        _h.fail("expect(256) should succeed when minimum is 256")
+      end
     end
 
     _h.complete(true)
@@ -3214,10 +3258,13 @@ actor \nodoc\ _TestExpectAboveBufferMinServer is
 
   fun ref _on_started() =>
     // expect(256) should fail because minimum is 128
-    match _tcp_connection.expect(256)
-    | ExpectSet =>
-      _h.fail("expect(256) should fail when minimum is 128")
-    | ExpectAboveBufferMinimum => None
+    match MakeExpect(256)
+    | let e: Expect =>
+      match _tcp_connection.expect(e)
+      | ExpectSet =>
+        _h.fail("expect(256) should fail when minimum is 128")
+      | ExpectAboveBufferMinimum => None
+      end
     end
 
     _h.complete(true)
@@ -3278,10 +3325,13 @@ actor \nodoc\ _TestExpectAtBufferMinServer is
 
   fun ref _on_started() =>
     // expect(256) should succeed (equals minimum)
-    match _tcp_connection.expect(256)
-    | ExpectSet => None
-    | ExpectAboveBufferMinimum =>
-      _h.fail("expect(256) should succeed when minimum is 256")
+    match MakeExpect(256)
+    | let e: Expect =>
+      match _tcp_connection.expect(e)
+      | ExpectSet => None
+      | ExpectAboveBufferMinimum =>
+        _h.fail("expect(256) should succeed when minimum is 256")
+      end
     end
 
     _h.complete(true)

--- a/lori/expect.pony
+++ b/lori/expect.pony
@@ -1,0 +1,31 @@
+use "constrained_types"
+
+primitive ExpectValidator is Validator[USize]
+  """
+  Validates that an expect value is at least 1.
+
+  An expect of 0 is meaningless — use `None` to indicate "deliver all available
+  data." Used by `MakeExpect` to construct `Expect` values.
+  """
+  fun apply(value: USize): ValidationResult =>
+    if value == 0 then
+      recover val
+        ValidationFailure("expect must be greater than zero")
+      end
+    else
+      ValidationSuccess
+    end
+
+type Expect is Constrained[USize, ExpectValidator]
+  """
+  A validated expect value in bytes. The value must be at least 1.
+
+  Construct with `MakeExpect(bytes)`, which returns
+  `(Expect | ValidationFailure)`. Pass to `TCPConnection.expect()`.
+  Use `None` instead of `Expect` to indicate "deliver all available data."
+  """
+
+type MakeExpect is MakeConstrained[USize, ExpectValidator]
+  """
+  Factory for `Expect` values. Returns `(Expect | ValidationFailure)`.
+  """

--- a/lori/lori.pony
+++ b/lori/lori.pony
@@ -342,8 +342,9 @@ match MakeReadBufferSize(8192)
 end
 ```
 
-The invariant chain is: `expect <= read_buffer_min <= read_buffer_size`. Setting
-expect above the buffer minimum returns
+The `expect()` method accepts `(Expect | None)` where `None` means "deliver all
+available data." The invariant chain is: `expect <= read_buffer_min <=
+read_buffer_size`. Setting expect above the buffer minimum returns
 [`ExpectAboveBufferMinimum`](/lori/lori-ExpectAboveBufferMinimum/) — raise the
 minimum first, then set expect. Resizing below the current expect returns
 [`ReadBufferResizeBelowExpect`](/lori/lori-ReadBufferResizeBelowExpect/).

--- a/lori/read_buffer.pony
+++ b/lori/read_buffer.pony
@@ -22,7 +22,7 @@ primitive ExpectSet
 
 primitive ExpectAboveBufferMinimum
   """
-  The requested expect value exceeds the current read buffer minimum. Raise
+  The requested `Expect` value exceeds the current read buffer minimum. Raise
   the buffer minimum first, then set expect.
   """
 

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -30,7 +30,7 @@ class TCPConnection
   var _bytes_in_read_buffer: USize = 0
   var _read_buffer_size: USize = 16384
   var _read_buffer_min: USize = 16384
-  var _expect: USize = 0
+  var _expect: (Expect | None) = None
 
   // Send token tracking
   var _next_token_id: USize = 0
@@ -40,7 +40,7 @@ class TCPConnection
   var _ssl: (SSL ref | None) = None
   var _ssl_ready: Bool = false
   var _ssl_failed: Bool = false
-  var _ssl_expect: USize = 0
+  var _ssl_expect: (Expect | None) = None
   // Distinguishes "initial SSL from constructor" vs "upgraded SSL from
   // start_tls()". Used by _ssl_poll() and hard_close() to route to the
   // correct callbacks (_on_tls_ready/_on_tls_failure vs
@@ -337,20 +337,32 @@ class TCPConnection
     """
     The user's requested expect value, regardless of whether SSL is active.
     Internally, expect is split across _expect (non-SSL) and _ssl_expect (SSL),
-    but invariant checks need the user's actual requested value.
+    but invariant checks need the user's actual requested value. Returns 0 when
+    both are None, since 0 < any valid buffer min — the correct behavior for
+    invariant checks when no expect constraint is active.
     """
-    _expect.max(_ssl_expect)
+    match \exhaustive\ _expect
+    | let e: Expect => e()
+    | None =>
+      match \exhaustive\ _ssl_expect
+      | let e: Expect => e()
+      | None => 0
+      end
+    end
 
-  fun ref expect(qty: USize): ExpectResult =>
+  fun ref expect(qty: (Expect | None)): ExpectResult =>
     """
     Set the number of bytes to read before delivering data via
-    `_on_received`. When `qty` is 0, all available data is delivered.
+    `_on_received`. When `qty` is `None`, all available data is delivered.
 
     Returns `ExpectAboveBufferMinimum` if `qty` exceeds the current read
     buffer minimum. Raise the buffer minimum first, then set expect.
     """
-    if qty > _read_buffer_min then
-      return ExpectAboveBufferMinimum
+    match qty
+    | let e: Expect =>
+      if e() > _read_buffer_min then
+        return ExpectAboveBufferMinimum
+      end
     end
 
     match \exhaustive\ _lifecycle_event_receiver
@@ -358,10 +370,10 @@ class TCPConnection
       match \exhaustive\ _ssl
       | let _: SSL ref =>
         // Store the application's expect value for SSL read chunking.
-        // Tell the TCP read layer to read all available (0) since SSL
+        // Tell the TCP read layer to read all available (None) since SSL
         // record framing doesn't align with application framing.
         _ssl_expect = qty
-        _expect = 0
+        _expect = None
       | None =>
         _expect = qty
       end
@@ -591,7 +603,7 @@ class TCPConnection
     end
 
     _ssl_expect = _expect
-    _expect = 0
+    _expect = None
     _tls_upgrade = true
     _ssl = consume ssl
     _ssl_ready = false
@@ -945,12 +957,9 @@ class TCPConnection
 
             // Handle any data already in the read buffer
             while not _muted and _there_is_buffered_read_data() do
-              let bytes_to_consume = if _expect == 0 then
-                // if we aren't getting in `_expect` chunks,
-                // we should grab all the bytes that are currently available
-                _bytes_in_read_buffer
-              else
-                _expect
+              let bytes_to_consume = match \exhaustive\ _expect
+              | let e: Expect => e()
+              | None => _bytes_in_read_buffer
               end
 
               let x = _read_buffer = recover Array[U8] end
@@ -1045,10 +1054,9 @@ class TCPConnection
         while not _muted and _there_is_buffered_read_data()
         do
           // get data to be distributed and update `_bytes_in_read_buffer`
-          let chop_at = if _expect == 0 then
-            _bytes_in_read_buffer
-          else
-            _expect
+          let chop_at = match \exhaustive\ _expect
+          | let e: Expect => e()
+          | None => _bytes_in_read_buffer
           end
           (let data, _read_buffer) = (consume _read_buffer).chop(chop_at)
           _bytes_in_read_buffer = _bytes_in_read_buffer - chop_at
@@ -1100,10 +1108,9 @@ class TCPConnection
       match \exhaustive\ _lifecycle_event_receiver
       | let s: EitherLifecycleEventReceiver ref =>
         while not _muted and _there_is_buffered_read_data() do
-          let chop_at = if _expect == 0 then
-            _bytes_in_read_buffer
-          else
-            _expect
+          let chop_at = match \exhaustive\ _expect
+          | let e: Expect => e()
+          | None => _bytes_in_read_buffer
           end
           (let data, _read_buffer) = (consume _read_buffer).chop(chop_at)
           _bytes_in_read_buffer = _bytes_in_read_buffer - chop_at
@@ -1135,14 +1142,21 @@ class TCPConnection
     end
 
   fun _there_is_buffered_read_data(): Bool =>
-    (_bytes_in_read_buffer >= _expect) and (_bytes_in_read_buffer > 0)
+    match \exhaustive\ _expect
+    | let e: Expect => _bytes_in_read_buffer >= e()
+    | None => _bytes_in_read_buffer > 0
+    end
 
   fun ref _resize_read_buffer_if_needed() =>
     """
     Resize the read buffer if it's smaller than expected data size, or shrink
     it back to the minimum when empty and oversized.
     """
-    if _read_buffer.size() <= _expect then
+    let needs_grow = match \exhaustive\ _expect
+    | let e: Expect => _read_buffer.size() <= e()
+    | None => _read_buffer.size() == 0
+    end
+    if needs_grow then
       _read_buffer.undefined(_read_buffer_size)
     elseif (_bytes_in_read_buffer == 0)
       and (_read_buffer_size > _read_buffer_min)
@@ -1330,8 +1344,12 @@ class TCPConnection
       end
 
       // Read all available decrypted data
+      let ssl_read_expect: USize = match \exhaustive\ _ssl_expect
+      | let e: Expect => e()
+      | None => 0
+      end
       while true do
-        match \exhaustive\ ssl.read(_ssl_expect)
+        match \exhaustive\ ssl.read(ssl_read_expect)
         | let d: Array[U8] iso => s._on_received(consume d)
         | None => break
         end


### PR DESCRIPTION
Replace the magic `USize` parameter (where 0 means "deliver all") with an `Expect` constrained type and `None`. The public API becomes `expect(qty: (Expect | None))` where `None` means "no framing — deliver all available data."

This follows the established pattern used by `IdleTimeout`, `ReadBufferSize`, and `MaxSpawn`. The internal fields `_expect` and `_ssl_expect` also change from `USize` to `(Expect | None)`, eliminating the magic number throughout.

Closes #213