### PR TITLE
Add TCP_NODELAY and socket buffer size methods

### DIFF
--- a/.release-notes/add-socket-options.md
+++ b/.release-notes/add-socket-options.md
@@ -1,0 +1,18 @@
+## Add TCP_NODELAY and socket buffer size methods
+
+TCPConnection now exposes five methods for commonly-tuned socket options on connected sockets:
+
+- `set_nodelay(state)` — enable/disable Nagle's algorithm (TCP_NODELAY)
+- `set_so_rcvbuf(bufsize)` / `get_so_rcvbuf()` — set/get the OS receive buffer size
+- `set_so_sndbuf(bufsize)` / `get_so_sndbuf()` — set/get the OS send buffer size
+
+All setters return 0 on success or a non-zero errno on failure. Getters return `(errno, value)`. All methods require a connected socket — they return a non-zero error indicator when the connection is not open.
+
+```pony
+fun ref _on_started() =>
+  _tcp_connection.set_nodelay(true)
+  _tcp_connection.set_so_rcvbuf(65536)
+  _tcp_connection.set_so_sndbuf(65536)
+
+  (let errno: U32, let rcvbuf: U32) = _tcp_connection.get_so_rcvbuf()
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,7 @@ examples/
   infinite-ping-pong/       -- Ping-pong client+server
   ip-version/               -- IPv4-only echo server
   read-buffer-size/         -- Configurable read buffer sizing
+  socket-options/           -- TCP_NODELAY and OS buffer size tuning
   net-ssl-echo-server/      -- SSL echo server
   net-ssl-infinite-ping-pong/ -- SSL ping-pong
   starttls-ping-pong/       -- STARTTLS upgrade from plaintext to TLS
@@ -253,6 +254,18 @@ The yield check is placed immediately after `_deliver_received()` in three locat
 - **Windows `_windows_resume_read()`**: Mirrors the `_read_completed()` dispatch loop. Needed because on Windows, yielding with unprocessed buffered data and just calling `_queue_read()` (which submits an IOCP read) would leave the buffered data unprocessed until new data arrives from the peer. `_windows_resume_read()` processes buffered data first, then submits the IOCP read. Guards with `not _connected` (not `_closed`) — after a graceful `close()`, `_closed` is true but the connection still needs an IOCP read submitted to detect the peer's FIN. Using `_closed` would skip `_queue_read()`, leaving the connection half-closed permanently. `_connected` is only false after `hard_close()` (full teardown), which is the actual case to guard against.
 
 **SSL granularity**: `yield_read()` operates at TCP-read granularity. All SSL-decrypted messages from a single `ssl.receive()` call are delivered inside `_ssl_poll()` before the yield check fires. Per-SSL-message yielding would require changes to `_ssl_poll()` and handling partially-consumed SSL buffers on resume.
+
+### Socket options
+
+`TCPConnection` exposes commonly-tuned socket options as public methods, grouped with `keepalive()`:
+
+- `set_nodelay(state: Bool): U32` — enable/disable TCP_NODELAY (Nagle's algorithm). Uses `OSSockOpt.ipproto_tcp()` as the socket level.
+- `set_so_rcvbuf(bufsize: U32): U32` / `get_so_rcvbuf(): (U32, U32)` — OS receive buffer size.
+- `set_so_sndbuf(bufsize: U32): U32` / `get_so_sndbuf(): (U32, U32)` — OS send buffer size.
+
+All methods guard with `is_open()`. Setters return 0 on success or errno on failure. Getters return `(errno, value)`. When the connection is not open, setters return 1 and getters return `(1, 0)`. These delegate to `_OSSocket` methods in `ossocket.pony`.
+
+Note: `keepalive()` predates these methods and uses `if _connected` rather than `is_open()` — a minor inconsistency.
 
 ### Platform differences
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,6 +32,10 @@ Handling `send()` errors and throttle/unthrottle callbacks. A flood client sends
 
 Cooperative scheduler fairness with `yield_read()`. A flood client sends 100 four-byte messages and the server yields the read loop every 10 messages, letting other actors run before reading resumes automatically. Shows how to prevent a single connection from monopolizing the scheduler without the persistent pause of `mute()`/`unmute()`.
 
+## [socket-options](socket-options/)
+
+Socket option tuning with `set_nodelay()`, `set_so_rcvbuf()`, `get_so_rcvbuf()`, `set_so_sndbuf()`, and `get_so_sndbuf()`. A server disables Nagle's algorithm and sets OS buffer sizes on each accepted connection, then reads back the actual values (the OS may round up). Shows how to configure commonly-tuned TCP socket options on a live connection.
+
 ## [read-buffer-size](read-buffer-size/)
 
 Configurable read buffer sizing with two phases. A server starts with a small 128-byte buffer for a control phase, then switches to an 8192-byte buffer for bulk transfer after receiving a command. Demonstrates `set_read_buffer_minimum()` and `resize_read_buffer()` for tuning buffer allocation at runtime, and the `read_buffer_size` constructor parameter for setting the initial size.

--- a/examples/socket-options/socket-options.pony
+++ b/examples/socket-options/socket-options.pony
@@ -1,0 +1,109 @@
+"""
+Socket option tuning on a connected TCP connection.
+
+A self-contained echo server that configures TCP_NODELAY and OS buffer sizes on
+each accepted connection. The client connects, sends "Hello", receives the echo,
+and prints the configured socket option values before closing. Demonstrates
+`set_nodelay()`, `set_so_rcvbuf()`, `get_so_rcvbuf()`, `set_so_sndbuf()`, and
+`get_so_sndbuf()` on a live connection.
+"""
+use "../../lori"
+
+actor Main
+  new create(env: Env) =>
+    let listen_auth = TCPListenAuth(env.root)
+    let connect_auth = TCPConnectAuth(env.root)
+    SocketOptionsListener(listen_auth, connect_auth, "127.0.0.1", "7676",
+      env.out)
+
+actor SocketOptionsListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _out: OutStream
+  let _connect_auth: TCPConnectAuth
+  let _server_auth: TCPServerAuth
+
+  new create(listen_auth: TCPListenAuth, connect_auth: TCPConnectAuth,
+    host: String, port: String, out: OutStream)
+  =>
+    _out = out
+    _connect_auth = connect_auth
+    _server_auth = TCPServerAuth(listen_auth)
+    _tcp_listener = TCPListener(listen_auth, host, port, this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): SocketOptionsServer =>
+    SocketOptionsServer(_server_auth, fd, _out)
+
+  fun ref _on_listening() =>
+    _out.print("Listener started on 127.0.0.1:7676")
+    SocketOptionsClient(_connect_auth, "127.0.0.1", "7676", _out)
+
+  fun ref _on_listen_failure() =>
+    _out.print("Couldn't start listener.")
+
+  fun ref _on_closed() =>
+    _out.print("Listener closed.")
+
+actor SocketOptionsServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _out: OutStream
+
+  new create(auth: TCPServerAuth, fd: U32, out: OutStream) =>
+    _out = out
+    _tcp_connection = TCPConnection.server(auth, fd, this, this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    // Disable Nagle for low-latency responses
+    _tcp_connection.set_nodelay(true)
+
+    // Set OS buffer sizes
+    _tcp_connection.set_so_rcvbuf(32768)
+    _tcp_connection.set_so_sndbuf(32768)
+
+    // Read back the actual values (OS may round up)
+    (let rcv_errno: U32, let rcv_size: U32) =
+      _tcp_connection.get_so_rcvbuf()
+    (let snd_errno: U32, let snd_size: U32) =
+      _tcp_connection.get_so_sndbuf()
+
+    if (rcv_errno == 0) and (snd_errno == 0) then
+      _out.print("Server: rcvbuf=" + rcv_size.string()
+        + " sndbuf=" + snd_size.string())
+    else
+      _out.print("Server: failed to read buffer sizes")
+    end
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    _tcp_connection.send(consume data)
+
+  fun ref _on_closed() =>
+    _out.print("Server: connection closed")
+
+actor SocketOptionsClient is
+  (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _out: OutStream
+
+  new create(auth: TCPConnectAuth, host: String, port: String,
+    out: OutStream)
+  =>
+    _out = out
+    _tcp_connection = TCPConnection.client(auth, host, port, "", this, this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _tcp_connection.send("Hello")
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    _out.print("Client: received echo: " + String.from_array(consume data))
+    _tcp_connection.close()
+
+  fun ref _on_closed() =>
+    _out.print("Client: closed")

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -50,6 +50,8 @@ actor \nodoc\ Main is TestList
     test(_TestResizeReadBufferBelowMinLowersMin)
     test(_TestExpectAboveBufferMinimum)
     test(_TestExpectAtBufferMinimum)
+    test(_TestSocketOptionsConnected)
+    test(_TestSocketOptionsNotConnected)
 
 class \nodoc\ iso _TestOutgoingFails is UnitTest
   """
@@ -3353,3 +3355,102 @@ actor \nodoc\ _TestReadBufferTriggerClient is
 
   fun ref _on_connected() =>
     _tcp_connection.close()
+
+class \nodoc\ iso _TestSocketOptionsConnected is UnitTest
+  """
+  Test that set_nodelay, set_so_rcvbuf, get_so_rcvbuf, set_so_sndbuf, and
+  get_so_sndbuf succeed on a connected socket.
+  """
+  fun name(): String => "SocketOptionsConnected"
+
+  fun apply(h: TestHelper) =>
+    let listener = _TestSocketOptionsListener(h)
+    h.dispose_when_done(listener)
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestSocketOptionsListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(h.env.root), "127.0.0.1", "7708", this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestSocketOptionsServer =>
+    _TestSocketOptionsServer(fd, _h)
+
+  fun ref _on_listening() =>
+    _TestReadBufferTriggerClient(TCPConnectAuth(_h.env.root),
+      "127.0.0.1", "7708")
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open listener")
+
+actor \nodoc\ _TestSocketOptionsServer is
+  (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(fd: U32, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.server(
+      TCPServerAuth(h.env.root), fd, this, this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    // set_nodelay: enable and disable should both succeed
+    _h.assert_eq[U32](0, _tcp_connection.set_nodelay(true),
+      "set_nodelay(true) should succeed")
+    _h.assert_eq[U32](0, _tcp_connection.set_nodelay(false),
+      "set_nodelay(false) should succeed")
+
+    // set_so_rcvbuf: set then get. OS may round up, so check >= requested.
+    let rcvbuf_result = _tcp_connection.set_so_rcvbuf(8192)
+    _h.assert_eq[U32](0, rcvbuf_result, "set_so_rcvbuf should succeed")
+    (let rcv_errno: U32, let rcv_size: U32) =
+      _tcp_connection.get_so_rcvbuf()
+    _h.assert_eq[U32](0, rcv_errno, "get_so_rcvbuf errno should be 0")
+    _h.assert_true(rcv_size >= 8192,
+      "get_so_rcvbuf should return >= 8192, got " + rcv_size.string())
+
+    // set_so_sndbuf: set then get. OS may round up, so check >= requested.
+    let sndbuf_result = _tcp_connection.set_so_sndbuf(8192)
+    _h.assert_eq[U32](0, sndbuf_result, "set_so_sndbuf should succeed")
+    (let snd_errno: U32, let snd_size: U32) =
+      _tcp_connection.get_so_sndbuf()
+    _h.assert_eq[U32](0, snd_errno, "get_so_sndbuf errno should be 0")
+    _h.assert_true(snd_size >= 8192,
+      "get_so_sndbuf should return >= 8192, got " + snd_size.string())
+
+    _h.complete(true)
+    _tcp_connection.close()
+
+class \nodoc\ iso _TestSocketOptionsNotConnected is UnitTest
+  """
+  Test that socket option methods return non-zero errno on a connection
+  that is not open.
+  """
+  fun name(): String => "SocketOptionsNotConnected"
+
+  fun apply(h: TestHelper) =>
+    let conn = TCPConnection.none()
+
+    h.assert_true(conn.set_nodelay(true) != 0,
+      "set_nodelay on none should return non-zero")
+    h.assert_true(conn.set_so_rcvbuf(8192) != 0,
+      "set_so_rcvbuf on none should return non-zero")
+    h.assert_true(conn.set_so_sndbuf(8192) != 0,
+      "set_so_sndbuf on none should return non-zero")
+
+    (let rcv_errno: U32, _) = conn.get_so_rcvbuf()
+    h.assert_true(rcv_errno != 0,
+      "get_so_rcvbuf on none should return non-zero errno")
+    (let snd_errno: U32, _) = conn.get_so_sndbuf()
+    h.assert_true(snd_errno != 0,
+      "get_so_sndbuf on none should return non-zero errno")

--- a/lori/lori.pony
+++ b/lori/lori.pony
@@ -354,6 +354,38 @@ Resizing below the amount of unprocessed data in the buffer returns
 When the buffer is empty and larger than the minimum, it automatically shrinks
 back to the minimum size.
 
+## Socket Options
+
+`TCPConnection` exposes commonly-tuned socket options for connected sockets.
+All methods guard with `is_open()` and return an error indicator when the
+connection is not open.
+
+**TCP_NODELAY** disables Nagle's algorithm so small writes are sent immediately:
+
+```pony
+fun ref _on_started() =>
+  // Disable Nagle for low-latency responses
+  _tcp_connection.set_nodelay(true)
+```
+
+**OS buffer sizes** control the kernel's receive and send buffers. The OS may
+round the requested size up to a platform-specific minimum:
+
+```pony
+fun ref _on_started() =>
+  _tcp_connection.set_so_rcvbuf(65536)
+  _tcp_connection.set_so_sndbuf(65536)
+
+  // Read back the actual values
+  (let errno: U32, let actual: U32) = _tcp_connection.get_so_rcvbuf()
+  if errno == 0 then
+    // actual may be >= 65536 due to OS rounding
+  end
+```
+
+All setters return `U32` — 0 on success, or a non-zero errno on failure.
+Getters return `(U32, U32)` — (errno, value).
+
 ## Connection Limits
 
 `TCPListener` accepts an optional `limit` parameter to cap the number of

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -180,6 +180,66 @@ class TCPConnection
       PonyTCP.keepalive(_fd, secs)
     end
 
+  fun set_nodelay(state: Bool): U32 =>
+    """
+    Turn Nagle on/off. Defaults to on (Nagle enabled, nodelay off). When
+    enabled (`state = true`), small writes are sent immediately without
+    waiting to coalesce — useful for latency-sensitive protocols. When
+    disabled (`state = false`), the OS may buffer small writes.
+
+    Returns 0 on success, or a non-zero errno on failure. Only meaningful
+    on a connected socket — returns non-zero if the connection is not open.
+    """
+    if not is_open() then return 1 end
+    _OSSocket.setsockopt_u32(_fd, OSSockOpt.ipproto_tcp(),
+      OSSockOpt.tcp_nodelay(), if state then 1 else 0 end)
+
+  fun get_so_rcvbuf(): (U32, U32) =>
+    """
+    Get the OS receive buffer size for this socket.
+
+    Returns a 2-tuple: (errno, value). On success, errno is 0 and value is
+    the buffer size in bytes. On failure, errno is non-zero and value should
+    be ignored. Only meaningful on a connected socket — returns (1, 0) if
+    the connection is not open.
+    """
+    if not is_open() then return (1, 0) end
+    _OSSocket.get_so_rcvbuf(_fd)
+
+  fun set_so_rcvbuf(bufsize: U32): U32 =>
+    """
+    Set the OS receive buffer size for this socket. The OS may round the
+    requested size up to a minimum or clamp it to a maximum.
+
+    Returns 0 on success, or a non-zero errno on failure. Only meaningful
+    on a connected socket — returns non-zero if the connection is not open.
+    """
+    if not is_open() then return 1 end
+    _OSSocket.set_so_rcvbuf(_fd, bufsize)
+
+  fun get_so_sndbuf(): (U32, U32) =>
+    """
+    Get the OS send buffer size for this socket.
+
+    Returns a 2-tuple: (errno, value). On success, errno is 0 and value is
+    the buffer size in bytes. On failure, errno is non-zero and value should
+    be ignored. Only meaningful on a connected socket — returns (1, 0) if
+    the connection is not open.
+    """
+    if not is_open() then return (1, 0) end
+    _OSSocket.get_so_sndbuf(_fd)
+
+  fun set_so_sndbuf(bufsize: U32): U32 =>
+    """
+    Set the OS send buffer size for this socket. The OS may round the
+    requested size up to a minimum or clamp it to a maximum.
+
+    Returns 0 on success, or a non-zero errno on failure. Only meaningful
+    on a connected socket — returns non-zero if the connection is not open.
+    """
+    if not is_open() then return 1 end
+    _OSSocket.set_so_sndbuf(_fd, bufsize)
+
   fun ref idle_timeout(duration: (IdleTimeout | None)) =>
     """
     Set or disable the idle timeout. Idle timeout is disabled by default.


### PR DESCRIPTION
Expose commonly-tuned socket options as public methods on TCPConnection: `set_nodelay`, `set_so_rcvbuf`/`get_so_rcvbuf`, and `set_so_sndbuf`/`get_so_sndbuf`. These delegate to the existing `_OSSocket` infrastructure.

All methods guard with `is_open()` rather than bare `_connected` (which `keepalive` uses), so they correctly reject calls after `close()`. Setters return `U32` errno; getters return `(errno, value)`.

`set_nodelay` uses `OSSockOpt.ipproto_tcp()` as the socket level, which is the correct level for TCP_NODELAY (the stdlib uses `sol_socket`, which is technically wrong).

Addresses section 13 of Discussion #199.