### PR TITLE
Add general socket option access

### DIFF
--- a/.release-notes/add-general-socket-option-access.md
+++ b/.release-notes/add-general-socket-option-access.md
@@ -1,0 +1,23 @@
+## Add general socket option access
+
+TCPConnection now exposes general-purpose `getsockopt`/`setsockopt` methods for accessing any socket option, not just the ones with dedicated convenience methods:
+
+- `getsockopt(level, option_name, option_max_size)` — raw bytes interface to `getsockopt(2)`
+- `getsockopt_u32(level, option_name)` — convenience wrapper when the option value is a `U32`
+- `setsockopt(level, option_name, option)` — raw bytes interface to `setsockopt(2)`
+- `setsockopt_u32(level, option_name, option)` — convenience wrapper when the option value is a `U32`
+
+All methods require a connected socket and return errno-based results matching the existing convenience methods. Use `OSSockOpt` constants for the `level` and `option_name` parameters.
+
+```pony
+// Set TCP_KEEPIDLE via the general-purpose interface
+_tcp_connection.setsockopt_u32(
+  OSSockOpt.ipproto_tcp(), OSSockOpt.tcp_keepidle(), 60)
+
+// Read back a socket option as raw bytes
+(let errno: U32, let data: Array[U8] iso) =
+  _tcp_connection.getsockopt(
+    OSSockOpt.sol_socket(), OSSockOpt.so_rcvbuf())
+```
+
+For commonly-tuned options (TCP_NODELAY, SO_RCVBUF, SO_SNDBUF), the dedicated convenience methods remain the preferred interface.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -286,13 +286,20 @@ The yield check is placed immediately after `_deliver_received()` in three locat
 
 ### Socket options
 
-`TCPConnection` exposes commonly-tuned socket options as public methods, grouped with `keepalive()`:
+`TCPConnection` exposes commonly-tuned socket options as dedicated convenience methods, grouped with `keepalive()`:
 
 - `set_nodelay(state: Bool): U32` — enable/disable TCP_NODELAY (Nagle's algorithm). Uses `OSSockOpt.ipproto_tcp()` as the socket level.
 - `set_so_rcvbuf(bufsize: U32): U32` / `get_so_rcvbuf(): (U32, U32)` — OS receive buffer size.
 - `set_so_sndbuf(bufsize: U32): U32` / `get_so_sndbuf(): (U32, U32)` — OS send buffer size.
 
-All methods guard with `is_open()`. Setters return 0 on success or errno on failure. Getters return `(errno, value)`. When the connection is not open, setters return 1 and getters return `(1, 0)`. These delegate to `_OSSocket` methods in `ossocket.pony`.
+For options without dedicated methods, four general-purpose methods expose the full `getsockopt(2)`/`setsockopt(2)` interface:
+
+- `getsockopt(level, option_name, option_max_size): (U32, Array[U8] iso^)` — raw bytes get.
+- `getsockopt_u32(level, option_name): (U32, U32)` — U32 convenience get.
+- `setsockopt(level, option_name, option): U32` — raw bytes set.
+- `setsockopt_u32(level, option_name, option): U32` — U32 convenience set.
+
+All methods guard with `is_open()`. Setters return 0 on success or errno on failure. Getters return `(errno, value)`. When the connection is not open, setters return 1 and getters return `(1, 0)`. All delegate to `_OSSocket` methods in `ossocket.pony`. Use `OSSockOpt` constants for level and option name parameters.
 
 Note: `keepalive()` predates these methods and uses `_state.is_open()` (updated from the original `_connected` check when the lifecycle state machine was introduced).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,7 +34,7 @@ Cooperative scheduler fairness with `yield_read()`. A flood client sends 100 fou
 
 ## [socket-options](socket-options/)
 
-Socket option tuning with `set_nodelay()`, `set_so_rcvbuf()`, `get_so_rcvbuf()`, `set_so_sndbuf()`, and `get_so_sndbuf()`. A server disables Nagle's algorithm and sets OS buffer sizes on each accepted connection, then reads back the actual values (the OS may round up). Shows how to configure commonly-tuned TCP socket options on a live connection.
+Socket option tuning with dedicated convenience methods (`set_nodelay()`, `set_so_rcvbuf()`, `get_so_rcvbuf()`) and the general-purpose `setsockopt_u32()`/`getsockopt_u32()` interface. A server disables Nagle's algorithm and sets OS buffer sizes on each accepted connection, then reads back the actual values (the OS may round up). Shows both approaches to configuring TCP socket options on a live connection.
 
 ## [read-buffer-size](read-buffer-size/)
 

--- a/examples/socket-options/socket-options.pony
+++ b/examples/socket-options/socket-options.pony
@@ -2,10 +2,12 @@
 Socket option tuning on a connected TCP connection.
 
 A self-contained echo server that configures TCP_NODELAY and OS buffer sizes on
-each accepted connection. The client connects, sends "Hello", receives the echo,
-and prints the configured socket option values before closing. Demonstrates
-`set_nodelay()`, `set_so_rcvbuf()`, `get_so_rcvbuf()`, `set_so_sndbuf()`, and
-`get_so_sndbuf()` on a live connection.
+each accepted connection using both dedicated convenience methods and the
+general-purpose `getsockopt`/`setsockopt` interface. The client connects, sends
+"Hello", receives the echo, and prints the configured socket option values
+before closing. Demonstrates `set_nodelay()`, `set_so_rcvbuf()`,
+`get_so_rcvbuf()`, `setsockopt_u32()`, and `getsockopt_u32()` on a live
+connection.
 """
 use "../../lori"
 
@@ -61,15 +63,22 @@ actor SocketOptionsServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
     // Disable Nagle for low-latency responses
     _tcp_connection.set_nodelay(true)
 
-    // Set OS buffer sizes
+    // Set OS buffer sizes using convenience methods
     _tcp_connection.set_so_rcvbuf(32768)
-    _tcp_connection.set_so_sndbuf(32768)
 
-    // Read back the actual values (OS may round up)
+    // Set send buffer using the general-purpose setsockopt_u32 interface.
+    // Any option from OSSockOpt can be set this way.
+    _tcp_connection.setsockopt_u32(
+      OSSockOpt.sol_socket(), OSSockOpt.so_sndbuf(), 32768)
+
+    // Read back the actual values (OS may round up).
+    // Convenience method for receive buffer:
     (let rcv_errno: U32, let rcv_size: U32) =
       _tcp_connection.get_so_rcvbuf()
+    // General-purpose method for send buffer:
     (let snd_errno: U32, let snd_size: U32) =
-      _tcp_connection.get_so_sndbuf()
+      _tcp_connection.getsockopt_u32(
+        OSSockOpt.sol_socket(), OSSockOpt.so_sndbuf())
 
     if (rcv_errno == 0) and (snd_errno == 0) then
       _out.print("Server: rcvbuf=" + rcv_size.string()

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -3358,8 +3358,9 @@ actor \nodoc\ _TestReadBufferTriggerClient is
 
 class \nodoc\ iso _TestSocketOptionsConnected is UnitTest
   """
-  Test that set_nodelay, set_so_rcvbuf, get_so_rcvbuf, set_so_sndbuf, and
-  get_so_sndbuf succeed on a connected socket.
+  Test that socket option methods succeed on a connected socket, including
+  convenience methods (set_nodelay, set_so_rcvbuf, etc.) and general-purpose
+  getsockopt/setsockopt/getsockopt_u32/setsockopt_u32.
   """
   fun name(): String => "SocketOptionsConnected"
 
@@ -3428,13 +3429,50 @@ actor \nodoc\ _TestSocketOptionsServer is
     _h.assert_true(snd_size >= 8192,
       "get_so_sndbuf should return >= 8192, got " + snd_size.string())
 
+    // setsockopt_u32/getsockopt_u32: set SO_RCVBUF via general method,
+    // read back via general method.
+    let gen_set_result = _tcp_connection.setsockopt_u32(
+      OSSockOpt.sol_socket(), OSSockOpt.so_rcvbuf(), 16384)
+    _h.assert_eq[U32](0, gen_set_result,
+      "setsockopt_u32 SO_RCVBUF should succeed")
+    (let gen_get_errno: U32, let gen_get_size: U32) =
+      _tcp_connection.getsockopt_u32(
+        OSSockOpt.sol_socket(), OSSockOpt.so_rcvbuf())
+    _h.assert_eq[U32](0, gen_get_errno,
+      "getsockopt_u32 SO_RCVBUF errno should be 0")
+    _h.assert_true(gen_get_size >= 16384,
+      "getsockopt_u32 SO_RCVBUF should return >= 16384, got "
+        + gen_get_size.string())
+
+    // setsockopt/getsockopt: set SO_SNDBUF via raw bytes, read back via
+    // raw bytes.
+    let raw_set_result = _tcp_connection.setsockopt(
+      OSSockOpt.sol_socket(), OSSockOpt.so_sndbuf(),
+      Array[U8](4).>push_u32(16384))
+    _h.assert_eq[U32](0, raw_set_result,
+      "setsockopt SO_SNDBUF should succeed")
+    (let raw_get_errno: U32, let raw_get_bytes: Array[U8] iso) =
+      _tcp_connection.getsockopt(
+        OSSockOpt.sol_socket(), OSSockOpt.so_sndbuf())
+    _h.assert_eq[U32](0, raw_get_errno,
+      "getsockopt SO_SNDBUF errno should be 0")
+    try
+      let raw_get_size = (consume raw_get_bytes).read_u32(0)?
+      _h.assert_true(raw_get_size >= 16384,
+        "getsockopt SO_SNDBUF should return >= 16384, got "
+          + raw_get_size.string())
+    else
+      _h.fail("getsockopt SO_SNDBUF returned too few bytes")
+    end
+
     _h.complete(true)
     _tcp_connection.close()
 
 class \nodoc\ iso _TestSocketOptionsNotConnected is UnitTest
   """
   Test that socket option methods return non-zero errno on a connection
-  that is not open.
+  that is not open, including both convenience methods and general-purpose
+  getsockopt/setsockopt.
   """
   fun name(): String => "SocketOptionsNotConnected"
 
@@ -3454,3 +3492,23 @@ class \nodoc\ iso _TestSocketOptionsNotConnected is UnitTest
     (let snd_errno: U32, _) = conn.get_so_sndbuf()
     h.assert_true(snd_errno != 0,
       "get_so_sndbuf on none should return non-zero errno")
+
+    // General-purpose methods
+    h.assert_true(
+      conn.setsockopt_u32(
+        OSSockOpt.sol_socket(), OSSockOpt.so_rcvbuf(), 8192) != 0,
+      "setsockopt_u32 on none should return non-zero")
+    h.assert_true(
+      conn.setsockopt(
+        OSSockOpt.sol_socket(), OSSockOpt.so_rcvbuf(),
+        Array[U8](4).>push_u32(8192)) != 0,
+      "setsockopt on none should return non-zero")
+
+    (let gen_u32_errno: U32, _) =
+      conn.getsockopt_u32(OSSockOpt.sol_socket(), OSSockOpt.so_rcvbuf())
+    h.assert_true(gen_u32_errno != 0,
+      "getsockopt_u32 on none should return non-zero errno")
+    (let gen_errno: U32, _) =
+      conn.getsockopt(OSSockOpt.sol_socket(), OSSockOpt.so_rcvbuf())
+    h.assert_true(gen_errno != 0,
+      "getsockopt on none should return non-zero errno")

--- a/lori/lori.pony
+++ b/lori/lori.pony
@@ -386,6 +386,15 @@ fun ref _on_started() =>
 All setters return `U32` — 0 on success, or a non-zero errno on failure.
 Getters return `(U32, U32)` — (errno, value).
 
+**General-purpose access** is available via `getsockopt`/`setsockopt` and their `_u32` variants for any option in [`OSSockOpt`](/lori/lori-OSSockOpt/). For commonly-tuned options, prefer the dedicated methods above.
+
+```pony
+fun ref _on_started() =>
+  // Set TCP_KEEPIDLE via the general-purpose interface
+  _tcp_connection.setsockopt_u32(
+    OSSockOpt.ipproto_tcp(), OSSockOpt.tcp_keepidle(), 60)
+```
+
 ## Connection Limits
 
 `TCPListener` accepts an optional `limit` parameter to cap the number of

--- a/lori/ossocket.pony
+++ b/lori/ossocket.pony
@@ -7,7 +7,7 @@ use @setsockopt[I32](fd: U32, level: I32, option_name: I32,
 primitive _OSSocket
   """
   Socket type-independent wrapper functions for `getsockopt(2)` and
-  `setsockopt(2)` system calls for internal `net` package use.
+  `setsockopt(2)` system calls.
   """
 
   fun get_so_error(fd: U32): (U32, U32) =>

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -239,6 +239,83 @@ class TCPConnection
     if not is_open() then return 1 end
     _OSSocket.set_so_sndbuf(_fd, bufsize)
 
+  fun getsockopt(level: I32, option_name: I32,
+    option_max_size: USize = 4): (U32, Array[U8] iso^)
+  =>
+    """
+    General interface to `getsockopt(2)` for accessing any socket option.
+
+    The `option_max_size` argument is the maximum number of bytes the caller
+    expects the kernel to return. This method allocates a buffer of that size
+    before calling `getsockopt(2)`.
+
+    Returns a 2-tuple: on success, `(0, data)` where `data` is the bytes
+    returned by the kernel, sized to the actual length the kernel wrote. On
+    failure, `(errno, undefined)` — the second element must be ignored. Only
+    meaningful on a connected socket — returns `(1, empty)` if the connection
+    is not open.
+
+    For commonly-tuned options, prefer the dedicated convenience methods
+    (`set_nodelay`, `get_so_rcvbuf`, etc.). Do not change the socket's
+    non-blocking mode — lori's event-driven I/O requires non-blocking
+    sockets.
+    """
+    if not is_open() then return (1, recover Array[U8] end) end
+    _OSSocket.getsockopt(_fd, level, option_name, option_max_size)
+
+  fun getsockopt_u32(level: I32, option_name: I32): (U32, U32) =>
+    """
+    Wrapper for `getsockopt(2)` where the kernel returns a C `uint32_t`.
+
+    Returns a 2-tuple: on success, `(0, value)`. On failure,
+    `(errno, undefined)` — the second element must be ignored. Only
+    meaningful on a connected socket — returns `(1, 0)` if the connection
+    is not open.
+
+    For commonly-tuned options, prefer the dedicated convenience methods
+    (`get_so_rcvbuf`, `get_so_sndbuf`, etc.). Do not change the socket's
+    non-blocking mode — lori's event-driven I/O requires non-blocking
+    sockets.
+    """
+    if not is_open() then return (1, 0) end
+    _OSSocket.getsockopt_u32(_fd, level, option_name)
+
+  fun setsockopt(level: I32, option_name: I32, option: Array[U8]): U32 =>
+    """
+    General interface to `setsockopt(2)` for setting any socket option.
+
+    The caller is responsible for the correct size, byte contents, and
+    byte order of the `option` array for the requested `level` and
+    `option_name`.
+
+    Returns 0 on success, or the value of `errno` on failure. Only
+    meaningful on a connected socket — returns non-zero if the connection
+    is not open.
+
+    For commonly-tuned options, prefer the dedicated convenience methods
+    (`set_nodelay`, `set_so_rcvbuf`, etc.). Do not change the socket's
+    non-blocking mode — lori's event-driven I/O requires non-blocking
+    sockets.
+    """
+    if not is_open() then return 1 end
+    _OSSocket.setsockopt(_fd, level, option_name, option)
+
+  fun setsockopt_u32(level: I32, option_name: I32, option: U32): U32 =>
+    """
+    Wrapper for `setsockopt(2)` where the kernel expects a C `uint32_t`.
+
+    Returns 0 on success, or the value of `errno` on failure. Only
+    meaningful on a connected socket — returns non-zero if the connection
+    is not open.
+
+    For commonly-tuned options, prefer the dedicated convenience methods
+    (`set_nodelay`, `set_so_rcvbuf`, etc.). Do not change the socket's
+    non-blocking mode — lori's event-driven I/O requires non-blocking
+    sockets.
+    """
+    if not is_open() then return 1 end
+    _OSSocket.setsockopt_u32(_fd, level, option_name, option)
+
   fun ref idle_timeout(duration: (IdleTimeout | None)) =>
     """
     Set or disable the idle timeout. Idle timeout is disabled by default.


### PR DESCRIPTION
Expose `getsockopt`/`setsockopt` and their `_u32` variants as public methods on `TCPConnection`, delegating to the existing `_OSSocket` infrastructure. This gives applications access to any socket option via `OSSockOpt` constants, not just the ones with dedicated convenience methods (Discussion #199, section 14).

Each method guards with `is_open()` and follows the same return-value conventions as the existing convenience methods. Docstrings warn against changing the socket's non-blocking mode.

Also fixes a stale `_OSSocket` docstring that referenced "internal `net` package use" from when the code was copied from stdlib.