### PR TITLE
Fix NetAddress FFI declarations to use ref instead of tag

### DIFF
--- a/lori/pony_tcp.pony
+++ b/lori/pony_tcp.pony
@@ -24,7 +24,7 @@ use @pony_os_listen_tcp4[AsioEventID](the_actor: AsioEventNotify,
 use @pony_os_listen_tcp6[AsioEventID](the_actor: AsioEventNotify,
   host: Pointer[U8] tag,
   port: Pointer[U8] tag)
-use @pony_os_peername[Bool](fd: U32, ip: net.NetAddress tag)
+use @pony_os_peername[Bool](fd: U32, ip: net.NetAddress ref)
 use @pony_os_recv[USize](event: AsioEventID,
   buffer: Pointer[U8] tag,
   offset: USize) ?
@@ -33,7 +33,7 @@ use @pony_os_send[USize](event: AsioEventID,
   from_offset: USize) ?
 use @pony_os_socket_close[None](fd: U32)
 use @pony_os_socket_shutdown[None](fd: U32)
-use @pony_os_sockname[Bool](fd: U32, ip: net.NetAddress tag)
+use @pony_os_sockname[Bool](fd: U32, ip: net.NetAddress ref)
 use @pony_os_writev[USize](ev: AsioEventID,
   wsa: Pointer[(USize, Pointer[U8] tag)] tag,
   wsacnt: I32) ? if windows
@@ -98,7 +98,7 @@ primitive PonyTCP
   fun keepalive(fd: U32, secs: U32) =>
     @pony_os_keepalive(fd, secs)
 
-  fun peername(fd: U32, ip: net.NetAddress tag): Bool =>
+  fun peername(fd: U32, ip: net.NetAddress ref): Bool =>
     @pony_os_peername(fd, ip)
 
   fun receive(event: AsioEventID,
@@ -120,7 +120,7 @@ primitive PonyTCP
   fun shutdown(fd: U32) =>
     @pony_os_socket_shutdown(fd)
 
-  fun sockname(fd: U32, ip: net.NetAddress tag): Bool =>
+  fun sockname(fd: U32, ip: net.NetAddress ref): Bool =>
     @pony_os_sockname(fd, ip)
 
   fun writev(event: AsioEventID, data: Array[ByteSeq] box,

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -422,18 +422,22 @@ class TCPConnection
     Return the local IP address. If this TCPConnection is closed then the
     address returned is invalid.
     """
-    let ip = recover net.NetAddress end
-    PonyTCP.sockname(_fd, ip)
-    ip
+    recover
+      let ip: net.NetAddress ref = net.NetAddress
+      PonyTCP.sockname(_fd, ip)
+      ip
+    end
 
   fun remote_address(): net.NetAddress =>
     """
     Return the remote IP address. If this TCPConnection is closed then the
     address returned is invalid.
     """
-    let ip = recover net.NetAddress end
-    PonyTCP.peername(_fd, ip)
-    ip
+    recover
+      let ip: net.NetAddress ref = net.NetAddress
+      PonyTCP.peername(_fd, ip)
+      ip
+    end
 
   fun ref mute() =>
     """

--- a/lori/tcp_listener.pony
+++ b/lori/tcp_listener.pony
@@ -54,9 +54,11 @@ class TCPListener
     Return the local IP address. If this TCPListener is closed then the
     address returned is invalid.
     """
-    let ip = recover net.NetAddress end
-    PonyTCP.sockname(_fd, ip)
-    ip
+    recover
+      let ip: net.NetAddress ref = net.NetAddress
+      PonyTCP.sockname(_fd, ip)
+      ip
+    end
 
   fun ref _event_notify(event: AsioEventID, flags: U32, arg: U32) =>
     if event isnt _event then


### PR DESCRIPTION
The C functions `pony_os_sockname` and `pony_os_peername` mutate the `NetAddress` struct they receive, but the FFI declarations used `tag` which promises no mutation. This changes the declarations to `ref` and restructures the call sites so the `NetAddress` is `ref` inside a `recover` block where the FFI mutation happens, then lifted to `val` on exit.

Part of the FFI mutation audit: ponylang/ponyc#4925