### PR TITLE
Update macOS runner to macos-26

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -33,7 +33,7 @@ jobs:
 
   macos:
     name: MacOS
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v4.1.1
       - name: install pony tools

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -34,7 +34,7 @@ jobs:
           content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
 
   macos:
-    runs-on: macos-15
+    runs-on: macos-26
 
     name: MacOS
     steps:


### PR DESCRIPTION
macOS 26 runners are now generally available for GitHub Actions.

Update arm64 macOS runner from macos-15 to macos-26.