### PR TITLE
Upgrade actions/cache to v5.0.3

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,7 +63,7 @@ jobs:
         run: .ci-scripts\windows-install-pony-tools.ps1 nightlies
       - name: cache SSL libs
         id: restore-libs
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.3
         with:
           path: build/libs
           key: libs-windows-2025-${{ hashFiles('make.ps1') }}

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -75,7 +75,7 @@ jobs:
         run: .ci-scripts\windows-install-pony-tools.ps1 nightlies
       - name: Cache SSL libs
         id: restore-libs
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.3
         with:
           path: build/libs
           key: libs-windows-2025-${{ hashFiles('make.ps1') }}

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - name: cache SSL libs
         id: restore-libs
-        uses: actions/cache@v4
+        uses: actions/cache@v5.0.3
         with:
           path: build/libs
           key: libs-windows-2025-${{ hashFiles('make.ps1') }}


### PR DESCRIPTION
actions/cache v4 is deprecated. Upgrades all 3 workflow files to v5.0.3.

The only breaking change in v5 is the Node.js 24 upgrade, which requires
Actions Runner >= 2.327.1 — satisfied by all our GitHub-hosted runners.