### PR TITLE
Add optional connection timeout for client connections

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,38 @@
+## Add optional connection timeout for client connections
+
+Client connection attempts can now be bounded with a timeout that covers the TCP Happy Eyeballs phase and (for SSL connections) the TLS handshake. Pass a `ConnectionTimeout` to the `client` or `ssl_client` constructor:
+
+```pony
+match MakeConnectionTimeout(5_000)
+| let ct: ConnectionTimeout =>
+  _tcp_connection = TCPConnection.client(auth, host, port, "", this, this
+    where connection_timeout = ct)
+end
+```
+
+If the timeout fires before `_on_connected`, the connection fails with `ConnectionFailedTimeout` in `_on_connection_failure`. The timeout is disabled by default (`None`).
+
+## Expand ConnectionFailureReason with ConnectionFailedTimeout
+
+`ConnectionFailureReason` now includes `ConnectionFailedTimeout`. This is a breaking change — exhaustive matches on `ConnectionFailureReason` must add a branch for the new variant:
+
+Before:
+
+```pony
+match reason
+| ConnectionFailedDNS => // ...
+| ConnectionFailedTCP => // ...
+| ConnectionFailedSSL => // ...
+end
+```
+
+After:
+
+```pony
+match reason
+| ConnectionFailedDNS => // ...
+| ConnectionFailedTCP => // ...
+| ConnectionFailedSSL => // ...
+| ConnectionFailedTimeout => // ...
+end
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,11 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Added
 
+- Add optional connection timeout for client connections ([PR #236](https://github.com/ponylang/lori/pull/236))
 
 ### Changed
 
+- Expand ConnectionFailureReason with ConnectionFailedTimeout ([PR #236](https://github.com/ponylang/lori/pull/236))
 
 ## [0.11.0] - 2026-03-15
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ lori/
   start_failure_reason.pony -- StartFailureReason primitive and type alias
   tls_failure_reason.pony   -- TLSFailureReason primitives and type alias
   idle_timeout.pony         -- IdleTimeout constrained type and validator
+  connection_timeout.pony   -- ConnectionTimeout constrained type and validator
   ip_version.pony           -- IP4, IP6, DualStack primitives and IPVersion type alias
   max_spawn.pony            -- MaxSpawn constrained type, validator, and default
   auth.pony                 -- Auth primitives (NetAuth, TCPAuth, TCPListenAuth, etc.)
@@ -65,6 +66,7 @@ examples/
   net-ssl-echo-server/      -- SSL echo server
   net-ssl-infinite-ping-pong/ -- SSL ping-pong
   starttls-ping-pong/       -- STARTTLS upgrade from plaintext to TLS
+  connection-timeout/        -- Connection timeout with non-routable address
   yield-read/               -- Cooperative scheduler fairness with yield_read()
 stress-tests/
   open-close/               -- Connection open/close stress test
@@ -76,7 +78,7 @@ stress-tests/
 
 Lori separates connection logic (class) from actor scheduling (trait):
 
-1. **`TCPConnection`** (class) — All TCP state and I/O logic including SSL. Created with `TCPConnection.client(...)`, `TCPConnection.server(...)`, `TCPConnection.ssl_client(...)`, or `TCPConnection.ssl_server(...)`. All four real constructors accept an optional `read_buffer_size: ReadBufferSize = DefaultReadBufferSize()` parameter that sets both the initial buffer allocation and the shrink-back minimum. Client and SSL client constructors also accept an optional `ip_version: IPVersion = DualStack` parameter to restrict to IPv4 (`IP4`) or IPv6 (`IP6`). Existing plaintext connections can be upgraded to TLS via `start_tls()`. Not an actor itself.
+1. **`TCPConnection`** (class) — All TCP state and I/O logic including SSL. Created with `TCPConnection.client(...)`, `TCPConnection.server(...)`, `TCPConnection.ssl_client(...)`, or `TCPConnection.ssl_server(...)`. All four real constructors accept an optional `read_buffer_size: ReadBufferSize = DefaultReadBufferSize()` parameter that sets both the initial buffer allocation and the shrink-back minimum. Client and SSL client constructors also accept an optional `ip_version: IPVersion = DualStack` parameter to restrict to IPv4 (`IP4`) or IPv6 (`IP6`), and an optional `connection_timeout: (ConnectionTimeout | None) = None` parameter to bound the connect-to-ready phase. Existing plaintext connections can be upgraded to TLS via `start_tls()`. Not an actor itself.
 2. **`TCPConnectionActor`** (trait) — The actor trait users implement. Requires `fun ref _connection(): TCPConnection`. Provides behaviors that delegate to the TCPConnection: `_event_notify`, `_read_again`, `dispose`, etc.
 3. **Lifecycle event receivers** — `ClientLifecycleEventReceiver` (callbacks: `_on_connected`, `_on_connecting`, `_on_connection_failure(reason)`, `_on_received`, `_on_closed`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure(reason)`, etc.) and `ServerLifecycleEventReceiver` (callbacks: `_on_started`, `_on_start_failure(reason)`, `_on_received`, `_on_closed`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure(reason)`, etc.). Both share common callbacks like `_on_received`, `_on_closed`, `_on_throttled`/`_on_unthrottled`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure`, `_on_idle_timeout`.
 
@@ -229,7 +231,7 @@ Design: Discussion #150.
 
 Failure callbacks carry a reason parameter identifying the failure cause. Three type aliases, each following the `start_tls_error.pony` pattern (primitives + type alias):
 
-- **`ConnectionFailureReason`** (`_on_connection_failure`): `ConnectionFailedDNS` (name resolution failed, no TCP attempts), `ConnectionFailedTCP` (resolved but all TCP connections failed), `ConnectionFailedSSL` (TCP connected but SSL handshake failed). The DNS/TCP distinction uses `_had_inflight` (set after `PonyTCP.connect` returns > 0).
+- **`ConnectionFailureReason`** (`_on_connection_failure`): `ConnectionFailedDNS` (name resolution failed, no TCP attempts), `ConnectionFailedTCP` (resolved but all TCP connections failed), `ConnectionFailedSSL` (TCP connected but SSL handshake failed), `ConnectionFailedTimeout` (connect-to-ready phase timed out). The DNS/TCP distinction uses `_had_inflight` (set after `PonyTCP.connect` returns > 0). The timeout distinction uses `_connect_timed_out` (set by `_fire_connect_timeout()` before calling `hard_close()`).
 - **`StartFailureReason`** (`_on_start_failure`): `StartFailedSSL` (SSL session creation or handshake failure). Currently a single-variant type — future reasons (e.g. resource limits) can be added without breaking the type alias.
 - **`TLSFailureReason`** (`_on_tls_failure`): `TLSAuthFailed` (certificate/auth error), `TLSGeneralError` (protocol error). The distinction uses `_ssl_auth_failed` (set by `_ssl_poll()` on `SSLAuthFail` before calling `hard_close()`).
 
@@ -248,6 +250,22 @@ Lifecycle:
 - **Reset points**: `_read()` (POSIX, once per read event), `_read_completed()` (Windows, once per read event), `send()` success path (after the SSL/plaintext write block).
 - **Cancel point**: `hard_close()` in both the not-connected branch (before `return`) and the connected branch (before `PonyAsio.unsubscribe(_event)`).
 - **Event dispatch**: Identity check `event is _timer_event` at the top of `_event_notify`, before the main `event is _event` check. Returns immediately after firing. `_timer_event` is cleared synchronously in `_cancel_idle_timer()`, so stale disposable events for cancelled timers route through the existing catch-all at the end of `_event_notify` (which calls `PonyAsio.destroy`).
+
+### Connection timeout
+
+Optional one-shot ASIO timer that bounds the connect-to-ready phase for client connections. Covers TCP Happy Eyeballs + SSL handshake. The duration is a `ConnectionTimeout` constrained type (same range as `IdleTimeout`). Fields:
+
+- `_connect_timer_event: AsioEventID` — the ASIO timer event, `AsioEvent.none()` when inactive.
+- `_connect_timeout_nsec: U64` — configured timeout in nanoseconds, 0 when disabled.
+- `_connect_timed_out: Bool` — set by `_fire_connect_timeout()` before `hard_close()`, read by `_hard_close_connecting()` and `_hard_close_connected()` to route `ConnectionFailedTimeout`.
+
+Lifecycle:
+
+- **Arm point**: `_complete_client_initialization`, after `_had_inflight` is set, before `_connecting_callback()`. Only arms when `_had_inflight` is true (at least one TCP attempt started).
+- **Cancel points**: `_establish_connection` plaintext branch (before `_on_connected`), `_ssl_poll` SSLReady branch (after `_ssl_ready = true`), `_hard_close_connecting`, `_hard_close_connected`.
+- **Event dispatch**: Identity check `event is _connect_timer_event` at the top of `_event_notify`, before the idle timer check.
+
+Design: Discussion #234.
 
 ### Read buffer sizing
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -24,6 +24,10 @@ Server that closes connections after 10 seconds of inactivity. Demonstrates
 `idle_timeout()` for setting a per-connection timer and `_on_idle_timeout()`
 for handling the expiration — no extra actors or shared timers needed.
 
+## [connection-timeout](connection-timeout/)
+
+Client that connects to a non-routable address (192.0.2.1, RFC 5737 TEST-NET-1) with a 3-second connection timeout. Demonstrates `MakeConnectionTimeout`, the `connection_timeout` constructor parameter, and exhaustive matching on `ConnectionFailureReason` in `_on_connection_failure`.
+
 ## [backpressure](backpressure/)
 
 Handling `send()` errors and throttle/unthrottle callbacks. A flood client sends 200 chunks of 64KB as fast as possible, demonstrating what happens when the OS send buffer fills: `send()` returns `SendErrorNotWriteable`, `_on_throttled` fires, and the client waits for `_on_unthrottled` to resume. Also shows `_on_sent` for tracking write completion.

--- a/examples/connection-timeout/connection-timeout.pony
+++ b/examples/connection-timeout/connection-timeout.pony
@@ -1,0 +1,51 @@
+"""
+Client that demonstrates connection timeout.
+
+Connects to 192.0.2.1 (RFC 5737 TEST-NET-1), a non-routable address that
+black-holes SYN packets. A 3-second connection timeout bounds the attempt.
+When the timeout fires, `_on_connection_failure` receives
+`ConnectionFailedTimeout` and the program exits.
+"""
+use "../../lori"
+
+actor Main
+  new create(env: Env) =>
+    TimeoutClient(TCPConnectAuth(env.root), env.out)
+
+actor TimeoutClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _out: OutStream
+
+  new create(auth: TCPConnectAuth, out: OutStream) =>
+    _out = out
+    _out.print("Connecting to 192.0.2.1:7677 with 3-second timeout...")
+    match MakeConnectionTimeout(3_000)
+    | let ct: ConnectionTimeout =>
+      _tcp_connection = TCPConnection.client(auth,
+        "192.0.2.1",
+        "7677",
+        "",
+        this,
+        this
+        where connection_timeout = ct)
+    end
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _out.print("Connected (unexpected for a non-routable address).")
+    _tcp_connection.close()
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    match reason
+    | ConnectionFailedTimeout =>
+      _out.print("Connection timed out (expected).")
+    | ConnectionFailedDNS =>
+      _out.print("DNS resolution failed.")
+    | ConnectionFailedTCP =>
+      _out.print("All TCP connection attempts failed.")
+    | ConnectionFailedSSL =>
+      _out.print("SSL handshake failed.")
+    end

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -52,6 +52,14 @@ actor \nodoc\ Main is TestList
     test(_TestExpectAtBufferMinimum)
     test(_TestSocketOptionsConnected)
     test(_TestSocketOptionsNotConnected)
+    test(_TestConnectionTimeoutFires)
+    test(_TestConnectionTimeoutCancelledOnConnect)
+    test(_TestSSLConnectionTimeoutFires)
+    test(_TestSSLConnectionTimeoutCancelledOnConnect)
+    test(_TestConnectionTimeoutValidationRejectsZero)
+    test(_TestConnectionTimeoutValidationAcceptsBoundary)
+    test(_TestCloseWhileConnectingWithTimeout)
+    test(_TestHardCloseWhileConnectingWithTimeout)
 
 class \nodoc\ iso _TestOutgoingFails is UnitTest
   """
@@ -3512,3 +3520,569 @@ class \nodoc\ iso _TestSocketOptionsNotConnected is UnitTest
       conn.getsockopt(OSSockOpt.sol_socket(), OSSockOpt.so_rcvbuf())
     h.assert_true(gen_errno != 0,
       "getsockopt on none should return non-zero errno")
+
+class \nodoc\ iso _TestConnectionTimeoutFires is UnitTest
+  """
+  Test that the connection timeout fires when connecting to a non-routable
+  address. Connects to 192.0.2.1 (RFC 5737 TEST-NET-1) with a 2-second
+  timeout.
+  """
+  fun name(): String => "ConnectionTimeoutFires"
+
+  fun apply(h: TestHelper) =>
+    let client = _TestConnectionTimeoutFiresClient(h)
+    h.dispose_when_done(client)
+
+    h.long_test(15_000_000_000)
+
+actor \nodoc\ _TestConnectionTimeoutFiresClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    match MakeConnectionTimeout(2_000)
+    | let ct: ConnectionTimeout =>
+      _tcp_connection = TCPConnection.client(
+        TCPConnectAuth(_h.env.root),
+        "192.0.2.1",
+        "9737",
+        "",
+        this,
+        this
+        where connection_timeout = ct)
+    | let _: ValidationFailure =>
+      _h.fail("MakeConnectionTimeout(2_000) should succeed")
+    end
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _h.fail("_on_connected for a connection that should have timed out")
+    _h.complete(false)
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    match reason
+    | ConnectionFailedTimeout =>
+      _h.complete(true)
+    else
+      _h.fail("Expected ConnectionFailedTimeout, got a different reason")
+      _h.complete(false)
+    end
+
+class \nodoc\ iso _TestConnectionTimeoutCancelledOnConnect is UnitTest
+  """
+  Test that the connect timer is cancelled when a connection succeeds.
+  Starts a local listener, connects a client with a long timeout, and
+  verifies _on_connected fires normally.
+  """
+  fun name(): String => "ConnectionTimeoutCancelledOnConnect"
+
+  fun apply(h: TestHelper) =>
+    let listener = _TestConnectionTimeoutCancelListener(h)
+    h.dispose_when_done(listener)
+
+    h.long_test(15_000_000_000)
+
+actor \nodoc\ _TestConnectionTimeoutCancelListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _client: (_TestConnectionTimeoutCancelClient | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      "9738",
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestConnectionTimeoutCancelServer =>
+    _TestConnectionTimeoutCancelServer(fd, _h)
+
+  fun ref _on_closed() =>
+    try (_client as _TestConnectionTimeoutCancelClient).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestConnectionTimeoutCancelClient(_h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestConnectionTimeoutCancelListener")
+
+actor \nodoc\ _TestConnectionTimeoutCancelClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    match MakeConnectionTimeout(30_000)
+    | let ct: ConnectionTimeout =>
+      _tcp_connection = TCPConnection.client(
+        TCPConnectAuth(_h.env.root),
+        "localhost",
+        "9738",
+        "",
+        this,
+        this
+        where connection_timeout = ct)
+    | let _: ValidationFailure =>
+      _h.fail("MakeConnectionTimeout(30_000) should succeed")
+    end
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _h.complete(true)
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    _h.fail("Connection should have succeeded, got failure")
+    _h.complete(false)
+
+actor \nodoc\ _TestConnectionTimeoutCancelServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(fd: U32, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.server(
+      TCPServerAuth(_h.env.root),
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+class \nodoc\ iso _TestConnectionTimeoutValidationRejectsZero is UnitTest
+  fun name(): String => "ConnectionTimeoutValidationRejectsZero"
+
+  fun apply(h: TestHelper) =>
+    match MakeConnectionTimeout(0)
+    | let _: ConnectionTimeout =>
+      h.fail("MakeConnectionTimeout(0) should return ValidationFailure")
+    | let _: ValidationFailure =>
+      h.assert_true(true)
+    end
+
+class \nodoc\ iso _TestConnectionTimeoutValidationAcceptsBoundary is UnitTest
+  fun name(): String => "ConnectionTimeoutValidationAcceptsBoundary"
+
+  fun apply(h: TestHelper) =>
+    match MakeConnectionTimeout(1)
+    | let ct: ConnectionTimeout =>
+      h.assert_eq[U64](1, ct())
+    | let _: ValidationFailure =>
+      h.fail("MakeConnectionTimeout(1) should succeed")
+    end
+
+    match MakeConnectionTimeout(U64.max_value() / 1_000_000)
+    | let ct: ConnectionTimeout =>
+      h.assert_eq[U64](U64.max_value() / 1_000_000, ct())
+    | let _: ValidationFailure =>
+      h.fail("MakeConnectionTimeout(U64.max_value() / 1_000_000) should succeed")
+    end
+
+    match MakeConnectionTimeout((U64.max_value() / 1_000_000) + 1)
+    | let _: ConnectionTimeout =>
+      h.fail(
+        "MakeConnectionTimeout(max + 1) should return ValidationFailure")
+    | let _: ValidationFailure =>
+      h.assert_true(true)
+    end
+
+class \nodoc\ iso _TestSSLConnectionTimeoutFires is UnitTest
+  """
+  Test that the connection timeout fires during SSL handshake. Connects an
+  ssl_client to a plain TCP server — TCP connects but the SSL handshake
+  stalls because the server doesn't speak TLS. Exercises the
+  _hard_close_connected() timeout path (distinct from the plaintext
+  _hard_close_connecting() path).
+  """
+  fun name(): String => "SSLConnectionTimeoutFires"
+
+  fun apply(h: TestHelper) ? =>
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(FileAuth(h.env.root), "assets/cert.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    let listener = _TestSSLConnectionTimeoutFiresListener(
+      consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(15_000_000_000)
+
+actor \nodoc\ _TestSSLConnectionTimeoutFiresListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _sslctx: SSLContext val
+  let _h: TestHelper
+  var _client: (_TestSSLConnectionTimeoutFiresClient | None) = None
+
+  new create(sslctx: SSLContext val, h: TestHelper) =>
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      "9739",
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestSSLConnectionTimeoutFiresServer =>
+    _TestSSLConnectionTimeoutFiresServer(fd, _h)
+
+  fun ref _on_closed() =>
+    try (_client as _TestSSLConnectionTimeoutFiresClient).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestSSLConnectionTimeoutFiresClient(_sslctx, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestSSLConnectionTimeoutFiresListener")
+
+actor \nodoc\ _TestSSLConnectionTimeoutFiresClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(sslctx: SSLContext val, h: TestHelper) =>
+    _h = h
+    match MakeConnectionTimeout(2_000)
+    | let ct: ConnectionTimeout =>
+      _tcp_connection = TCPConnection.ssl_client(
+        TCPConnectAuth(_h.env.root),
+        sslctx,
+        "localhost",
+        "9739",
+        "",
+        this,
+        this
+        where connection_timeout = ct)
+    | let _: ValidationFailure =>
+      _h.fail("MakeConnectionTimeout(2_000) should succeed")
+    end
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _h.fail("_on_connected for SSL connection that should have timed out")
+    _h.complete(false)
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    match reason
+    | ConnectionFailedTimeout =>
+      _h.complete(true)
+    else
+      _h.fail("Expected ConnectionFailedTimeout, got a different reason")
+      _h.complete(false)
+    end
+
+actor \nodoc\ _TestSSLConnectionTimeoutFiresServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  """
+  Plain TCP server (no SSL) — the SSL client's handshake will stall.
+  """
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(fd: U32, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.server(
+      TCPServerAuth(_h.env.root),
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+class \nodoc\ iso _TestSSLConnectionTimeoutCancelledOnConnect is UnitTest
+  """
+  Test that the connect timer is cancelled when an SSL handshake completes.
+  Connects an ssl_client to a proper SSL server with a long timeout and
+  verifies _on_connected fires. Exercises the _cancel_connect_timer() call
+  in _ssl_poll() at the SSLReady branch.
+  """
+  fun name(): String => "SSLConnectionTimeoutCancelledOnConnect"
+
+  fun apply(h: TestHelper) ? =>
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(FileAuth(h.env.root), "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(FileAuth(h.env.root), "assets/cert.pem"),
+            FilePath(FileAuth(h.env.root), "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    let listener = _TestSSLConnectionTimeoutCancelListener(
+      consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(15_000_000_000)
+
+actor \nodoc\ _TestSSLConnectionTimeoutCancelListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _sslctx: SSLContext val
+  let _h: TestHelper
+  var _client: (_TestSSLConnectionTimeoutCancelClient | None) = None
+
+  new create(sslctx: SSLContext val, h: TestHelper) =>
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      "9740",
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestSSLConnectionTimeoutCancelSSLServer =>
+    _TestSSLConnectionTimeoutCancelSSLServer(_sslctx, fd, _h)
+
+  fun ref _on_closed() =>
+    try (_client as _TestSSLConnectionTimeoutCancelClient).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestSSLConnectionTimeoutCancelClient(_sslctx, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestSSLConnectionTimeoutCancelListener")
+
+actor \nodoc\ _TestSSLConnectionTimeoutCancelClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(sslctx: SSLContext val, h: TestHelper) =>
+    _h = h
+    match MakeConnectionTimeout(30_000)
+    | let ct: ConnectionTimeout =>
+      _tcp_connection = TCPConnection.ssl_client(
+        TCPConnectAuth(_h.env.root),
+        sslctx,
+        "localhost",
+        "9740",
+        "",
+        this,
+        this
+        where connection_timeout = ct)
+    | let _: ValidationFailure =>
+      _h.fail("MakeConnectionTimeout(30_000) should succeed")
+    end
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _h.complete(true)
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    _h.fail("SSL connection should have succeeded, got failure")
+    _h.complete(false)
+
+actor \nodoc\ _TestSSLConnectionTimeoutCancelSSLServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(sslctx: SSLContext val, fd: U32, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.ssl_server(
+      TCPServerAuth(_h.env.root),
+      sslctx,
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+class \nodoc\ iso _TestCloseWhileConnectingWithTimeout is UnitTest
+  """
+  Test that close() during the connecting phase with a connect timeout armed
+  cancels the timer and reports ConnectionFailedTCP, not ConnectionFailedTimeout.
+  """
+  fun name(): String => "CloseWhileConnectingWithTimeout"
+
+  fun apply(h: TestHelper) =>
+    let listener = _TestCloseWhileConnectingWithTimeoutListener(h)
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestCloseWhileConnectingWithTimeoutClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    match MakeConnectionTimeout(30_000)
+    | let ct: ConnectionTimeout =>
+      _tcp_connection = TCPConnection.client(
+        TCPConnectAuth(_h.env.root),
+        "localhost",
+        "9741",
+        "",
+        this,
+        this
+        where connection_timeout = ct)
+    | let _: ValidationFailure =>
+      _h.fail("MakeConnectionTimeout(30_000) should succeed")
+    end
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connecting(count: U32) =>
+    _tcp_connection.close()
+
+  fun ref _on_connected() =>
+    _h.fail("_on_connected should not fire after close")
+    _h.complete(false)
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    match reason
+    | ConnectionFailedTimeout =>
+      _h.fail("Expected non-timeout failure, got ConnectionFailedTimeout")
+      _h.complete(false)
+    else
+      _h.complete(true)
+    end
+
+actor \nodoc\ _TestCloseWhileConnectingWithTimeoutListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _client: (_TestCloseWhileConnectingWithTimeoutClient | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      "9741",
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestDoNothingServerActor =>
+    _TestDoNothingServerActor(fd, _h)
+
+  fun ref _on_closed() =>
+    try
+      (_client as _TestCloseWhileConnectingWithTimeoutClient).dispose()
+    end
+
+  fun ref _on_listening() =>
+    _client = _TestCloseWhileConnectingWithTimeoutClient(_h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestCloseWhileConnectingWithTimeoutListener")
+
+class \nodoc\ iso _TestHardCloseWhileConnectingWithTimeout is UnitTest
+  """
+  Test that hard_close() during the connecting phase with a connect timeout
+  armed cancels the timer and reports ConnectionFailedTCP, not
+  ConnectionFailedTimeout.
+  """
+  fun name(): String => "HardCloseWhileConnectingWithTimeout"
+
+  fun apply(h: TestHelper) =>
+    let listener = _TestHardCloseWhileConnectingWithTimeoutListener(h)
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestHardCloseWhileConnectingWithTimeoutClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    match MakeConnectionTimeout(30_000)
+    | let ct: ConnectionTimeout =>
+      _tcp_connection = TCPConnection.client(
+        TCPConnectAuth(_h.env.root),
+        "localhost",
+        "9742",
+        "",
+        this,
+        this
+        where connection_timeout = ct)
+    | let _: ValidationFailure =>
+      _h.fail("MakeConnectionTimeout(30_000) should succeed")
+    end
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connecting(count: U32) =>
+    _tcp_connection.hard_close()
+
+  fun ref _on_connected() =>
+    _h.fail("_on_connected should not fire after hard_close")
+    _h.complete(false)
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    match reason
+    | ConnectionFailedTimeout =>
+      _h.fail("Expected non-timeout failure, got ConnectionFailedTimeout")
+      _h.complete(false)
+    else
+      _h.complete(true)
+    end
+
+actor \nodoc\ _TestHardCloseWhileConnectingWithTimeoutListener
+  is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _client: (_TestHardCloseWhileConnectingWithTimeoutClient | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      "9742",
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestDoNothingServerActor =>
+    _TestDoNothingServerActor(fd, _h)
+
+  fun ref _on_closed() =>
+    try
+      (_client as _TestHardCloseWhileConnectingWithTimeoutClient).dispose()
+    end
+
+  fun ref _on_listening() =>
+    _client = _TestHardCloseWhileConnectingWithTimeoutClient(_h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail(
+      "Unable to open _TestHardCloseWhileConnectingWithTimeoutListener")

--- a/lori/connection_failure_reason.pony
+++ b/lori/connection_failure_reason.pony
@@ -17,5 +17,16 @@ primitive ConnectionFailedSSL
   handshake protocol errors before `_on_connected` would have fired.
   """
 
+primitive ConnectionFailedTimeout
+  """
+  The connection attempt timed out before completing. The timer covers
+  TCP Happy Eyeballs and (for SSL connections) the TLS handshake. The
+  timeout is configured via the `connection_timeout` parameter on the
+  `client` or `ssl_client` constructor.
+  """
+
 type ConnectionFailureReason is
-  (ConnectionFailedDNS | ConnectionFailedTCP | ConnectionFailedSSL)
+  ( ConnectionFailedDNS
+  | ConnectionFailedTCP
+  | ConnectionFailedSSL
+  | ConnectionFailedTimeout )

--- a/lori/connection_timeout.pony
+++ b/lori/connection_timeout.pony
@@ -1,0 +1,53 @@
+use "constrained_types"
+
+primitive ConnectionTimeoutValidator is Validator[U64]
+  """
+  Validates that a connection timeout duration is within the allowed range.
+
+  The minimum value is 1 millisecond. The maximum value is
+  18,446,744,073,709 milliseconds (~213,503 days) — the largest value
+  that can be converted to nanoseconds without overflowing U64.
+
+  Used by `MakeConnectionTimeout` to construct `ConnectionTimeout` values.
+  """
+  fun apply(value: U64): ValidationResult =>
+    if value == 0 then
+      recover val
+        ValidationFailure(
+          "connection timeout must be greater than zero")
+      end
+    elseif value > _max_millis() then
+      recover val
+        ValidationFailure(
+          "connection timeout must be at most "
+            + _max_millis().string()
+            + " milliseconds")
+      end
+    else
+      ValidationSuccess
+    end
+
+  fun _max_millis(): U64 =>
+    """
+    The maximum connection timeout in milliseconds. Values above this would
+    overflow U64 when converted to nanoseconds internally.
+    """
+    U64.max_value() / 1_000_000
+
+type ConnectionTimeout is Constrained[U64, ConnectionTimeoutValidator]
+  """
+  A validated connection timeout duration in milliseconds. The allowed range is
+  1 to 18,446,744,073,709 milliseconds (~213,503 days). The upper bound
+  ensures the value can be safely converted to nanoseconds without
+  overflowing U64.
+
+  Construct with `MakeConnectionTimeout(milliseconds)`, which returns
+  `(ConnectionTimeout | ValidationFailure)`. Pass to the `client` or
+  `ssl_client` constructor's `connection_timeout` parameter, or pass `None`
+  to disable it (the default).
+  """
+
+type MakeConnectionTimeout is MakeConstrained[U64, ConnectionTimeoutValidator]
+  """
+  Factory for `ConnectionTimeout` values. Returns `(ConnectionTimeout | ValidationFailure)`.
+  """

--- a/lori/lifecycle_event_receiver.pony
+++ b/lori/lifecycle_event_receiver.pony
@@ -137,8 +137,9 @@ trait ClientLifecycleEventReceiver
 
     The `reason` parameter identifies the failure stage:
     `ConnectionFailedDNS` (name resolution failed), `ConnectionFailedTCP`
-    (resolved but all TCP attempts failed), or `ConnectionFailedSSL`
-    (TCP connected but SSL handshake failed).
+    (resolved but all TCP attempts failed), `ConnectionFailedSSL`
+    (TCP connected but SSL handshake failed), or `ConnectionFailedTimeout`
+    (the connection attempt timed out before completing).
     """
     None
 

--- a/lori/lori.pony
+++ b/lori/lori.pony
@@ -107,7 +107,7 @@ actor MyClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
     _tcp_connection.send("Hello, server!")
 
   fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
-    // All connection attempts failed
+    // DNS, TCP, SSL, or timeout failure
     None
 
   fun ref _on_received(data: Array[U8] iso) =>
@@ -289,6 +289,32 @@ shared `Timers` actors under backpressure.
 This is independent of TCP keepalive (`keepalive()`). TCP keepalive is a
 transport-level dead-peer probe. Idle timeout is application-level inactivity
 detection.
+
+## Connection Timeout
+
+Client connections can hang indefinitely when SYN packets are black-holed or an SSL handshake stalls. The `connection_timeout` constructor parameter bounds the connect-to-ready phase — TCP Happy Eyeballs and (for SSL connections) the TLS handshake. If the timeout fires before `_on_connected`, the connection fails with [`ConnectionFailedTimeout`](/lori/lori-ConnectionFailedTimeout/).
+
+```pony
+match MakeConnectionTimeout(5_000)
+| let ct: ConnectionTimeout =>
+  _tcp_connection = TCPConnection.client(auth, host, port, "", this, this
+    where connection_timeout = ct)
+end
+```
+
+Connection timeout is disabled by default (`None`). The duration is a [`ConnectionTimeout`](/lori/lori-ConnectionTimeout/) value — a constrained type with the same range as `IdleTimeout` (1 to 18,446,744,073,709 milliseconds). The timer is a one-shot: it either fires and fails the connection, or is cancelled when the connection becomes ready.
+
+The timer is armed after `PonyTCP.connect` returns, so it does not cover DNS resolution time. If DNS itself blocks (common with unresponsive nameservers), the total wait will exceed the configured timeout by the DNS resolution time.
+
+```pony
+fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+  match reason
+  | ConnectionFailedTimeout => // timed out
+  | ConnectionFailedDNS => // name resolution failed
+  | ConnectionFailedTCP => // all TCP attempts failed
+  | ConnectionFailedSSL => // SSL handshake failed
+  end
+```
 
 ## Read Yielding
 

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -57,6 +57,15 @@ class TCPConnection
   var _timer_event: AsioEventID = AsioEvent.none()
   var _idle_timeout_nsec: U64 = 0
 
+  // Per-connection connect timeout via ASIO timer (one-shot)
+  var _connect_timer_event: AsioEventID = AsioEvent.none()
+  var _connect_timeout_nsec: U64 = 0
+  // COUPLING: Set by _fire_connect_timeout() before calling hard_close().
+  // Read by _hard_close_connecting() and _hard_close_connected() to route
+  // the failure reason to ConnectionFailedTimeout. Same pattern as
+  // _ssl_auth_failed.
+  var _connect_timed_out: Bool = false
+
   // client startup state
   var _host: String = ""
   var _port: String = ""
@@ -70,8 +79,14 @@ class TCPConnection
     enclosing: TCPConnectionActor ref,
     ler: ClientLifecycleEventReceiver ref,
     read_buffer_size: ReadBufferSize = DefaultReadBufferSize(),
-    ip_version: IPVersion = DualStack)
+    ip_version: IPVersion = DualStack,
+    connection_timeout: (ConnectionTimeout | None) = None)
   =>
+    """
+    Create a client-side plaintext connection. An optional `connection_timeout`
+    bounds the TCP Happy Eyeballs phase. If the timeout fires before
+    `_on_connected`, the connection fails with `ConnectionFailedTimeout`.
+    """
     _lifecycle_event_receiver = ler
     _enclosing = enclosing
     _host = host
@@ -80,6 +95,9 @@ class TCPConnection
     _read_buffer_size = read_buffer_size()
     _read_buffer_min = read_buffer_size()
     _ip_version = ip_version
+    match connection_timeout
+    | let ct: ConnectionTimeout => _connect_timeout_nsec = ct() * 1_000_000
+    end
 
     _resize_read_buffer_if_needed()
 
@@ -109,12 +127,16 @@ class TCPConnection
     enclosing: TCPConnectionActor ref,
     ler: ClientLifecycleEventReceiver ref,
     read_buffer_size: ReadBufferSize = DefaultReadBufferSize(),
-    ip_version: IPVersion = DualStack)
+    ip_version: IPVersion = DualStack,
+    connection_timeout: (ConnectionTimeout | None) = None)
   =>
     """
     Create a client-side SSL connection. The SSL session is created from the
     provided SSLContext. If session creation fails, the connection reports
     failure asynchronously via _on_connection_failure(ConnectionFailedSSL).
+    An optional `connection_timeout` bounds the connect-to-ready phase
+    (TCP Happy Eyeballs + TLS handshake). If the timeout fires before
+    `_on_connected`, the connection fails with `ConnectionFailedTimeout`.
     """
     _lifecycle_event_receiver = ler
     _enclosing = enclosing
@@ -124,6 +146,9 @@ class TCPConnection
     _read_buffer_size = read_buffer_size()
     _read_buffer_min = read_buffer_size()
     _ip_version = ip_version
+    match connection_timeout
+    | let ct: ConnectionTimeout => _connect_timeout_nsec = ct() * 1_000_000
+    end
 
     try
       _ssl = ssl_ctx.client(host)?
@@ -551,8 +576,8 @@ class TCPConnection
   fun ref _hard_close_connecting() =>
     """
     Hard close during the connecting phase. Disposes SSL, fires the
-    appropriate failure callback, and cancels the idle timer. The caller
-    must set `_state = _Closed` before calling this.
+    appropriate failure callback, and cancels both the idle and connect
+    timers. The caller must set `_state = _Closed` before calling this.
     """
     _shutdown = true
     _shutdown_peer = true
@@ -563,7 +588,9 @@ class TCPConnection
     end
     match _lifecycle_event_receiver
     | let c: ClientLifecycleEventReceiver ref =>
-      let reason = if _had_inflight then
+      let reason = if _connect_timed_out then
+        ConnectionFailedTimeout
+      elseif _had_inflight then
         ConnectionFailedTCP
       else
         ConnectionFailedDNS
@@ -571,13 +598,14 @@ class TCPConnection
       c._on_connection_failure(reason)
     end
     _cancel_idle_timer()
+    _cancel_connect_timer()
 
   fun ref _hard_close_connected() =>
     """
     Hard close for an established connection. Fires `_on_send_failed` for
-    any pending token, clears pending buffers, cancels idle timer,
-    unsubscribes the event, closes the fd, disposes SSL, and fires the
-    appropriate lifecycle callbacks. The caller must set `_state = _Closed`
+    any pending token, clears pending buffers, cancels idle and connect
+    timers, unsubscribes the event, closes the fd, disposes SSL, and fires
+    the appropriate lifecycle callbacks. The caller must set `_state = _Closed`
     before calling this.
     """
     _shutdown = true
@@ -600,6 +628,7 @@ class TCPConnection
     _pending_token = None
 
     _cancel_idle_timer()
+    _cancel_connect_timer()
     PonyAsio.unsubscribe(_event)
     _set_unreadable()
     _set_unwriteable()
@@ -639,7 +668,11 @@ class TCPConnection
             // the connection never started.
             match \exhaustive\ s
             | let c: ClientLifecycleEventReceiver ref =>
-              c._on_connection_failure(ConnectionFailedSSL)
+              if _connect_timed_out then
+                c._on_connection_failure(ConnectionFailedTimeout)
+              else
+                c._on_connection_failure(ConnectionFailedSSL)
+              end
             | let srv: ServerLifecycleEventReceiver ref =>
               srv._on_start_failure(StartFailedSSL)
             end
@@ -1405,6 +1438,43 @@ class TCPConnection
       _reset_idle_timer()
     end
 
+  fun ref _arm_connect_timer() =>
+    """
+    Create the ASIO timer event for the connect timeout. Called after
+    `PonyTCP.connect` succeeds (at least one connection attempt is inflight).
+    No-op when `_connect_timeout_nsec == 0` (no timeout configured).
+    """
+    if _connect_timeout_nsec == 0 then return end
+    match \exhaustive\ _enclosing
+    | let e: TCPConnectionActor ref =>
+      _connect_timer_event =
+        PonyAsio.create_timer_event(e, _connect_timeout_nsec)
+    | None =>
+      _Unreachable()
+    end
+
+  fun ref _cancel_connect_timer() =>
+    """
+    Cancel the connect timeout timer. Unsubscribes and clears
+    `_connect_timer_event` immediately. Stale disposable notifications
+    route through the catch-all disposable handler in `_event_notify`.
+    """
+    if not _connect_timer_event.is_null() then
+      PonyAsio.unsubscribe(_connect_timer_event)
+      _connect_timer_event = AsioEvent.none()
+      _connect_timeout_nsec = 0
+    end
+
+  fun ref _fire_connect_timeout() =>
+    """
+    The connect timeout has fired. Sets `_connect_timed_out` so that
+    `hard_close()` routes the failure to `ConnectionFailedTimeout`, then
+    cancels the timer and hard-closes the connection.
+    """
+    _connect_timed_out = true
+    _cancel_connect_timer()
+    hard_close()
+
   fun ref _ssl_flush_sends() =>
     """
     Flush any pending encrypted data from the SSL session to the wire.
@@ -1436,6 +1506,7 @@ class TCPConnection
       | SSLReady =>
         if not _ssl_ready then
           _ssl_ready = true
+          _cancel_connect_timer()
           // _tls_upgrade distinguishes initial SSL (constructor) from
           // mid-stream TLS upgrade (start_tls). Changing _tls_upgrade
           // semantics or removing it would break the callback routing
@@ -1515,6 +1586,7 @@ class TCPConnection
       _ssl_flush_sends()
       // _on_connected() deferred until _ssl_ready
     | None =>
+      _cancel_connect_timer()
       match _lifecycle_event_receiver
       | let c: ClientLifecycleEventReceiver ref =>
         c._on_connected()
@@ -1552,10 +1624,13 @@ class TCPConnection
     PonyTCP.close(PonyAsio.event_fd(event))
 
   fun ref _event_notify(event: AsioEventID, flags: U32, arg: U32) =>
-    // Timer fired. Disposable events for cancelled timers never reach here
-    // because _cancel_idle_timer() clears _timer_event synchronously.
-    // Stale timer disposables route through the catch-all disposable handler
-    // below.
+    // Timer events. Disposable events for cancelled timers never reach here
+    // because the cancel methods clear timer fields synchronously. Stale
+    // timer disposables route through the catch-all disposable handler below.
+    if event is _connect_timer_event then
+      _fire_connect_timeout()
+      return
+    end
     if event is _timer_event then
       _fire_idle_timeout()
       return
@@ -1656,6 +1731,9 @@ class TCPConnection
       _inflight_connections = PonyTCP.connect(e, _host, _port, _from,
         asio_flags where ip_version = _ip_version)
       _had_inflight = _inflight_connections > 0
+      if _had_inflight then
+        _arm_connect_timer()
+      end
       _connecting_callback()
     | None =>
       _Unreachable()


### PR DESCRIPTION
Client connection attempts can hang indefinitely when SYN packets are black-holed or an SSL handshake stalls. This adds an optional one-shot ASIO timer that bounds the connect-to-ready phase for client connections, covering TCP Happy Eyeballs and (for SSL) the TLS handshake.

The `connection_timeout` constructor parameter on `client` and `ssl_client` accepts `(ConnectionTimeout | None)`, defaulting to `None` (no timeout). When the timeout fires before the connection becomes ready, `_on_connection_failure` receives a new `ConnectionFailedTimeout` reason.

Breaking change: `ConnectionFailureReason` union now includes `ConnectionFailedTimeout`, which breaks exhaustive matches.

This is a multi-type PR (Added + Changed) — CHANGELOG will be updated manually. No changelog label needed.

Design: #234