### PR TITLE
Fix idle timer issues with SSL connections

### DIFF
--- a/.release-notes/idle-timer-ssl-fix.md
+++ b/.release-notes/idle-timer-ssl-fix.md
@@ -1,0 +1,9 @@
+## Fix idle timer issues with SSL connections
+
+The idle timer had two issues with SSL connections:
+
+The timer was being armed when the TCP connection established, before the SSL handshake completed. If an idle timeout was configured before the connection was ready, `_on_idle_timeout()` could fire before `_on_connected()` or `_on_started()`.
+
+Calling `idle_timeout()` on an SSL connection during the handshake could also arm the timer prematurely, producing the same early `_on_idle_timeout()`. Additionally, when the handshake later completed, a second timer was created — leaking the first ASIO timer event.
+
+The idle timer now defers arming until the SSL handshake completes, regardless of whether the timeout is configured before or during the handshake.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -246,7 +246,7 @@ Per-connection idle timeout via ASIO timer events. The duration is an `IdleTimeo
 
 Lifecycle:
 
-- **Arm points**: `_complete_server_initialization` (after `_set_writeable()`) and `_event_notify` Happy Eyeballs success (after `_set_readable()`). `_arm_idle_timer()` is a no-op when `_idle_timeout_nsec == 0`. Also called from `idle_timeout()` when setting a timeout on an established connection with no existing timer.
+- **Arm points**: plaintext branch of `_establish_connection` and `_complete_server_initialization`; `_ssl_poll` SSLReady branch for initial SSL connections (not TLS upgrades). `_arm_idle_timer()` is a no-op when `_idle_timeout_nsec == 0` or when a timer already exists (idempotency guard). Also called from `idle_timeout()` when setting a timeout on an established connection with no existing timer. `idle_timeout()` defers arming during initial SSL handshake (`_ssl` present, `_ssl_ready` false, not a TLS upgrade) — `_ssl_poll` arms at SSLReady.
 - **Reset points**: `_read()` (POSIX, once per read event), `_read_completed()` (Windows, once per read event), `send()` success path (after the SSL/plaintext write block).
 - **Cancel point**: `hard_close()` in both the not-connected branch (before `return`) and the connected branch (before `PonyAsio.unsubscribe(_event)`).
 - **Event dispatch**: Identity check `event is _timer_event` at the top of `_event_notify`, before the main `event is _event` check. Returns immediately after firing. `_timer_event` is cleared synchronously in `_cancel_idle_timer()`, so stale disposable events for cancelled timers route through the existing catch-all at the end of `_event_notify` (which calls `PonyAsio.destroy`).

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -33,6 +33,9 @@ actor \nodoc\ Main is TestList
     test(_TestIdleTimeout)
     test(_TestIdleTimeoutReset)
     test(_TestIdleTimeoutDisable)
+    test(_TestSSLIdleTimeout)
+    test(_TestSSLIdleTimeoutNotArmedDuringHandshake)
+    test(_TestSSLIdleTimeoutDeferredArm)
     test(_TestYieldRead)
     test(_TestIP4PingPong)
     test(_TestIP6PingPong)
@@ -2299,6 +2302,327 @@ class \nodoc\ _TestIdleTimeoutDisableWatchdog is TimerNotify
   fun ref apply(timer: Timer, count: U64): Bool =>
     _server._watchdog_complete()
     false
+
+class \nodoc\ iso _TestSSLIdleTimeout is UnitTest
+  """
+  Test that the idle timeout fires on an SSL connection when no data is sent
+  or received. SSL server sets a 5-second idle timeout in _on_started();
+  SSL client connects but sends nothing.
+  """
+  fun name(): String => "SSLIdleTimeout"
+
+  fun apply(h: TestHelper) ? =>
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(FileAuth(h.env.root), "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(FileAuth(h.env.root), "assets/cert.pem"),
+            FilePath(FileAuth(h.env.root), "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    let listener = _TestSSLIdleTimeoutListener(consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(15_000_000_000)
+
+actor \nodoc\ _TestSSLIdleTimeoutListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _sslctx: SSLContext val
+  let _h: TestHelper
+  var _client: (_TestSSLIdleTimeoutClient | None) = None
+
+  new create(sslctx: SSLContext val, h: TestHelper) =>
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      "9743",
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestSSLIdleTimeoutServer =>
+    _TestSSLIdleTimeoutServer(_sslctx, fd, _h)
+
+  fun ref _on_closed() =>
+    try (_client as _TestSSLIdleTimeoutClient).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestSSLIdleTimeoutClient(_sslctx, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestSSLIdleTimeoutListener")
+
+actor \nodoc\ _TestSSLIdleTimeoutClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(sslctx: SSLContext val, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.ssl_client(
+      TCPConnectAuth(_h.env.root),
+      sslctx,
+      "localhost",
+      "9743",
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+actor \nodoc\ _TestSSLIdleTimeoutServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(sslctx: SSLContext val, fd: U32, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.ssl_server(
+      TCPServerAuth(_h.env.root),
+      sslctx,
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    match MakeIdleTimeout(5_000)
+    | let t: IdleTimeout =>
+      _tcp_connection.idle_timeout(t)
+    end
+
+  fun ref _on_idle_timeout() =>
+    _h.complete(true)
+
+class \nodoc\ iso _TestSSLIdleTimeoutNotArmedDuringHandshake is UnitTest
+  """
+  Regression test for issue #235. An SSL client with an idle timeout
+  configured before the handshake connects to a plain TCP server so the
+  handshake stalls. The idle timer must not arm until the handshake completes,
+  so the connection timeout (5s) should fire instead of the idle timeout (1s).
+  """
+  fun name(): String => "SSLIdleTimeoutNotArmedDuringHandshake"
+
+  fun apply(h: TestHelper) ? =>
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(FileAuth(h.env.root), "assets/cert.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    let listener = _TestSSLIdleTimeoutNotArmedListener(consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(15_000_000_000)
+
+actor \nodoc\ _TestSSLIdleTimeoutNotArmedListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _sslctx: SSLContext val
+  let _h: TestHelper
+  var _client: (_TestSSLIdleTimeoutNotArmedClient | None) = None
+
+  new create(sslctx: SSLContext val, h: TestHelper) =>
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      "9744",
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestSSLIdleTimeoutNotArmedServer =>
+    _TestSSLIdleTimeoutNotArmedServer(fd, _h)
+
+  fun ref _on_closed() =>
+    try (_client as _TestSSLIdleTimeoutNotArmedClient).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestSSLIdleTimeoutNotArmedClient(_sslctx, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestSSLIdleTimeoutNotArmedListener")
+
+actor \nodoc\ _TestSSLIdleTimeoutNotArmedClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(sslctx: SSLContext val, h: TestHelper) =>
+    _h = h
+    match (MakeIdleTimeout(1_000), MakeConnectionTimeout(5_000))
+    | (let it: IdleTimeout, let ct: ConnectionTimeout) =>
+      _tcp_connection = TCPConnection.ssl_client(
+        TCPConnectAuth(_h.env.root),
+        sslctx,
+        "localhost",
+        "9744",
+        "",
+        this,
+        this
+        where connection_timeout = ct)
+      _tcp_connection.idle_timeout(it)
+    | (let _: ValidationFailure, _) =>
+      _h.fail("MakeIdleTimeout(1_000) should succeed")
+    | (_, let _: ValidationFailure) =>
+      _h.fail("MakeConnectionTimeout(5_000) should succeed")
+    end
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _h.fail("SSL handshake should not complete against plain TCP server")
+    _h.complete(false)
+
+  fun ref _on_idle_timeout() =>
+    _h.fail("Idle timeout fired before SSL handshake completed")
+    _h.complete(false)
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    match reason
+    | ConnectionFailedTimeout =>
+      _h.complete(true)
+    else
+      _h.fail("Expected ConnectionFailedTimeout, got a different reason")
+      _h.complete(false)
+    end
+
+actor \nodoc\ _TestSSLIdleTimeoutNotArmedServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  """
+  Plain TCP server (no SSL) — the SSL client's handshake will stall.
+  """
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(fd: U32, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.server(
+      TCPServerAuth(_h.env.root),
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+class \nodoc\ iso _TestSSLIdleTimeoutDeferredArm is UnitTest
+  """
+  Test the deferred-arm path: an SSL client configures an idle timeout
+  before the connection is established, then verifies it fires after the
+  handshake succeeds. The idle_timeout() value is stored before the
+  connection opens, and _ssl_poll arms the timer at SSLReady.
+  """
+  fun name(): String => "SSLIdleTimeoutDeferredArm"
+
+  fun apply(h: TestHelper) ? =>
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(FileAuth(h.env.root), "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(FileAuth(h.env.root), "assets/cert.pem"),
+            FilePath(FileAuth(h.env.root), "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    let listener = _TestSSLIdleTimeoutDeferredArmListener(consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(15_000_000_000)
+
+actor \nodoc\ _TestSSLIdleTimeoutDeferredArmListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _sslctx: SSLContext val
+  let _h: TestHelper
+  var _client: (_TestSSLIdleTimeoutDeferredArmClient | None) = None
+
+  new create(sslctx: SSLContext val, h: TestHelper) =>
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      "9745",
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestSSLIdleTimeoutDeferredArmServer =>
+    _TestSSLIdleTimeoutDeferredArmServer(_sslctx, fd, _h)
+
+  fun ref _on_closed() =>
+    try (_client as _TestSSLIdleTimeoutDeferredArmClient).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestSSLIdleTimeoutDeferredArmClient(_sslctx, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestSSLIdleTimeoutDeferredArmListener")
+
+actor \nodoc\ _TestSSLIdleTimeoutDeferredArmClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(sslctx: SSLContext val, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.ssl_client(
+      TCPConnectAuth(_h.env.root),
+      sslctx,
+      "localhost",
+      "9745",
+      "",
+      this,
+      this)
+    // Configure idle timeout before the handshake completes.
+    // idle_timeout() defers arming; _ssl_poll arms at SSLReady.
+    match MakeIdleTimeout(5_000)
+    | let t: IdleTimeout =>
+      _tcp_connection.idle_timeout(t)
+    end
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_idle_timeout() =>
+    _h.complete(true)
+
+actor \nodoc\ _TestSSLIdleTimeoutDeferredArmServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(sslctx: SSLContext val, fd: U32, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.ssl_server(
+      TCPServerAuth(_h.env.root),
+      sslctx,
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
 
 class \nodoc\ iso _TestYieldRead is UnitTest
   """

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -365,10 +365,19 @@ class TCPConnection
     | let t: IdleTimeout =>
       _idle_timeout_nsec = t() * 1_000_000
       if _state.is_open() then
-        if _timer_event.is_null() then
-          _arm_idle_timer()
+        // Don't arm during initial SSL handshake — the timer would fire
+        // before _on_connected()/_on_started(). _ssl_poll will arm at
+        // SSLReady. TLS upgrades are excluded: the timer is already
+        // running from the plaintext phase and should be reset normally.
+        match _ssl
+        | let _: SSL ref if (not _ssl_ready) and (not _tls_upgrade) =>
+          None
         else
-          _reset_idle_timer()
+          if _timer_event.is_null() then
+            _arm_idle_timer()
+          else
+            _reset_idle_timer()
+          end
         end
       end
     | None =>
@@ -1390,8 +1399,12 @@ class TCPConnection
     Create the ASIO timer event for idle timeout. Called when the connection
     establishes and `_idle_timeout_nsec > 0`, or when `idle_timeout()` is
     called on an established connection.
+
+    Idempotent — if a timer already exists, this is a no-op. Prevents ASIO
+    timer event leaks from double-arm scenarios.
     """
     if _idle_timeout_nsec == 0 then return end
+    if not _timer_event.is_null() then return end
     match \exhaustive\ _enclosing
     | let e: TCPConnectionActor ref =>
       _timer_event = PonyAsio.create_timer_event(e, _idle_timeout_nsec)
@@ -1507,6 +1520,12 @@ class TCPConnection
         if not _ssl_ready then
           _ssl_ready = true
           _cancel_connect_timer()
+          // Arm idle timer now that the handshake is complete. Not for
+          // TLS upgrades — the timer is already running from the
+          // plaintext phase.
+          if not _tls_upgrade then
+            _arm_idle_timer()
+          end
           // _tls_upgrade distinguishes initial SSL (constructor) from
           // mid-stream TLS upgrade (start_tls). Changing _tls_upgrade
           // semantics or removing it would break the callback routing
@@ -1578,14 +1597,14 @@ class TCPConnection
     _state = _Open
     _set_writeable()
     _set_readable()
-    _arm_idle_timer()
 
     match \exhaustive\ _ssl
     | let _: SSL ref =>
       // Flush ClientHello to initiate SSL handshake
       _ssl_flush_sends()
-      // _on_connected() deferred until _ssl_ready
+      // _on_connected() and _arm_idle_timer() deferred until _ssl_ready
     | None =>
+      _arm_idle_timer()
       _cancel_connect_timer()
       match _lifecycle_event_receiver
       | let c: ClientLifecycleEventReceiver ref =>
@@ -1756,14 +1775,14 @@ class TCPConnection
       _state = _Open
       _set_readable()
       _set_writeable()
-      _arm_idle_timer()
 
       match \exhaustive\ _ssl
       | let _: SSL ref =>
         // Flush any initial SSL data (usually no-op for servers)
         _ssl_flush_sends()
-        // _on_started() deferred until _ssl_ready
+        // _on_started() and _arm_idle_timer() deferred until _ssl_ready
       | None =>
+        _arm_idle_timer()
         s._on_started()
       end
 


### PR DESCRIPTION
The idle timer had two issues with SSL connections.

The timer was arming at TCP connect time, before the SSL handshake finished. For SSL connections with an idle timeout configured early, `_on_idle_timeout()` could fire before `_on_connected()` or `_on_started()`.

Separately, calling `idle_timeout()` on an SSL connection during the handshake window (TCP connected but handshake still in progress) could also arm the timer prematurely. When the handshake later completed, `_ssl_poll` armed a second timer, leaking the first ASIO timer event.

Both are fixed: the timer now defers arming until the SSL handshake completes, regardless of whether the timeout is configured before or during the handshake. `_arm_idle_timer()` is also idempotent now as defense in depth.

Closes #235