### PR TITLE
Fix resource leak from orphaned Happy Eyeballs connections

### DIFF
--- a/.release-notes/fix-connecting-phase-resource-cleanup.md
+++ b/.release-notes/fix-connecting-phase-resource-cleanup.md
@@ -1,0 +1,5 @@
+## Fix resource leak from orphaned Happy Eyeballs connections
+
+When a client connection was closed or timed out during the Happy Eyeballs connecting phase, inflight connection attempts that hadn't completed yet could be orphaned — their socket file descriptors and ASIO events were never cleaned up. This could cause the Pony runtime to hang on shutdown because leaked ASIO events kept the event loop alive.
+
+The fix ensures all inflight connection attempts are properly drained and cleaned up before the connection fully closes, regardless of how the close was initiated (user `close()`, `hard_close()`, or connection timeout).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,25 +166,26 @@ TCPConnection uses explicit state objects (`_ConnectionState` trait in `_connect
 
 ```
 _ConnectionNone → _ClientConnecting → _Open → _Closing → _Closed
-                                    ↘ _Closed (hard_close)
+                                    ↘ _UnconnectedClosing → _Closed
 _ConnectionNone → _Open (server) → _Closing → _Closed
 ```
 
 | State | `is_open()` | `is_closed()` | Description |
 |---|---|---|---|
 | `_ConnectionNone` | false | false | Before `_finish_initialization`. All methods call `_Unreachable()`. |
-| `_ClientConnecting` | false | false | Happy Eyeballs in progress. Has `_pending_close` flag for `close()` during connecting. |
+| `_ClientConnecting` | false | false | Happy Eyeballs in progress. `close()`/`hard_close()` transition to `_UnconnectedClosing`. |
+| `_UnconnectedClosing` | false | true | Draining inflight Happy Eyeballs connections after close/hard_close during connecting phase. |
 | `_Open` | true | false | Connection established, I/O active. |
 | `_Closing` | false | true | Graceful shutdown in progress — waiting for peer FIN. Still reads to detect FIN. |
 | `_Closed` | false | true | Fully closed. Handles straggler event cleanup only. |
 
 State classes dispatch lifecycle-gated operations (`send`, `close`, `hard_close`, `start_tls`, `read_again`, `own_event`, `foreign_event`) and delegate to TCPConnection methods for the actual work. All I/O, SSL, buffer, and flow control logic remains on TCPConnection.
 
-**Private field access**: Pony restricts private field access to the defining type. State classes use helper methods on TCPConnection (`_set_state`, `_decrement_inflight`, `_establish_connection`, `_straggler_cleanup`, etc.) rather than accessing fields directly.
+**Private field access**: Pony restricts private field access to the defining type. State classes use helper methods on TCPConnection (`_set_state`, `_decrement_inflight`, `_has_inflight`, `_establish_connection`, `_straggler_cleanup`, etc.) rather than accessing fields directly.
 
 **Flags kept on TCPConnection**: `_shutdown` and `_shutdown_peer` remain as data fields (set by I/O methods, checked by `_Closing`). Flow control flags (`_throttled`, `_readable`, `_writeable`, `_muted`, `_yield_read`) are orthogonal to lifecycle state.
 
-**`_event_notify` dispatch**: Timer events and disposable handling stay on TCPConnection. The `is_own_event` check is captured BEFORE dispatch because `_ClientConnecting.foreign_event()` can promote a foreign event to `_event` (Happy Eyeballs winner).
+**`_event_notify` dispatch**: Timer events and disposable handling stay on TCPConnection. The `is_own_event` check is captured BEFORE dispatch because `_ClientConnecting.foreign_event()` can promote a foreign event to `_event` (Happy Eyeballs winner). All foreign events are delegated to `_state.foreign_event()` — each state guards with `if not (writeable or readable) then return end` to filter disposable, timer, and signal notifications while still processing error-only events (the fix for stale timer fires reaching `foreign_event` as straggler events). `PonyAsio.destroy` for disposable events is handled by the catch-all at the end of `_event_notify`.
 
 Design: Discussion #219.
 

--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -48,30 +48,17 @@ class _ConnectionNone is _ConnectionState
   fun is_closed(): Bool => false
 
 class _ClientConnecting is _ConnectionState
-  var _pending_close: Bool = false
-
   fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
     _Unreachable()
 
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
     flags: U32, arg: U32)
   =>
-    if not AsioEvent.writeable(flags) then return end
-
-    let fd = PonyAsio.event_fd(event)
-    let remaining = conn._decrement_inflight()
-
-    if _pending_close then
-      // Straggler cleanup during close — don't establish, just clean up
-      conn._straggler_cleanup(event)
-
-      if remaining == 0 then
-        // All inflight drained — fire failure and transition
-        conn._set_state(_Closed)
-        conn._hard_close_connecting()
-      end
+    if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
       return
     end
+    let fd = PonyAsio.event_fd(event)
+    conn._decrement_inflight()
 
     if conn._is_socket_connected(fd) then
       conn._establish_connection(event, fd)
@@ -85,10 +72,19 @@ class _ClientConnecting is _ConnectionState
     SendErrorNotConnected
 
   fun ref close(conn: TCPConnection ref) =>
-    _pending_close = true
+    if conn._has_inflight() then
+      conn._set_state(_UnconnectedClosing)
+    else
+      conn._set_state(_Closed)
+    end
+    conn._hard_close_connecting()
 
   fun ref hard_close(conn: TCPConnection ref) =>
-    conn._set_state(_Closed)
+    if conn._has_inflight() then
+      conn._set_state(_UnconnectedClosing)
+    else
+      conn._set_state(_Closed)
+    end
     conn._hard_close_connecting()
 
   fun ref start_tls(conn: TCPConnection ref, ssl_ctx: SSLContext val,
@@ -101,6 +97,51 @@ class _ClientConnecting is _ConnectionState
 
   fun is_open(): Bool => false
   fun is_closed(): Bool => false
+
+class _UnconnectedClosing is _ConnectionState
+  """
+  Draining inflight Happy Eyeballs connections after close/hard_close during
+  the connecting phase. The failure callback has already fired — the only job
+  is to clean up straggler events until inflight reaches zero, then transition
+  to _Closed.
+  """
+  fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
+    _Unreachable()
+
+  fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
+    flags: U32, arg: U32)
+  =>
+    if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
+      return
+    end
+    let remaining = conn._decrement_inflight()
+    conn._straggler_cleanup(event)
+
+    if remaining == 0 then
+      conn._set_state(_Closed)
+    end
+
+  fun ref send(conn: TCPConnection ref,
+    data: (ByteSeq | ByteSeqIter)): (SendToken | SendError)
+  =>
+    SendErrorNotConnected
+
+  fun ref close(conn: TCPConnection ref) =>
+    None
+
+  fun ref hard_close(conn: TCPConnection ref) =>
+    None
+
+  fun ref start_tls(conn: TCPConnection ref, ssl_ctx: SSLContext val,
+    host: String): (None | StartTLSError)
+  =>
+    StartTLSNotConnected
+
+  fun ref read_again(conn: TCPConnection ref) =>
+    None
+
+  fun is_open(): Bool => false
+  fun is_closed(): Bool => true
 
 class _Open is _ConnectionState
   fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
@@ -125,9 +166,11 @@ class _Open is _ConnectionState
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
     flags: U32, arg: U32)
   =>
-    if not AsioEvent.writeable(flags) then return end
-
-    // Happy Eyeballs straggler — clean up
+    if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
+      return
+    end
+    // Happy Eyeballs straggler — clean up regardless of event flags.
+    // Error events (EPOLLERR/EPOLLHUP) may arrive without writeable set.
     conn._decrement_inflight()
     conn._straggler_cleanup(event)
 
@@ -178,9 +221,10 @@ class _Closing is _ConnectionState
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
     flags: U32, arg: U32)
   =>
-    if not AsioEvent.writeable(flags) then return end
-
-    // Happy Eyeballs straggler — clean up
+    if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
+      return
+    end
+    // Happy Eyeballs straggler — clean up regardless of event flags.
     conn._decrement_inflight()
     conn._straggler_cleanup(event)
 
@@ -218,9 +262,11 @@ class _Closed is _ConnectionState
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
     flags: U32, arg: U32)
   =>
-    if not AsioEvent.writeable(flags) then return end
-
-    // Happy Eyeballs straggler — clean up
+    if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
+      return
+    end
+    // Happy Eyeballs straggler — clean up regardless of event flags.
+    conn._decrement_inflight()
     conn._straggler_cleanup(event)
 
   fun ref send(conn: TCPConnection ref,

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -2,6 +2,24 @@ use net = "net"
 use "ssl/net"
 
 class TCPConnection
+  """
+  Connection lifecycle state machine:
+
+  ```mermaid
+  stateDiagram-v2
+    [*] --> _ConnectionNone
+    _ConnectionNone --> _ClientConnecting : client init
+    _ConnectionNone --> _Open : server init
+    _ConnectionNone --> _Closed : SSL session creation failed
+    _ClientConnecting --> _Open : connect success
+    _ClientConnecting --> _UnconnectedClosing : close/hard_close (inflight > 0)
+    _ClientConnecting --> _Closed : close/hard_close/failure (inflight == 0)
+    _UnconnectedClosing --> _Closed : all inflight drained
+    _Open --> _Closing : close
+    _Open --> _Closed : hard_close
+    _Closing --> _Closed : shutdown complete or hard_close
+  ```
+  """
   var _state: _ConnectionState ref = _ConnectionNone
   var _shutdown: Bool = false
   var _shutdown_peer: Bool = false
@@ -651,7 +669,8 @@ class TCPConnection
     """
     Hard close during the connecting phase. Disposes SSL, fires the
     appropriate failure callback, and cancels the idle, connect, and user
-    timers. The caller must set `_state = _Closed` before calling this.
+    timers. Safe to call from any state — the caller is responsible for state
+    transitions. Must not be called more than once per connection lifecycle.
     """
     _shutdown = true
     _shutdown_peer = true
@@ -1687,6 +1706,9 @@ class TCPConnection
   fun ref _decrement_inflight(): U32 =>
     _inflight_connections = _inflight_connections - 1
     _inflight_connections
+
+  fun _has_inflight(): Bool =>
+    _inflight_connections > 0
 
   fun ref _establish_connection(event: AsioEventID, fd: U32) =>
     """


### PR DESCRIPTION
When `close()` or `hard_close()` was called during the connecting phase, inflight Happy Eyeballs connection attempts could be orphaned — error-only events (EPOLLERR/EPOLLHUP without EPOLLOUT) were silently dropped by the writeable guard in `foreign_event` handlers. The leaked socket FDs and ASIO events kept the runtime event loop alive.

Introduces `_UnconnectedClosing` state to explicitly drain inflight connections during connecting-phase shutdown, replacing the `_pending_close` boolean flag on `_ClientConnecting`. Filters disposable foreign events in `_event_notify` to safely remove writeable guards from all `foreign_event` handlers.

Closes #244