### PR TITLE
Fix resource leak from orphaned Happy Eyeballs connections

### DIFF
--- a/.release-notes/fix-orphaned-happy-eyeballs.md
+++ b/.release-notes/fix-orphaned-happy-eyeballs.md
@@ -1,0 +1,5 @@
+## Fix resource leak from orphaned Happy Eyeballs connections
+
+When `close()` or `hard_close()` was called during the connecting phase, inflight Happy Eyeballs connection attempts could leak file descriptors and ASIO events. On Linux, failed connection attempts delivered error-only events (`ASIO_READ` without `ASIO_WRITE`) that were silently dropped by the writeable guard, preventing cleanup. On macOS, failed sockets produced two events per socket; the old guard accidentally filtered one, but the cleanup still had gaps.
+
+Inflight connections are now reliably drained on all platforms.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,13 +167,17 @@ TCPConnection uses explicit state objects (`_ConnectionState` trait in `_connect
 ```
 _ConnectionNone → _ClientConnecting → _Open → _Closing → _Closed
                                     ↘ _Closed (hard_close)
+_ClientConnecting → _UnconnectedClosing → _Closed (close, drain stragglers)
+_ClientConnecting → _Closed (hard_close / all connections failed)
+_UnconnectedClosing → _Closed (all inflight drained / hard_close)
 _ConnectionNone → _Open (server) → _Closing → _Closed
 ```
 
 | State | `is_open()` | `is_closed()` | Description |
 |---|---|---|---|
 | `_ConnectionNone` | false | false | Before `_finish_initialization`. All methods call `_Unreachable()`. |
-| `_ClientConnecting` | false | false | Happy Eyeballs in progress. Has `_pending_close` flag for `close()` during connecting. |
+| `_ClientConnecting` | false | false | Happy Eyeballs in progress. `close()` transitions to `_UnconnectedClosing`. |
+| `_UnconnectedClosing` | false | true | Draining inflight Happy Eyeballs after `close()` during connecting. Fires `_on_connection_failure` when all drain. `hard_close()` short-circuits to `_Closed`. |
 | `_Open` | true | false | Connection established, I/O active. |
 | `_Closing` | false | true | Graceful shutdown in progress — waiting for peer FIN. Still reads to detect FIN. |
 | `_Closed` | false | true | Fully closed. Handles straggler event cleanup only. |

--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -48,30 +48,19 @@ class _ConnectionNone is _ConnectionState
   fun is_closed(): Bool => false
 
 class _ClientConnecting is _ConnectionState
-  var _pending_close: Bool = false
-
   fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
     _Unreachable()
 
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
     flags: U32, arg: U32)
   =>
-    if not AsioEvent.writeable(flags) then return end
-
-    let fd = PonyAsio.event_fd(event)
-    let remaining = conn._decrement_inflight()
-
-    if _pending_close then
-      // Straggler cleanup during close — don't establish, just clean up
-      conn._straggler_cleanup(event)
-
-      if remaining == 0 then
-        // All inflight drained — fire failure and transition
-        conn._set_state(_Closed)
-        conn._hard_close_connecting()
-      end
+    if PonyAsio.get_disposable(event) then return end
+    if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
       return
     end
+
+    let fd = PonyAsio.event_fd(event)
+    conn._decrement_inflight()
 
     if conn._is_socket_connected(fd) then
       conn._establish_connection(event, fd)
@@ -85,7 +74,7 @@ class _ClientConnecting is _ConnectionState
     SendErrorNotConnected
 
   fun ref close(conn: TCPConnection ref) =>
-    _pending_close = true
+    conn._set_state(_UnconnectedClosing)
 
   fun ref hard_close(conn: TCPConnection ref) =>
     conn._set_state(_Closed)
@@ -125,7 +114,10 @@ class _Open is _ConnectionState
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
     flags: U32, arg: U32)
   =>
-    if not AsioEvent.writeable(flags) then return end
+    if PonyAsio.get_disposable(event) then return end
+    if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
+      return
+    end
 
     // Happy Eyeballs straggler — clean up
     conn._decrement_inflight()
@@ -178,7 +170,10 @@ class _Closing is _ConnectionState
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
     flags: U32, arg: U32)
   =>
-    if not AsioEvent.writeable(flags) then return end
+    if PonyAsio.get_disposable(event) then return end
+    if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
+      return
+    end
 
     // Happy Eyeballs straggler — clean up
     conn._decrement_inflight()
@@ -211,6 +206,55 @@ class _Closing is _ConnectionState
   fun is_open(): Bool => false
   fun is_closed(): Bool => true
 
+class _UnconnectedClosing is _ConnectionState
+  """
+  Draining inflight Happy Eyeballs connections after close() during the
+  connecting phase. The failure callback is deferred until all inflight
+  connections drain. hard_close() can interrupt this drain (e.g., connection
+  timeout fires during drain), transitioning to _Closed immediately.
+  """
+  fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
+    _Unreachable()
+
+  fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
+    flags: U32, arg: U32)
+  =>
+    if PonyAsio.get_disposable(event) then return end
+    if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
+      return
+    end
+
+    let remaining = conn._decrement_inflight()
+    conn._straggler_cleanup(event)
+
+    if remaining == 0 then
+      conn._set_state(_Closed)
+      conn._hard_close_connecting()
+    end
+
+  fun ref send(conn: TCPConnection ref,
+    data: (ByteSeq | ByteSeqIter)): (SendToken | SendError)
+  =>
+    SendErrorNotConnected
+
+  fun ref close(conn: TCPConnection ref) =>
+    None
+
+  fun ref hard_close(conn: TCPConnection ref) =>
+    conn._set_state(_Closed)
+    conn._hard_close_connecting()
+
+  fun ref start_tls(conn: TCPConnection ref, ssl_ctx: SSLContext val,
+    host: String): (None | StartTLSError)
+  =>
+    StartTLSNotConnected
+
+  fun ref read_again(conn: TCPConnection ref) =>
+    None
+
+  fun is_open(): Bool => false
+  fun is_closed(): Bool => true
+
 class _Closed is _ConnectionState
   fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
     None
@@ -218,9 +262,13 @@ class _Closed is _ConnectionState
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
     flags: U32, arg: U32)
   =>
-    if not AsioEvent.writeable(flags) then return end
+    if PonyAsio.get_disposable(event) then return end
+    if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
+      return
+    end
 
     // Happy Eyeballs straggler — clean up
+    conn._decrement_inflight()
     conn._straggler_cleanup(event)
 
   fun ref send(conn: TCPConnection ref,

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -626,10 +626,10 @@ class TCPConnection
     """
     Attempt to perform a graceful shutdown. Don't accept new writes.
 
-    During the connecting phase (Happy Eyeballs in progress), marks the
-    connection as closed so straggler events clean up instead of establishing
-    a connection. Once all in-flight connections have drained,
-    `_on_connection_failure` fires.
+    During the connecting phase (Happy Eyeballs in progress), transitions to
+    `_UnconnectedClosing` to drain inflight connection attempts. Each
+    straggler event is cleaned up as it arrives. Once all inflight connections
+    have drained, `_on_connection_failure` fires.
 
     If the connection is established and not muted, we won't finish closing
     until we get a zero length read. If the connection is muted, perform a


### PR DESCRIPTION
Three bugs caused FD and ASIO event leaks when close/hard_close fired during the connecting phase:

1. The writeable-only guard in `foreign_event` handlers dropped error-only events on Linux (`EPOLLERR`/`EPOLLHUP` maps to `ASIO_READ` without `ASIO_WRITE`), so straggler cleanup never ran.
2. `_Closed.foreign_event()` didn't decrement `_inflight_connections`.
3. On macOS, failed sockets produce two kqueue events per socket. The old writeable guard accidentally prevented double-processing; the new readable-or-writeable guard needs a separate `get_disposable` check.

Replaces the `_pending_close` flag on `_ClientConnecting` with an explicit `_UnconnectedClosing` state class. Adds `PonyAsio.get_disposable()` + readable-or-writeable guards to all `foreign_event` handlers.

Design: #219
Closes #244