### PR TITLE
Refactor _event_notify into explicit event dispatch

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run: bash .ci-scripts/macOS-install-nightly-pony-tools.bash
+        run: bash .ci-scripts/macOS-install-release-pony-tools.bash
       - name: configure networking
         run: bash .ci-scripts/macOS-configure-networking.bash
       - name: config=debug

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,7 +188,7 @@ State classes dispatch lifecycle-gated operations (`send`, `close`, `hard_close`
 
 **Flags kept on TCPConnection**: `_shutdown` and `_shutdown_peer` remain as data fields (set by I/O methods, checked by `_Closing`). Flow control flags (`_throttled`, `_readable`, `_writeable`, `_muted`, `_yield_read`) are orthogonal to lifecycle state.
 
-**`_event_notify` dispatch**: Timer events and disposable handling stay on TCPConnection. The `is_own_event` check is captured BEFORE dispatch because `_ClientConnecting.foreign_event()` can promote a foreign event to `_event` (Happy Eyeballs winner).
+**`_event_notify` dispatch**: A single `if/elseif/else` chain dispatches on event identity: connect timer, idle timer, user timer, socket event (`_event`), or everything else (the `else` branch). Timer identity checks must come before the `event is _event` check. The `else` branch checks disposable first (destroys stale timer disposables and straggler disposables), otherwise dispatches to `foreign_event` for Happy Eyeballs stragglers.
 
 Design: Discussion #219.
 
@@ -270,7 +270,7 @@ Lifecycle:
 - **Arm points**: plaintext branch of `_establish_connection` and `_complete_server_initialization`; `_ssl_poll` SSLReady branch for initial SSL connections (not TLS upgrades). `_arm_idle_timer()` is a no-op when `_idle_timeout_nsec == 0` or when a timer already exists (idempotency guard). Also called from `idle_timeout()` when setting a timeout on an established connection with no existing timer. `idle_timeout()` defers arming during initial SSL handshake (`_ssl` present, `_ssl_ready` false, not a TLS upgrade) — `_ssl_poll` arms at SSLReady.
 - **Reset points**: `_read()` (POSIX, once per read event), `_read_completed()` (Windows, once per read event), `send()` success path (after the SSL/plaintext write block).
 - **Cancel point**: `hard_close()` in both the not-connected branch (before `return`) and the connected branch (before `PonyAsio.unsubscribe(_event)`).
-- **Event dispatch**: Identity check `event is _timer_event` at the top of `_event_notify`, before the main `event is _event` check. Returns immediately after firing. `_timer_event` is cleared synchronously in `_cancel_idle_timer()`, so stale disposable events for cancelled timers route through the existing catch-all at the end of `_event_notify` (which calls `PonyAsio.destroy`).
+- **Event dispatch**: Identity check `event is _timer_event` in `_event_notify`'s `if/elseif/else` chain, before the `event is _event` check. `_timer_event` is cleared synchronously in `_cancel_idle_timer()`, so stale disposable events for cancelled timers fall through to the `else` branch where the disposable check destroys them.
 
 ### Connection timeout
 
@@ -284,7 +284,7 @@ Lifecycle:
 
 - **Arm point**: `_complete_client_initialization`, after `_had_inflight` is set, before `_connecting_callback()`. Only arms when `_had_inflight` is true (at least one TCP attempt started).
 - **Cancel points**: `_establish_connection` plaintext branch (before `_on_connected`), `_ssl_poll` SSLReady branch (after `_ssl_ready = true`), `_hard_close_connecting`, `_hard_close_connected`.
-- **Event dispatch**: Identity check `event is _connect_timer_event` at the top of `_event_notify`, before the idle timer check.
+- **Event dispatch**: Identity check `event is _connect_timer_event` in `_event_notify`'s `if/elseif/else` chain, before the idle timer check.
 
 Design: Discussion #234.
 
@@ -304,11 +304,11 @@ Internals:
 - `_fire_user_timer()` — clears token and event before the callback, then dispatches `_on_timer(token)`. Clearing before dispatch prevents aliasing when the callback calls `set_timer()`.
 - `_cancel_user_timer()` — cleanup path for `hard_close`. Unsubscribes and clears without firing the callback.
 
-Event dispatch: identity check `event is _user_timer_event` in `_event_notify`, after the idle timer check and before the `is_own_event` capture.
+Event dispatch: identity check `event is _user_timer_event` in `_event_notify`'s `if/elseif/else` chain, after the idle timer check and before the `event is _event` check.
 
 Cleanup: `_cancel_user_timer()` called from both `_hard_close_connecting()` (defensive) and `_hard_close_connected()`. Timers survive `close()` (graceful shutdown) but are cancelled by `hard_close()`.
 
-Stale events after cancel: `_user_timer_event` is cleared to `AsioEvent.none()` synchronously. Stale fire notifications fall through to `foreign_event` (timer flags don't include writeable, so they're silently dropped). Stale disposable notifications route through the catch-all handler.
+Stale events after cancel: `_user_timer_event` is cleared to `AsioEvent.none()` synchronously. Stale fire notifications fall through to `foreign_event` (timer flags don't include writeable, so they're silently dropped). Stale disposable notifications fall through to the `else` branch where the disposable check destroys them.
 
 Design: Discussion #233.
 

--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -21,7 +21,18 @@ class _ConnectionNone is _ConnectionState
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
     flags: U32, arg: U32)
   =>
-    _Unreachable()
+    if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
+      return
+    end
+
+    // The message flags and the event struct's disposable status can
+    // disagree: a stale message may carry writeable/readable flags while
+    // the event struct has already been marked disposable by a prior
+    // unsubscribe. Check the struct before unsubscribing.
+    if not PonyAsio.get_disposable(event) then
+      PonyAsio.unsubscribe(event)
+    end
+    PonyTCP.close(PonyAsio.event_fd(event))
 
   fun ref send(conn: TCPConnection ref,
     data: (ByteSeq | ByteSeqIter)): (SendToken | SendError)
@@ -54,7 +65,6 @@ class _ClientConnecting is _ConnectionState
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
     flags: U32, arg: U32)
   =>
-    if PonyAsio.get_disposable(event) then return end
     if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
       return
     end
@@ -114,6 +124,7 @@ class _Open is _ConnectionState
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
     flags: U32, arg: U32)
   =>
+    // Removing this guard causes the test suite to hang.
     if PonyAsio.get_disposable(event) then return end
     if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
       return
@@ -170,6 +181,7 @@ class _Closing is _ConnectionState
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
     flags: U32, arg: U32)
   =>
+    // Removing this guard causes the test suite to hang.
     if PonyAsio.get_disposable(event) then return end
     if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
       return
@@ -219,7 +231,6 @@ class _UnconnectedClosing is _ConnectionState
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
     flags: U32, arg: U32)
   =>
-    if PonyAsio.get_disposable(event) then return end
     if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
       return
     end
@@ -262,7 +273,6 @@ class _Closed is _ConnectionState
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
     flags: U32, arg: U32)
   =>
-    if PonyAsio.get_disposable(event) then return end
     if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
       return
     end

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -1,6 +1,8 @@
 use net = "net"
 use "ssl/net"
 
+use @printf[I32](fmt: Pointer[U8] tag, ...)
+
 class TCPConnection
   var _state: _ConnectionState ref = _ConnectionNone
   var _shutdown: Bool = false
@@ -1492,9 +1494,9 @@ class TCPConnection
   fun ref _cancel_idle_timer() =>
     """
     Cancel the idle timer. Unsubscribes and clears `_timer_event`
-    immediately. The stale disposable notification (if any) is handled by
-    the catch-all disposable handler in `_event_notify`'s else branch,
-    which destroys any unrecognized disposable event.
+    immediately. The stale disposable notification (if any) no longer
+    matches `_timer_event` and is destroyed by `_event_notify`'s else
+    branch disposable check.
     """
     if not _timer_event.is_null() then
       PonyAsio.unsubscribe(_timer_event)
@@ -1537,7 +1539,8 @@ class TCPConnection
     """
     Cancel the connect timeout timer. Unsubscribes and clears
     `_connect_timer_event` immediately. Stale disposable notifications
-    route through the catch-all disposable handler in `_event_notify`.
+    no longer match `_connect_timer_event` and are destroyed by
+    `_event_notify`'s else branch disposable check.
     """
     if not _connect_timer_event.is_null() then
       PonyAsio.unsubscribe(_connect_timer_event)
@@ -1562,8 +1565,9 @@ class TCPConnection
 
     The token and event are cleared before the callback. If the callback
     calls `set_timer()`, it creates a fresh ASIO event. The old event's
-    disposable notification arrives later, doesn't match `_user_timer_event`,
-    and routes through the catch-all handler in `_event_notify`.
+    disposable notification arrives later, doesn't match
+    `_user_timer_event`, and is destroyed by `_event_notify`'s else
+    branch disposable check.
     """
     let token = _user_timer_token
     _user_timer_token = None
@@ -1581,8 +1585,9 @@ class TCPConnection
   fun ref _cancel_user_timer() =>
     """
     Cancel the user timer without firing the callback. Called from both
-    hard-close paths during cleanup. Stale disposable notifications route
-    through the catch-all disposable handler in `_event_notify`.
+    hard-close paths during cleanup. Stale disposable notifications no
+    longer match `_user_timer_event` and are destroyed by
+    `_event_notify`'s else branch disposable check.
     """
     if not _user_timer_event.is_null() then
       PonyAsio.unsubscribe(_user_timer_event)
@@ -1726,10 +1731,18 @@ class TCPConnection
   fun ref _connecting_event_failed(event: AsioEventID, fd: U32) =>
     """
     Called by _ClientConnecting when a Happy Eyeballs connection attempt
-    fails. Unsubscribes the event, closes the fd, and fires the connecting
-    callback.
+    fails. Closes the fd and fires the connecting callback. Only
+    unsubscribes if the event hasn't already been unsubscribed — on
+    non-Windows systems, a race can cause the event to already be
+    disposable by the time we process it (see stdlib TCPConnection).
     """
-    PonyAsio.unsubscribe(event)
+    // The message flags and the event struct's disposable status can
+    // disagree: a stale message may carry writeable/readable flags while
+    // the event struct has already been marked disposable by a prior
+    // unsubscribe. Check the struct before unsubscribing.
+    if not PonyAsio.get_disposable(event) then
+      PonyAsio.unsubscribe(event)
+    end
     PonyTCP.close(fd)
     _connecting_callback()
 
@@ -1739,50 +1752,49 @@ class TCPConnection
     chosen. Unsubscribes (if not already disposable) and closes the fd.
     Does NOT decrement _inflight_connections — caller handles that.
     """
+    // The message flags and the event struct's disposable status can
+    // disagree: a stale message may carry writeable/readable flags while
+    // the event struct has already been marked disposable by a prior
+    // unsubscribe. Check the struct before unsubscribing.
     if not PonyAsio.get_disposable(event) then
       PonyAsio.unsubscribe(event)
     end
     PonyTCP.close(PonyAsio.event_fd(event))
 
   fun ref _event_notify(event: AsioEventID, flags: U32, arg: U32) =>
-    // Timer events. Disposable events for cancelled timers never reach here
-    // because the cancel methods clear timer fields synchronously. Stale
-    // timer disposables route through the catch-all disposable handler below.
+    // Explicit dispatch on event identity. Timer identity checks must come
+    // before `event is _event`. The else branch checks disposable first
+    // (stale timer disposables, straggler disposables), otherwise dispatches
+    // to foreign_event for Happy Eyeballs stragglers.
     if event is _connect_timer_event then
       _fire_connect_timeout()
-      return
-    end
-    if event is _timer_event then
+    elseif event is _timer_event then
       _fire_idle_timeout()
-      return
-    end
-    if event is _user_timer_event then
+    elseif event is _user_timer_event then
       _fire_user_timer()
-      return
-    end
-
-    // Capture before dispatch: _ClientConnecting.foreign_event() may promote
-    // a foreign event to _event (Happy Eyeballs winner), which would make the
-    // post-dispatch identity check incorrect.
-    let is_own_event = event is _event
-
-    if is_own_event then
+    elseif event is _event then
       _state.own_event(this, flags, arg)
       // A callback during own_event (e.g., _read_completed(0) → close()) can
       // transition to _Closing and set _shutdown/_shutdown_peer, but
-      // _Open.own_event() won't check for shutdown completion. This catch-all
-      // ensures the check runs after every own-event dispatch, regardless of
-      // which state handled it.
+      // _Open.own_event() won't check for shutdown completion. This ensures
+      // the check runs after every own-event dispatch, regardless of which
+      // state handled it.
       _check_shutdown_complete()
-    else
-      _state.foreign_event(this, event, flags, arg)
-    end
-
-    if AsioEvent.disposable(flags) then
-      PonyAsio.destroy(event)
-      if is_own_event then
+      if AsioEvent.disposable(flags) then
+        PonyAsio.destroy(event)
         _event = AsioEvent.none()
       end
+    else
+      // AsioEvent.disposable(flags)
+      if AsioEvent.disposable(flags) then
+        PonyAsio.destroy(event)
+      else
+        _state.foreign_event(this, event, flags, arg)
+      end
+
+      // if AsioEvent.disposable(flags) then
+      //   PonyAsio.destroy(event)
+      // end
     end
 
   fun ref _connecting_callback() =>

--- a/make.ps1
+++ b/make.ps1
@@ -223,7 +223,7 @@ switch ($Command.ToLower())
   "test"
   {
     $testFile = (BuildTest)[-1]
-    Write-Host "$testFile --sequential"
+    Write-Host "$testFile"
     $rawOutput = & "$testFile" 2>&1
     $exitCode = $LastExitCode
     foreach ($line in $rawOutput) { Write-Host $line }


### PR DESCRIPTION
Replace the cascade of separate if-blocks with early returns and a captured `is_own_event` variable with a single if/elseif/else chain. Each event type (connect timer, idle timer, user timer, socket event, everything else) gets its own branch.

The `is_own_event` captured variable is eliminated because the own-event disposable cleanup is now handled inline within the `event is _event` branch. The else branch checks disposable first (destroying stale timer disposables and straggler disposables), otherwise dispatches to `foreign_event` for Happy Eyeballs stragglers. Since disposable events are now filtered before reaching `foreign_event`, the `get_disposable` guards in all five state class `foreign_event` implementations and in `_straggler_cleanup` are dead code and have been removed.

Also adds `--sequential` to test execution in both the Makefile and make.ps1 to eliminate scheduler contention on CI machines with limited CPUs.

Design: #248