### PR TITLE
Eliminate _ssl_buffer_until to make invalid state unrepresentable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -194,18 +194,18 @@ Design: Discussion #219.
 
 ### SSL internals
 
-SSL state lives directly in `TCPConnection` (fields `_ssl`, `_ssl_ready`, `_ssl_failed`, `_ssl_buffer_until`, `_ssl_auth_failed`). Key behaviors:
+SSL state lives directly in `TCPConnection` (fields `_ssl`, `_ssl_ready`, `_ssl_failed`, `_ssl_auth_failed`). Key behaviors:
 
 - **0-to-N output per input on both sides:** Both read and write can produce zero, one, or many output chunks per input chunk. During handshake, output may be zero (buffered). A single TCP read containing multiple SSL records produces multiple decrypted chunks.
 - **`_ssl_poll()` pump:** Called after `ssl.receive()` in `_deliver_received()`. Checks SSL state, delivers decrypted data to the lifecycle event receiver, and flushes encrypted protocol data (handshake responses, etc.) via `_ssl_flush_sends()`.
 - **Client handshake initiation:** When TCP connects, `_ssl_flush_sends()` sends the ClientHello. The handshake proceeds via `_deliver_received()` → `ssl.receive()` → `_ssl_poll()`.
 - **Ready signaling:** `_ssl_ready` is set when `ssl.state()` returns `SSLReady`, which triggers `_on_connected`/`_on_started` delivery.
 - **Error handling:** `SSLAuthFail` sets `_ssl_auth_failed = true` then triggers `hard_close()`. `SSLError` triggers `hard_close()` directly. `hard_close()` reads `_ssl_auth_failed` to pass `TLSAuthFailed` vs `TLSGeneralError` to `_on_tls_failure` (for TLS upgrades), or `ConnectionFailedSSL`/`StartFailedSSL` to `_on_connection_failure`/`_on_start_failure` (for initial SSL). If the handshake never completed, clients get `_on_connection_failure(ConnectionFailedSSL)` and servers get `_on_start_failure(StartFailedSSL)`.
-- **Buffer-until handling:** The application's `buffer_until()` value is stored in `_ssl_buffer_until` as `(BufferSize | Streaming)` and converted to `USize` at the `ssl.read()` call site (0 for `Streaming`). The TCP read layer uses `Streaming` (read all available) since SSL record framing doesn't align with application framing.
+- **Buffer-until handling:** The `_buffer_until` field always holds the user's requested value. The TCP read layer uses `_tcp_buffer_until()`, which returns `Streaming` when `_ssl` is non-None (SSL record framing doesn't align with application framing). `_ssl_poll()` reads `_buffer_until` directly, converting to `USize` at the `ssl.read()` call site (0 for `Streaming`).
 
 ### TLS upgrade (STARTTLS)
 
-`start_tls(ssl_ctx, host)` upgrades an established plaintext connection to TLS. It creates an SSL session, migrates buffer-until state (`_ssl_buffer_until = _buffer_until; _buffer_until = Streaming`), sets `_tls_upgrade = true`, and flushes the ClientHello. The `_tls_upgrade` flag distinguishes "initial SSL from constructor" vs "upgraded SSL from start_tls()":
+`start_tls(ssl_ctx, host)` upgrades an established plaintext connection to TLS. It creates an SSL session, sets `_tls_upgrade = true`, and flushes the ClientHello. No buffer-until migration is needed — `_tcp_buffer_until()` automatically returns `Streaming` once `_ssl` is set. The `_tls_upgrade` flag distinguishes "initial SSL from constructor" vs "upgraded SSL from start_tls()":
 
 - **`_ssl_poll()`**: When `SSLReady` is reached and `_tls_upgrade` is true, calls `_on_tls_ready()` instead of `_on_connected()`/`_on_started()`.
 - **`hard_close()`**: When SSL handshake is incomplete and `_tls_upgrade` is true, calls `_on_tls_failure(reason)` (where `reason` is `TLSAuthFailed` or `TLSGeneralError` based on `_ssl_auth_failed`) then `_on_closed()` (the application already knew about the plaintext connection). Without `_tls_upgrade`, the initial-SSL path fires `_on_connection_failure(ConnectionFailedSSL)`/`_on_start_failure(StartFailedSSL)` instead.
@@ -328,7 +328,7 @@ API:
 - `resize_read_buffer(size: ReadBufferSize)` — forces buffer to exact size, lowers minimum if below it.
 - `buffer_until(qty: (BufferSize | Streaming))` — returns `BufferSizeAboveMinimum` if `qty` exceeds `_read_buffer_min`. `Streaming` means "deliver all available data."
 
-`_user_buffer_until()` returns the unwrapped buffer-until value as `USize` (0 when both `_buffer_until` and `_ssl_buffer_until` are `Streaming`) for invariant checks against buffer sizes.
+`_user_buffer_until()` returns the unwrapped buffer-until value as `USize` (0 when `Streaming`) for invariant checks against buffer sizes. `_tcp_buffer_until()` returns the value the TCP read layer should use — `Streaming` when SSL is active, otherwise `_buffer_until`.
 
 Shrink-back happens in `_resize_read_buffer_if_needed()` when `_bytes_in_read_buffer == 0` and `_read_buffer_size > _read_buffer_min`. On Windows, a post-loop call to `_resize_read_buffer_if_needed()` was added in `_read_completed()` and `_windows_resume_read()` because the existing calls inside the `while _there_is_buffered_read_data()` loop can never see `_bytes_in_read_buffer == 0`.
 

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -41,7 +41,6 @@ class TCPConnection
   var _ssl: (SSL ref | None) = None
   var _ssl_ready: Bool = false
   var _ssl_failed: Bool = false
-  var _ssl_buffer_until: (BufferSize | Streaming) = Streaming
   // Distinguishes "initial SSL from constructor" vs "upgraded SSL from
   // start_tls()". Used by _ssl_poll() and hard_close() to route to the
   // correct callbacks (_on_tls_ready/_on_tls_failure vs
@@ -577,19 +576,26 @@ class TCPConnection
   fun _user_buffer_until(): USize =>
     """
     The user's requested buffer-until value, regardless of whether SSL is
-    active. Internally, buffer-until is split across `_buffer_until` (non-SSL)
-    and `_ssl_buffer_until` (SSL), but invariant checks need the user's actual
-    requested value. Returns 0 when both are `Streaming`, since 0 < any valid
-    buffer min — the correct behavior for invariant checks when no buffer-until
-    constraint is active.
+    active. Returns 0 when `Streaming`, since 0 < any valid buffer min — the
+    correct behavior for invariant checks when no buffer-until constraint is
+    active.
     """
     match \exhaustive\ _buffer_until
     | let e: BufferSize => e()
-    | Streaming =>
-      match \exhaustive\ _ssl_buffer_until
-      | let e: BufferSize => e()
-      | Streaming => 0
-      end
+    | Streaming => 0
+    end
+
+  fun _tcp_buffer_until(): (BufferSize | Streaming) =>
+    """
+    The buffer-until value for the TCP read layer. When SSL is active, returns
+    `Streaming` because SSL record framing doesn't align with application
+    framing — the TCP layer reads all available data and lets `_ssl_poll()`
+    handle chunking via `_buffer_until`. When SSL is not active, returns the
+    user's `_buffer_until` value directly.
+    """
+    match _ssl
+    | let _: SSL box => Streaming
+    | None => _buffer_until
     end
 
   fun ref buffer_until(qty: (BufferSize | Streaming)): BufferUntilResult =>
@@ -610,16 +616,7 @@ class TCPConnection
 
     match \exhaustive\ _lifecycle_event_receiver
     | let _: EitherLifecycleEventReceiver =>
-      match \exhaustive\ _ssl
-      | let _: SSL ref =>
-        // Store the application's buffer-until value for SSL read chunking.
-        // Tell the TCP read layer to read all available (Streaming) since SSL
-        // record framing doesn't align with application framing.
-        _ssl_buffer_until = qty
-        _buffer_until = Streaming
-      | None =>
-        _buffer_until = qty
-      end
+      _buffer_until = qty
     | None =>
       _Unreachable()
     end
@@ -862,8 +859,6 @@ class TCPConnection
       return StartTLSSessionFailed
     end
 
-    _ssl_buffer_until = _buffer_until
-    _buffer_until = Streaming
     _tls_upgrade = true
     _ssl = consume ssl
     _ssl_ready = false
@@ -1191,7 +1186,7 @@ class TCPConnection
 
             // Handle any data already in the read buffer
             while not _muted and _there_is_buffered_read_data() do
-              let bytes_to_consume = match \exhaustive\ _buffer_until
+              let bytes_to_consume = match \exhaustive\ _tcp_buffer_until()
               | let e: BufferSize => e()
               | Streaming => _bytes_in_read_buffer
               end
@@ -1287,7 +1282,7 @@ class TCPConnection
         while not _muted and _there_is_buffered_read_data()
         do
           // get data to be distributed and update `_bytes_in_read_buffer`
-          let chop_at = match \exhaustive\ _buffer_until
+          let chop_at = match \exhaustive\ _tcp_buffer_until()
           | let e: BufferSize => e()
           | Streaming => _bytes_in_read_buffer
           end
@@ -1338,7 +1333,7 @@ class TCPConnection
       match \exhaustive\ _lifecycle_event_receiver
       | let s: EitherLifecycleEventReceiver ref =>
         while not _muted and _there_is_buffered_read_data() do
-          let chop_at = match \exhaustive\ _buffer_until
+          let chop_at = match \exhaustive\ _tcp_buffer_until()
           | let e: BufferSize => e()
           | Streaming => _bytes_in_read_buffer
           end
@@ -1372,7 +1367,7 @@ class TCPConnection
     end
 
   fun _there_is_buffered_read_data(): Bool =>
-    match \exhaustive\ _buffer_until
+    match \exhaustive\ _tcp_buffer_until()
     | let e: BufferSize => _bytes_in_read_buffer >= e()
     | Streaming => _bytes_in_read_buffer > 0
     end
@@ -1382,7 +1377,7 @@ class TCPConnection
     Resize the read buffer if it's smaller than the buffer-until threshold, or
     shrink it back to the minimum when empty and oversized.
     """
-    let needs_grow = match \exhaustive\ _buffer_until
+    let needs_grow = match \exhaustive\ _tcp_buffer_until()
     | let e: BufferSize => _read_buffer.size() <= e()
     | Streaming => _read_buffer.size() == 0
     end
@@ -1660,7 +1655,7 @@ class TCPConnection
       end
 
       // Read all available decrypted data
-      let ssl_read_buffer_until: USize = match \exhaustive\ _ssl_buffer_until
+      let ssl_read_buffer_until: USize = match \exhaustive\ _buffer_until
       | let e: BufferSize => e()
       | Streaming => 0
       end


### PR DESCRIPTION
The `_buffer_until` and `_ssl_buffer_until` fields were both `(BufferSize | Streaming)` with an invariant that at most one could be `BufferSize` — but the type system didn't enforce it. The invalid `(BufferSize, BufferSize)` state was technically representable.

This replaces the two fields with one. `_buffer_until` now always holds the user's requested value. A new `_tcp_buffer_until()` helper derives the TCP read layer's value at read time: `Streaming` when `_ssl` is non-None (SSL handles framing), otherwise `_buffer_until`. One field means no invalid state.

Simplifies `buffer_until()`, `start_tls()`, and `_user_buffer_until()` as a consequence — the setter routing, migration lines, and nested match are all unnecessary with a single field.

Closes #216