### PR TITLE
Push SSL handshake state into the connection state machine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,14 +53,14 @@ lori/
   pony_asio.pony            -- FFI wrappers for pony_asio_event_* functions
   ossocket.pony             -- _OSSocket: getsockopt/setsockopt wrappers
   ossocketopt.pony          -- OSSockOpt: socket option constants (large, generated)
-  _connection_state.pony    -- _ConnectionState trait and lifecycle state classes
+  _connection_state.pony    -- _ConnectionState trait and lifecycle state classes (including _SSLHandshaking, _TLSUpgrading)
   _panics.pony              -- _Unreachable primitive for impossible states
   _test.pony                -- Test runner (Main only)
   _test_connection.pony     -- Connection basics, ping-pong, buffer_until, listener tests
   _test_flow_control.pony   -- Mute/unmute tests
   _test_send.pony           -- Send, sendv, send-after-close tests
-  _test_ssl.pony            -- SSL ping-pong and SSL sendv tests
-  _test_start_tls.pony      -- STARTTLS upgrade and precondition tests
+  _test_ssl.pony            -- SSL ping-pong, SSL sendv, and SSL handshake state tests
+  _test_start_tls.pony      -- STARTTLS upgrade, precondition, TLS upgrade state, and TLS failure tests
   _test_close_while_connecting.pony -- Close/hard_close during connecting phase
   _test_idle_timeout.pony   -- Idle timeout (plaintext + SSL) tests
   _test_yield_read.pony     -- Yield read tests
@@ -167,26 +167,33 @@ TCPConnection uses explicit state objects (`_ConnectionState` trait in `_connect
 ```
 _ConnectionNone → _ClientConnecting → _Open → _Closing → _Closed
                                     ↘ _Closed (hard_close)
+_ClientConnecting → _SSLHandshaking → _Open (ssl_handshake_complete)
+                                    ↘ _Closed (hard_close / SSL error)
 _ClientConnecting → _UnconnectedClosing → _Closed (close, drain stragglers)
 _ClientConnecting → _Closed (hard_close / all connections failed)
 _UnconnectedClosing → _Closed (all inflight drained / hard_close)
-_ConnectionNone → _Open (server) → _Closing → _Closed
+_ConnectionNone → _Open (server, plaintext) → _Closing → _Closed
+_ConnectionNone → _SSLHandshaking (server, SSL) → _Open (ssl_handshake_complete)
+_Open → _TLSUpgrading (start_tls) → _Open (ssl_handshake_complete)
+                                   ↘ _Closed (hard_close / TLS error)
 ```
 
-| State | `is_open()` | `is_closed()` | Description |
-|---|---|---|---|
-| `_ConnectionNone` | false | false | Before `_finish_initialization`. All methods call `_Unreachable()`. |
-| `_ClientConnecting` | false | false | Happy Eyeballs in progress. `close()` transitions to `_UnconnectedClosing`. |
-| `_UnconnectedClosing` | false | true | Draining inflight Happy Eyeballs after `close()` during connecting. Fires `_on_connection_failure` when all drain. `hard_close()` short-circuits to `_Closed`. |
-| `_Open` | true | false | Connection established, I/O active. |
-| `_Closing` | false | true | Graceful shutdown in progress — waiting for peer FIN. Still reads to detect FIN. |
-| `_Closed` | false | true | Fully closed. Handles straggler event cleanup only. |
+| State | `is_open()` | `is_closed()` | `sends_allowed()` | Description |
+|---|---|---|---|---|
+| `_ConnectionNone` | false | false | false | Before `_finish_initialization`. All methods call `_Unreachable()`. |
+| `_ClientConnecting` | false | false | false | Happy Eyeballs in progress. `close()` transitions to `_UnconnectedClosing`. |
+| `_UnconnectedClosing` | false | true | false | Draining inflight Happy Eyeballs after `close()` during connecting. Fires `_on_connection_failure` when all drain. `hard_close()` short-circuits to `_Closed`. |
+| `_SSLHandshaking` | false | false | false | TCP connected, initial SSL handshake in progress. Application not notified yet. `close()` delegates to `hard_close()`. |
+| `_TLSUpgrading` | true | false | false | Established connection upgrading to TLS via `start_tls()`. Application already notified. `close()` delegates to `hard_close()`. |
+| `_Open` | true | false | true | Connection established, application notified, I/O active. |
+| `_Closing` | false | true | false | Graceful shutdown in progress — waiting for peer FIN. Still reads to detect FIN. |
+| `_Closed` | false | true | false | Fully closed. Handles straggler event cleanup only. |
 
-State classes dispatch lifecycle-gated operations (`send`, `close`, `hard_close`, `start_tls`, `read_again`, `own_event`, `foreign_event`) and delegate to TCPConnection methods for the actual work. All I/O, SSL, buffer, and flow control logic remains on TCPConnection.
+State classes dispatch lifecycle-gated operations (`send`, `close`, `hard_close`, `start_tls`, `read_again`, `ssl_handshake_complete`, `own_event`, `foreign_event`) and delegate to TCPConnection methods for the actual work. All I/O, SSL, buffer, and flow control logic remains on TCPConnection.
 
 **Private field access**: Pony restricts private field access to the defining type. State classes use helper methods on TCPConnection (`_set_state`, `_decrement_inflight`, `_establish_connection`, `_straggler_cleanup`, etc.) rather than accessing fields directly.
 
-**Flags kept on TCPConnection**: `_shutdown` and `_shutdown_peer` remain as data fields (set by I/O methods, checked by `_Closing`). Flow control flags (`_throttled`, `_readable`, `_writeable`, `_muted`, `_yield_read`) are orthogonal to lifecycle state.
+**Flags kept on TCPConnection**: `_shutdown` and `_shutdown_peer` remain as data fields (set by I/O methods, checked by `_Closing`). Flow control flags (`_throttled`, `_readable`, `_writeable`, `_muted`, `_yield_read`) are orthogonal to lifecycle state. SSL error flags (`_ssl_failed`, `_ssl_auth_failed`) remain as data fields for callback routing during hard-close. `_ssl_ready` is a one-shot guard in `_ssl_poll()` against persistent `SSLReady` — it prevents the handshake completion logic from re-executing on every read event after the handshake finishes. It is not a lifecycle state (the state machine handles that via `_SSLHandshaking` → `_Open`).
 
 **`_event_notify` dispatch**: A single `if/elseif/else` chain dispatches on event identity: connect timer, idle timer, user timer, socket event (`_event`), or everything else (the `else` branch). Timer identity checks must come before the `event is _event` check. The `else` branch checks disposable first (destroys stale timer disposables and straggler disposables), otherwise dispatches to `foreign_event` for Happy Eyeballs stragglers.
 
@@ -194,23 +201,32 @@ Design: Discussion #219.
 
 ### SSL internals
 
-SSL state lives directly in `TCPConnection` (fields `_ssl`, `_ssl_ready`, `_ssl_failed`, `_ssl_auth_failed`). Key behaviors:
+SSL handshake state is managed by the connection state machine: `_SSLHandshaking` (initial SSL from constructor) and `_TLSUpgrading` (mid-stream upgrade via `start_tls()`). Both transition to `_Open` when `ssl.state()` returns `SSLReady`, dispatched through `_state.ssl_handshake_complete()`. SSL error flags (`_ssl_failed`, `_ssl_auth_failed`) remain as data fields on `TCPConnection` for callback routing during hard-close. Key behaviors:
 
 - **0-to-N output per input on both sides:** Both read and write can produce zero, one, or many output chunks per input chunk. During handshake, output may be zero (buffered). A single TCP read containing multiple SSL records produces multiple decrypted chunks.
-- **`_ssl_poll()` pump:** Called after `ssl.receive()` in `_deliver_received()`. Checks SSL state, delivers decrypted data to the lifecycle event receiver, and flushes encrypted protocol data (handshake responses, etc.) via `_ssl_flush_sends()`.
-- **Client handshake initiation:** When TCP connects, `_ssl_flush_sends()` sends the ClientHello. The handshake proceeds via `_deliver_received()` → `ssl.receive()` → `_ssl_poll()`.
-- **Ready signaling:** `_ssl_ready` is set when `ssl.state()` returns `SSLReady`, which triggers `_on_connected`/`_on_started` delivery.
-- **Error handling:** `SSLAuthFail` sets `_ssl_auth_failed = true` then triggers `hard_close()`. `SSLError` triggers `hard_close()` directly. `hard_close()` reads `_ssl_auth_failed` to pass `TLSAuthFailed` vs `TLSGeneralError` to `_on_tls_failure` (for TLS upgrades), or `ConnectionFailedSSL`/`StartFailedSSL` to `_on_connection_failure`/`_on_start_failure` (for initial SSL). If the handshake never completed, clients get `_on_connection_failure(ConnectionFailedSSL)` and servers get `_on_start_failure(StartFailedSSL)`.
+- **`_ssl_poll()` pump:** Called after `ssl.receive()` in `_deliver_received()`. Checks SSL state via `ssl.state()`: `SSLReady` dispatches to `_state.ssl_handshake_complete()` (guarded by `_ssl_ready` to fire only once), `SSLAuthFail` sets `_ssl_auth_failed` then triggers `hard_close()`, `SSLError` triggers `hard_close()` directly. After state checks, delivers decrypted data to the lifecycle event receiver, and flushes encrypted protocol data (handshake responses, etc.) via `_ssl_flush_sends()`.
+- **Client handshake initiation:** When TCP connects, `_ssl_flush_sends()` sends the ClientHello. The state transitions from `_ClientConnecting` to `_SSLHandshaking`. The handshake proceeds via `_deliver_received()` → `ssl.receive()` → `_ssl_poll()`.
+- **Ready signaling:** `_SSLHandshaking.ssl_handshake_complete()` transitions to `_Open`, cancels the connect timer, arms the idle timer, and fires `_on_connected`/`_on_started`. `_TLSUpgrading.ssl_handshake_complete()` transitions to `_Open` and fires `_on_tls_ready()`. All other states have `_Unreachable()` — the `_ssl_ready` guard in `_ssl_poll()` ensures `ssl_handshake_complete` is only called once.
+- **Error handling:** Each handshake state has its own hard-close method. `_hard_close_ssl_handshaking()` fires `ConnectionFailedSSL`/`ConnectionFailedTimeout` (client) or `StartFailedSSL` (server). `_hard_close_tls_upgrading()` fires `_on_tls_failure(reason)` then `_on_closed()`. `_hard_close_connected()` (from `_Open`/`_Closing`) fires only `_on_closed()`.
 - **Buffer-until handling:** The `_buffer_until` field always holds the user's requested value. The TCP read layer uses `_tcp_buffer_until()`, which returns `Streaming` when `_ssl` is non-None (SSL record framing doesn't align with application framing). `_ssl_poll()` reads `_buffer_until` directly, converting to `USize` at the `ssl.read()` call site (0 for `Streaming`).
+- **`_enqueue` during handshake:** `_ssl_flush_sends()` pushes handshake protocol data via `_enqueue()`. The `_enqueue()` guard uses `not is_closed()` (not `is_open()`) to allow handshake data through `_SSLHandshaking` (where `is_open() = false`).
+
+Design: Discussion #252.
 
 ### TLS upgrade (STARTTLS)
 
-`start_tls(ssl_ctx, host)` upgrades an established plaintext connection to TLS. It creates an SSL session, sets `_tls_upgrade = true`, and flushes the ClientHello. No buffer-until migration is needed — `_tcp_buffer_until()` automatically returns `Streaming` once `_ssl` is set. The `_tls_upgrade` flag distinguishes "initial SSL from constructor" vs "upgraded SSL from start_tls()":
+`start_tls(ssl_ctx, host)` upgrades an established plaintext connection to TLS. It creates an SSL session, transitions to `_TLSUpgrading`, and flushes the ClientHello. No buffer-until migration is needed — `_tcp_buffer_until()` automatically returns `Streaming` once `_ssl` is set. The state distinguishes initial SSL from TLS upgrades:
 
-- **`_ssl_poll()`**: When `SSLReady` is reached and `_tls_upgrade` is true, calls `_on_tls_ready()` instead of `_on_connected()`/`_on_started()`.
-- **`hard_close()`**: When SSL handshake is incomplete and `_tls_upgrade` is true, calls `_on_tls_failure(reason)` (where `reason` is `TLSAuthFailed` or `TLSGeneralError` based on `_ssl_auth_failed`) then `_on_closed()` (the application already knew about the plaintext connection). Without `_tls_upgrade`, the initial-SSL path fires `_on_connection_failure(ConnectionFailedSSL)`/`_on_start_failure(StartFailedSSL)` instead.
+- **`_TLSUpgrading.ssl_handshake_complete()`**: Transitions to `_Open` and calls `_on_tls_ready()`. No timer arming — the idle timer is already running from the plaintext phase.
+- **`_TLSUpgrading.hard_close()`**: Calls `_hard_close_tls_upgrading()`, which fires `_on_tls_failure(reason)` (where `reason` is `TLSAuthFailed` or `TLSGeneralError` based on `_ssl_auth_failed`) then `_on_closed()` (the application already knew about the plaintext connection).
+- **`_TLSUpgrading.send()`**: Returns `SendErrorNotConnected` — sends are blocked during the TLS handshake.
+- **`_TLSUpgrading.close()`**: Delegates to `hard_close()` — can't send FIN during TLS handshake.
+- **`_TLSUpgrading.is_open()`**: Returns `true` — the application has already been notified. This allows `idle_timeout()` and `set_timer()` to work during TLS upgrades.
+- **`_TLSUpgrading.sends_allowed()`**: Returns `false` — prevents `is_writeable()` from returning true during handshake.
 
 Preconditions enforced synchronously: connection must be open, not already TLS, not muted, no buffered read data (CVE-2021-23222), no pending writes. Returns `StartTLSError` on failure (connection unchanged). The "no pending writes" check is platform-aware: on POSIX it checks `_has_pending_writes()` (any unconfirmed bytes); on Windows IOCP it checks for un-submitted data only (`_pending_data.size() > _pending_sent`), since submitted-but-unconfirmed writes are already in the kernel's send buffer.
+
+Design: Discussion #252.
 
 ### Send system
 
@@ -219,7 +235,7 @@ Preconditions enforced synchronously: connection must be open, not already TLS, 
 - `SendToken` — opaque token identifying the send operation. Delivered to `_on_sent(token)` when data is fully handed to the OS.
 - `SendErrorNotConnected` — connection not open (permanent).
 - `SendErrorNotWriteable` — socket under backpressure (transient, wait for `_on_unthrottled`).
-During SSL handshake (before `_on_connected`/`_on_started`, or before `_on_tls_ready` after `start_tls()`), returns `SendErrorNotConnected`.
+During SSL handshake (`_SSLHandshaking` or `_TLSUpgrading`), returns `SendErrorNotConnected` directly from the state class without reaching `_do_send()`.
 
 `send()` accepts a single buffer (`ByteSeq`) or multiple buffers (`ByteSeqIter`). When multiple buffers are provided, they are sent in a single writev syscall, avoiding per-buffer syscall overhead.
 
@@ -267,9 +283,9 @@ Per-connection idle timeout via ASIO timer events. The duration is an `IdleTimeo
 
 Lifecycle:
 
-- **Arm points**: plaintext branch of `_establish_connection` and `_complete_server_initialization`; `_ssl_poll` SSLReady branch for initial SSL connections (not TLS upgrades). `_arm_idle_timer()` is a no-op when `_idle_timeout_nsec == 0` or when a timer already exists (idempotency guard). Also called from `idle_timeout()` when setting a timeout on an established connection with no existing timer. `idle_timeout()` defers arming during initial SSL handshake (`_ssl` present, `_ssl_ready` false, not a TLS upgrade) — `_ssl_poll` arms at SSLReady.
+- **Arm points**: plaintext branch of `_establish_connection` and `_complete_server_initialization`; `_SSLHandshaking.ssl_handshake_complete()` for initial SSL connections. `_arm_idle_timer()` is a no-op when `_idle_timeout_nsec == 0` or when a timer already exists (idempotency guard). Also called from `idle_timeout()` when setting a timeout on an established connection with no existing timer. `idle_timeout()` gates on `is_open()` — `_SSLHandshaking.is_open() = false` blocks arming during initial SSL handshake, while `_TLSUpgrading.is_open() = true` allows it (timer continues from plaintext phase).
 - **Reset points**: `_read()` (POSIX, once per read event), `_read_completed()` (Windows, once per read event), `send()` success path (after the SSL/plaintext write block).
-- **Cancel point**: `hard_close()` in both the not-connected branch (before `return`) and the connected branch (before `PonyAsio.unsubscribe(_event)`).
+- **Cancel point**: `_hard_close_connecting()` and `_hard_close_cleanup()` (shared by all connected hard-close paths: `_hard_close_connected`, `_hard_close_ssl_handshaking`, `_hard_close_tls_upgrading`).
 - **Event dispatch**: Identity check `event is _timer_event` in `_event_notify`'s `if/elseif/else` chain, before the `event is _event` check. `_timer_event` is cleared synchronously in `_cancel_idle_timer()`, so stale disposable events for cancelled timers fall through to the `else` branch where the disposable check destroys them.
 
 ### Connection timeout
@@ -278,12 +294,12 @@ Optional one-shot ASIO timer that bounds the connect-to-ready phase for client c
 
 - `_connect_timer_event: AsioEventID` — the ASIO timer event, `AsioEvent.none()` when inactive.
 - `_connect_timeout_nsec: U64` — configured timeout in nanoseconds, 0 when disabled.
-- `_connect_timed_out: Bool` — set by `_fire_connect_timeout()` before `hard_close()`, read by `_hard_close_connecting()` and `_hard_close_connected()` to route `ConnectionFailedTimeout`.
+- `_connect_timed_out: Bool` — set by `_fire_connect_timeout()` before `hard_close()`, read by `_hard_close_connecting()` and `_hard_close_ssl_handshaking()` to route `ConnectionFailedTimeout`.
 
 Lifecycle:
 
 - **Arm point**: `_complete_client_initialization`, after `_had_inflight` is set, before `_connecting_callback()`. Only arms when `_had_inflight` is true (at least one TCP attempt started).
-- **Cancel points**: `_establish_connection` plaintext branch (before `_on_connected`), `_ssl_poll` SSLReady branch (after `_ssl_ready = true`), `_hard_close_connecting`, `_hard_close_connected`.
+- **Cancel points**: `_establish_connection` plaintext branch (before `_on_connected`), `_SSLHandshaking.ssl_handshake_complete()` (before `_on_connected`/`_on_started`), `_hard_close_connecting`, `_hard_close_cleanup` (shared by all connected hard-close paths).
 - **Event dispatch**: Identity check `event is _connect_timer_event` in `_event_notify`'s `if/elseif/else` chain, before the idle timer check.
 
 Design: Discussion #234.
@@ -297,7 +313,7 @@ One-shot general-purpose timer per connection, independent of the idle timeout. 
 - `_user_timer_token: (TimerToken | None)` — the active timer's token, or `None`.
 
 API:
-- `set_timer(duration: TimerDuration): (TimerToken | SetTimerError)` — creates a one-shot timer. Returns `SetTimerNotOpen` if not application-level connected (includes initial SSL handshake). Returns `SetTimerAlreadyActive` if a timer is already active. TLS upgrades do not block timer creation.
+- `set_timer(duration: TimerDuration): (TimerToken | SetTimerError)` — creates a one-shot timer. Returns `SetTimerNotOpen` if `is_open()` is false (`_SSLHandshaking.is_open() = false` blocks during initial SSL handshake; `_TLSUpgrading.is_open() = true` allows during TLS upgrades). Returns `SetTimerAlreadyActive` if a timer is already active.
 - `cancel_timer(token: TimerToken)` — cancels the timer if the token matches. No-op for stale/wrong tokens. No connection state check (can cancel during `_Closing`).
 
 Internals:
@@ -306,7 +322,7 @@ Internals:
 
 Event dispatch: identity check `event is _user_timer_event` in `_event_notify`'s `if/elseif/else` chain, after the idle timer check and before the `event is _event` check.
 
-Cleanup: `_cancel_user_timer()` called from both `_hard_close_connecting()` (defensive) and `_hard_close_connected()`. Timers survive `close()` (graceful shutdown) but are cancelled by `hard_close()`.
+Cleanup: `_cancel_user_timer()` called from `_hard_close_connecting()` (defensive) and `_hard_close_cleanup()` (shared by all connected hard-close paths). Timers survive `close()` (graceful shutdown) but are cancelled by `hard_close()`.
 
 Stale events after cancel: `_user_timer_event` is cleared to `AsioEvent.none()` synchronously. Stale fire notifications fall through to `foreign_event` (timer flags don't include writeable, so they're silently dropped). Stale disposable notifications fall through to the `else` branch where the disposable check destroys them.
 
@@ -370,11 +386,6 @@ Note: `keepalive()` predates these methods and uses `_state.is_open()` (updated 
 ### Platform differences
 
 POSIX and Windows (IOCP) have distinct code paths throughout `TCPConnection`, guarded by `ifdef posix`/`ifdef windows`. POSIX uses edge-triggered oneshot events with resubscription; Windows uses IOCP completion callbacks.
-
-## Future Work
-
-- **SSL state machine**: The lifecycle boolean flags (`_connected`, `_closed`) have been replaced by explicit state objects (Discussion #219), but SSL state (`_ssl_ready`, `_ssl_failed`, `_ssl_auth_failed`, `_tls_upgrade`) still uses boolean flags. A future iteration could introduce SSL-specific state objects. Design origin: Discussion #174.
-
 
 ## Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ test: unit-tests
 ci: unit-tests examples stress-tests
 
 unit-tests: $(tests_binary)
-	$^ --exclude=integration
+	$^ --exclude=integration --sequential
 
 test-one: $(tests_binary)
 	$^ --only="$(t)"

--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -11,8 +11,11 @@ trait _ConnectionState
   fun ref start_tls(conn: TCPConnection ref, ssl_ctx: SSLContext val,
     host: String): (None | StartTLSError)
   fun ref read_again(conn: TCPConnection ref)
+  fun ref ssl_handshake_complete(conn: TCPConnection ref,
+    s: EitherLifecycleEventReceiver ref)
   fun is_open(): Bool
   fun is_closed(): Bool
+  fun sends_allowed(): Bool
 
 class _ConnectionNone is _ConnectionState
   fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
@@ -55,8 +58,14 @@ class _ConnectionNone is _ConnectionState
   fun ref read_again(conn: TCPConnection ref) =>
     _Unreachable()
 
+  fun ref ssl_handshake_complete(conn: TCPConnection ref,
+    s: EitherLifecycleEventReceiver ref)
+  =>
+    _Unreachable()
+
   fun is_open(): Bool => false
   fun is_closed(): Bool => false
+  fun sends_allowed(): Bool => false
 
 class _ClientConnecting is _ConnectionState
   fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
@@ -98,28 +107,18 @@ class _ClientConnecting is _ConnectionState
   fun ref read_again(conn: TCPConnection ref) =>
     None
 
+  fun ref ssl_handshake_complete(conn: TCPConnection ref,
+    s: EitherLifecycleEventReceiver ref)
+  =>
+    _Unreachable()
+
   fun is_open(): Bool => false
   fun is_closed(): Bool => false
+  fun sends_allowed(): Bool => false
 
 class _Open is _ConnectionState
   fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
-    if AsioEvent.writeable(flags) then
-      conn._set_writeable()
-      ifdef windows then
-        conn._write_completed(arg)
-      else
-        conn._send_pending_writes()
-      end
-    end
-
-    if AsioEvent.readable(flags) then
-      conn._set_readable()
-      ifdef windows then
-        conn._read_completed(arg)
-      else
-        conn._read()
-      end
-    end
+    conn._dispatch_io_event(flags, arg)
 
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
     flags: U32, arg: U32)
@@ -155,28 +154,18 @@ class _Open is _ConnectionState
   fun ref read_again(conn: TCPConnection ref) =>
     conn._do_read_again()
 
+  fun ref ssl_handshake_complete(conn: TCPConnection ref,
+    s: EitherLifecycleEventReceiver ref)
+  =>
+    _Unreachable()
+
   fun is_open(): Bool => true
   fun is_closed(): Bool => false
+  fun sends_allowed(): Bool => true
 
 class _Closing is _ConnectionState
   fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
-    if AsioEvent.writeable(flags) then
-      conn._set_writeable()
-      ifdef windows then
-        conn._write_completed(arg)
-      else
-        conn._send_pending_writes()
-      end
-    end
-
-    if AsioEvent.readable(flags) then
-      conn._set_readable()
-      ifdef windows then
-        conn._read_completed(arg)
-      else
-        conn._read()
-      end
-    end
+    conn._dispatch_io_event(flags, arg)
 
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
     flags: U32, arg: U32)
@@ -215,8 +204,14 @@ class _Closing is _ConnectionState
   fun ref read_again(conn: TCPConnection ref) =>
     conn._do_read_again()
 
+  fun ref ssl_handshake_complete(conn: TCPConnection ref,
+    s: EitherLifecycleEventReceiver ref)
+  =>
+    _Unreachable()
+
   fun is_open(): Bool => false
   fun is_closed(): Bool => true
+  fun sends_allowed(): Bool => false
 
 class _UnconnectedClosing is _ConnectionState
   """
@@ -263,8 +258,14 @@ class _UnconnectedClosing is _ConnectionState
   fun ref read_again(conn: TCPConnection ref) =>
     None
 
+  fun ref ssl_handshake_complete(conn: TCPConnection ref,
+    s: EitherLifecycleEventReceiver ref)
+  =>
+    _Unreachable()
+
   fun is_open(): Bool => false
   fun is_closed(): Bool => true
+  fun sends_allowed(): Bool => false
 
 class _Closed is _ConnectionState
   fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
@@ -300,5 +301,126 @@ class _Closed is _ConnectionState
   fun ref read_again(conn: TCPConnection ref) =>
     None
 
+  fun ref ssl_handshake_complete(conn: TCPConnection ref,
+    s: EitherLifecycleEventReceiver ref)
+  =>
+    _Unreachable()
+
   fun is_open(): Bool => false
   fun is_closed(): Bool => true
+  fun sends_allowed(): Bool => false
+
+class _SSLHandshaking is _ConnectionState
+  """
+  TCP connected, initial SSL handshake in progress. The application has not
+  been notified yet — `_on_connected`/`_on_started` fires only after the
+  handshake completes.
+  """
+  fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
+    conn._dispatch_io_event(flags, arg)
+
+  fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
+    flags: U32, arg: U32)
+  =>
+    // Removing this guard causes the test suite to hang.
+    if PonyAsio.get_disposable(event) then return end
+    if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
+      return
+    end
+
+    // Happy Eyeballs straggler — clean up
+    conn._decrement_inflight()
+    conn._straggler_cleanup(event)
+
+  fun ref send(conn: TCPConnection ref,
+    data: (ByteSeq | ByteSeqIter)): (SendToken | SendError)
+  =>
+    SendErrorNotConnected
+
+  fun ref close(conn: TCPConnection ref) =>
+    // Can't drain gracefully during handshake — nothing to FIN.
+    conn.hard_close()
+
+  fun ref hard_close(conn: TCPConnection ref) =>
+    conn._set_state(_Closed)
+    conn._hard_close_ssl_handshaking()
+
+  fun ref start_tls(conn: TCPConnection ref, ssl_ctx: SSLContext val,
+    host: String): (None | StartTLSError)
+  =>
+    StartTLSNotConnected
+
+  fun ref read_again(conn: TCPConnection ref) =>
+    conn._do_read_again()
+
+  fun ref ssl_handshake_complete(conn: TCPConnection ref,
+    s: EitherLifecycleEventReceiver ref)
+  =>
+    conn._set_state(_Open)
+    conn._cancel_connect_timer()
+    conn._arm_idle_timer()
+    match \exhaustive\ s
+    | let c: ClientLifecycleEventReceiver ref =>
+      c._on_connected()
+    | let srv: ServerLifecycleEventReceiver ref =>
+      srv._on_started()
+    end
+
+  fun is_open(): Bool => false
+  fun is_closed(): Bool => false
+  fun sends_allowed(): Bool => false
+
+class _TLSUpgrading is _ConnectionState
+  """
+  Established connection upgrading to TLS via `start_tls()`. The application
+  has already been notified of the plaintext connection — `_on_tls_ready`
+  fires when the handshake completes.
+  """
+  fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
+    conn._dispatch_io_event(flags, arg)
+
+  fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
+    flags: U32, arg: U32)
+  =>
+    // Removing this guard causes the test suite to hang.
+    if PonyAsio.get_disposable(event) then return end
+    if not (AsioEvent.writeable(flags) or AsioEvent.readable(flags)) then
+      return
+    end
+
+    // Happy Eyeballs straggler — clean up
+    conn._decrement_inflight()
+    conn._straggler_cleanup(event)
+
+  fun ref send(conn: TCPConnection ref,
+    data: (ByteSeq | ByteSeqIter)): (SendToken | SendError)
+  =>
+    SendErrorNotConnected
+
+  fun ref close(conn: TCPConnection ref) =>
+    // Can't send FIN during TLS handshake.
+    conn.hard_close()
+
+  fun ref hard_close(conn: TCPConnection ref) =>
+    conn._set_state(_Closed)
+    conn._hard_close_tls_upgrading()
+
+  fun ref start_tls(conn: TCPConnection ref, ssl_ctx: SSLContext val,
+    host: String): (None | StartTLSError)
+  =>
+    StartTLSAlreadyTLS
+
+  fun ref read_again(conn: TCPConnection ref) =>
+    conn._do_read_again()
+
+  fun ref ssl_handshake_complete(conn: TCPConnection ref,
+    s: EitherLifecycleEventReceiver ref)
+  =>
+    // TLS upgrade handshake complete — no timer arm needed (timer is
+    // already running from the plaintext phase).
+    conn._set_state(_Open)
+    s._on_tls_ready()
+
+  fun is_open(): Bool => true
+  fun is_closed(): Bool => false
+  fun sends_allowed(): Bool => false

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -73,3 +73,8 @@ actor \nodoc\ Main is TestList
     test(_TestTimerSurvivesClose)
     test(_TestSetTimerNotOpenDuringSSLHandshake)
     test(_TestSetTimerNotOpenDuringSSLHandshakeServer)
+    test(_TestSSLHandshakeFailureClient)
+    test(_TestSSLHandshakeFailureServer)
+    test(_TestSSLHandshakeCompleteTransitionsToOpen)
+    test(_TestStartTLSSendDuringUpgrade)
+    test(_TestStartTLSHandshakeFailure)

--- a/lori/_test_connection_timeout.pony
+++ b/lori/_test_connection_timeout.pony
@@ -148,7 +148,7 @@ class \nodoc\ iso _TestSSLConnectionTimeoutFires is UnitTest
   Test that the connection timeout fires during SSL handshake. Connects an
   ssl_client to a plain TCP server — TCP connects but the SSL handshake
   stalls because the server doesn't speak TLS. Exercises the
-  _hard_close_connected() timeout path (distinct from the plaintext
+  _hard_close_ssl_handshaking() timeout path (distinct from the plaintext
   _hard_close_connecting() path).
   """
   fun name(): String => "SSLConnectionTimeoutFires"
@@ -261,7 +261,7 @@ class \nodoc\ iso _TestSSLConnectionTimeoutCancelledOnConnect is UnitTest
   Test that the connect timer is cancelled when an SSL handshake completes.
   Connects an ssl_client to a proper SSL server with a long timeout and
   verifies _on_connected fires. Exercises the _cancel_connect_timer() call
-  in _ssl_poll() at the SSLReady branch.
+  in _SSLHandshaking.ssl_handshake_complete().
   """
   fun name(): String => "SSLConnectionTimeoutCancelledOnConnect"
 

--- a/lori/_test_ssl.pony
+++ b/lori/_test_ssl.pony
@@ -296,3 +296,357 @@ actor \nodoc\ _TestSSLSendvServer
     _h.assert_eq[String]("SSL Hello World", String.from_array(consume data))
     _h.complete_action("data verified")
     _tcp_connection.close()
+
+class \nodoc\ iso _TestSSLHandshakeFailureClient is UnitTest
+  """
+  Test that an SSL client whose handshake fails (peer sends garbage) gets
+  `_on_connection_failure(ConnectionFailedSSL)` via `_hard_close_ssl_handshaking`.
+  """
+  fun name(): String => "SSLHandshakeFailureClient"
+
+  fun apply(h: TestHelper) ? =>
+    let port = "9757"
+    let file_auth = FileAuth(h.env.root)
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(file_auth, "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(file_auth, "assets/cert.pem"),
+            FilePath(file_auth, "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    h.expect_action("client failure")
+
+    let listener = _TestSSLHandshakeFailureClientListener(
+      port, consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestSSLHandshakeFailureClientListener is TCPListenerActor
+  """
+  Plain TCP listener that accepts connections, sends garbage to break the
+  SSL handshake, and closes.
+  """
+  let _port: String
+  let _sslctx: SSLContext val
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _client: (_TestSSLHandshakeFailureSSLClient | None) = None
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _port = port
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      _port,
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestSSLHandshakeFailurePlainServer =>
+    _TestSSLHandshakeFailurePlainServer(fd, _h)
+
+  fun ref _on_closed() =>
+    try (_client as _TestSSLHandshakeFailureSSLClient).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestSSLHandshakeFailureSSLClient(
+      _port, _sslctx, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestSSLHandshakeFailureClientListener")
+
+actor \nodoc\ _TestSSLHandshakeFailurePlainServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  """
+  Plain TCP server that sends garbage bytes to break the SSL handshake.
+  """
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(fd: U32, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.server(
+      TCPServerAuth(_h.env.root),
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    _tcp_connection.send("XXXXXXXXXX")
+    _tcp_connection.close()
+
+actor \nodoc\ _TestSSLHandshakeFailureSSLClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  """
+  SSL client connecting to a plain TCP server. The handshake will fail.
+  """
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.ssl_client(
+      TCPConnectAuth(h.env.root),
+      sslctx,
+      "localhost",
+      port,
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _h.fail("Should not have connected")
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    match reason
+    | ConnectionFailedSSL =>
+      _h.complete_action("client failure")
+    else
+      _h.fail("Expected ConnectionFailedSSL")
+    end
+
+class \nodoc\ iso _TestSSLHandshakeFailureServer is UnitTest
+  """
+  Test that an SSL server whose handshake fails (peer sends garbage) gets
+  `_on_start_failure(StartFailedSSL)` via `_hard_close_ssl_handshaking`.
+  """
+  fun name(): String => "SSLHandshakeFailureServer"
+
+  fun apply(h: TestHelper) ? =>
+    let port = "9758"
+    let file_auth = FileAuth(h.env.root)
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(file_auth, "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(file_auth, "assets/cert.pem"),
+            FilePath(file_auth, "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    h.expect_action("server failure")
+
+    let listener = _TestSSLHandshakeFailureServerListener(
+      port, consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestSSLHandshakeFailureServerListener is TCPListenerActor
+  """
+  Listener that creates SSL servers. A plain TCP client connects and sends
+  garbage to break the SSL handshake.
+  """
+  let _port: String
+  let _sslctx: SSLContext val
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _client: (_TestSSLHandshakeFailurePlainClient | None) = None
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _port = port
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      _port,
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestSSLHandshakeFailureSSLServer =>
+    _TestSSLHandshakeFailureSSLServer(_sslctx, fd, _h)
+
+  fun ref _on_closed() =>
+    try (_client as _TestSSLHandshakeFailurePlainClient).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestSSLHandshakeFailurePlainClient(_port, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestSSLHandshakeFailureServerListener")
+
+actor \nodoc\ _TestSSLHandshakeFailureSSLServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  """
+  SSL server that receives garbage from a plain client. The handshake fails.
+  """
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(sslctx: SSLContext val, fd: U32, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.ssl_server(
+      TCPServerAuth(_h.env.root),
+      sslctx,
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    _h.fail("Should not have started")
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    match reason
+    | StartFailedSSL =>
+      _h.complete_action("server failure")
+    end
+
+actor \nodoc\ _TestSSLHandshakeFailurePlainClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  """
+  Plain TCP client that sends garbage to an SSL server.
+  """
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(port: String, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(h.env.root),
+      "localhost",
+      port,
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _tcp_connection.send("XXXXXXXXXX")
+    _tcp_connection.close()
+
+class \nodoc\ iso _TestSSLHandshakeCompleteTransitionsToOpen is UnitTest
+  """
+  Test that after a successful SSL handshake, the connection is in _Open
+  state: is_open() returns true and send() returns a SendToken.
+  """
+  fun name(): String => "SSLHandshakeCompleteTransitionsToOpen"
+
+  fun apply(h: TestHelper) ? =>
+    let port = "9759"
+    let file_auth = FileAuth(h.env.root)
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(file_auth, "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(file_auth, "assets/cert.pem"),
+            FilePath(file_auth, "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    h.expect_action("is_open verified")
+    h.expect_action("send returns token")
+
+    let listener = _TestSSLTransitionToOpenListener(
+      port, consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestSSLTransitionToOpenListener is TCPListenerActor
+  let _port: String
+  let _sslctx: SSLContext val
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _client: (_TestSSLTransitionToOpenClient | None) = None
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _port = port
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      _port,
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestSSLTransitionToOpenServer =>
+    _TestSSLTransitionToOpenServer(_sslctx, fd, _h)
+
+  fun ref _on_closed() =>
+    try (_client as _TestSSLTransitionToOpenClient).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestSSLTransitionToOpenClient(_port, _sslctx, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestSSLTransitionToOpenListener")
+
+actor \nodoc\ _TestSSLTransitionToOpenClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.ssl_client(
+      TCPConnectAuth(h.env.root),
+      sslctx,
+      "localhost",
+      port,
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _h.assert_true(_tcp_connection.is_open(), "is_open should be true")
+    _h.complete_action("is_open verified")
+
+    match \exhaustive\ _tcp_connection.send("test")
+    | let _: SendToken =>
+      _h.complete_action("send returns token")
+    | let _: SendError =>
+      _h.fail("send() should return SendToken")
+    end
+    _tcp_connection.close()
+
+actor \nodoc\ _TestSSLTransitionToOpenServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(sslctx: SSLContext val, fd: U32, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.ssl_server(
+      TCPServerAuth(_h.env.root),
+      sslctx,
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection

--- a/lori/_test_start_tls.pony
+++ b/lori/_test_start_tls.pony
@@ -376,3 +376,264 @@ actor \nodoc\ _TestStartTLSPreconditionsListener is TCPListenerActor
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to open _TestStartTLSPreconditionsListener")
+
+class \nodoc\ iso _TestStartTLSSendDuringUpgrade is UnitTest
+  """
+  Test that send() returns SendErrorNotConnected during a TLS upgrade
+  handshake (state: _TLSUpgrading). After start_tls() succeeds, the
+  connection is in _TLSUpgrading where sends_allowed() = false.
+  """
+  fun name(): String => "StartTLSSendDuringUpgrade"
+
+  fun apply(h: TestHelper) ? =>
+    let port = "9760"
+    let file_auth = FileAuth(h.env.root)
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(file_auth, "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(file_auth, "assets/cert.pem"),
+            FilePath(file_auth, "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    h.expect_action("send blocked during upgrade")
+
+    let listener = _TestStartTLSSendDuringUpgradeListener(
+      port, consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestStartTLSSendDuringUpgradeClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _sslctx: SSLContext val
+  let _h: TestHelper
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _sslctx = sslctx
+    _h = h
+
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(h.env.root),
+      "localhost",
+      port,
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    // Initiate TLS upgrade
+    match _tcp_connection.start_tls(_sslctx, "localhost")
+    | None =>
+      // Now in _TLSUpgrading — send() should fail
+      match \exhaustive\ _tcp_connection.send("should fail")
+      | SendErrorNotConnected =>
+        _h.complete_action("send blocked during upgrade")
+      | let _: SendToken =>
+        _h.fail("send() should not return SendToken during TLS upgrade")
+      | let _: SendError =>
+        _h.fail("Expected SendErrorNotConnected, got other SendError")
+      end
+    | let _: StartTLSError =>
+      _h.fail("start_tls should have succeeded")
+    end
+
+actor \nodoc\ _TestStartTLSSendDuringUpgradeListener is TCPListenerActor
+  let _port: String
+  let _sslctx: SSLContext val
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _client: (_TestStartTLSSendDuringUpgradeClient | None) = None
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _port = port
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      _port,
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestDoNothingServerActor =>
+    _TestDoNothingServerActor(fd, _h)
+
+  fun ref _on_closed() =>
+    try
+      (_client as _TestStartTLSSendDuringUpgradeClient).dispose()
+    end
+
+  fun ref _on_listening() =>
+    _client = _TestStartTLSSendDuringUpgradeClient(
+      _port, _sslctx, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestStartTLSSendDuringUpgradeListener")
+
+class \nodoc\ iso _TestStartTLSHandshakeFailure is UnitTest
+  """
+  Test that a TLS upgrade handshake failure fires `_on_tls_failure` followed
+  by `_on_closed` via `_hard_close_tls_upgrading`. Client initiates STARTTLS,
+  the server replies "OK" and sends garbage instead of doing the TLS
+  handshake, causing the client's TLS upgrade to fail.
+  """
+  fun name(): String => "StartTLSHandshakeFailure"
+
+  fun apply(h: TestHelper) ? =>
+    let port = "9761"
+    let file_auth = FileAuth(h.env.root)
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(file_auth, "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(file_auth, "assets/cert.pem"),
+            FilePath(file_auth, "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    h.expect_action("tls failure received")
+    h.expect_action("on closed received")
+
+    let listener = _TestStartTLSHandshakeFailureListener(
+      port, consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestStartTLSHandshakeFailureClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  """
+  Plaintext client that negotiates STARTTLS, then upgrades. The server sends
+  garbage after "OK", so the TLS handshake fails.
+  """
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _sslctx: SSLContext val
+  let _h: TestHelper
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _sslctx = sslctx
+    _h = h
+
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(h.env.root),
+      "localhost",
+      port,
+      "",
+      this,
+      this)
+    match MakeBufferSize(2)
+    | let e: BufferSize => _tcp_connection.buffer_until(e)
+    end
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _tcp_connection.send("STARTTLS")
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    let msg = String.from_array(consume data)
+    if msg == "OK" then
+      match _tcp_connection.start_tls(_sslctx, "localhost")
+      | let _: StartTLSError =>
+        _h.fail("Client start_tls should have succeeded")
+      end
+    else
+      _h.fail("Client got unexpected: " + msg)
+    end
+
+  fun ref _on_tls_ready() =>
+    _h.fail("TLS handshake should not have succeeded")
+
+  fun ref _on_tls_failure(reason: TLSFailureReason) =>
+    _h.complete_action("tls failure received")
+
+  fun ref _on_closed() =>
+    _h.complete_action("on closed received")
+
+actor \nodoc\ _TestStartTLSHandshakeFailureServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  """
+  Plaintext server that responds to "STARTTLS" with "OK", waits for the
+  client's ClientHello (which arrives as binary data), then sends garbage
+  to break the TLS handshake. The wait ensures "OK" is consumed by the
+  client before garbage arrives, avoiding a `StartTLSHasBufferedData`
+  precondition failure (CVE-2021-23222 check).
+  """
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+  var _awaiting_client_hello: Bool = false
+
+  new create(fd: U32, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.server(
+      TCPServerAuth(_h.env.root),
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    if _awaiting_client_hello then
+      // Client sent a ClientHello — respond with garbage to break the
+      // handshake.
+      _tcp_connection.send("XXXXXXXXXX")
+      _tcp_connection.close()
+    else
+      let msg = String.from_array(consume data)
+      if msg == "STARTTLS" then
+        _tcp_connection.send("OK")
+        _awaiting_client_hello = true
+      end
+    end
+
+actor \nodoc\ _TestStartTLSHandshakeFailureListener is TCPListenerActor
+  let _port: String
+  let _sslctx: SSLContext val
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _client: (_TestStartTLSHandshakeFailureClient | None) = None
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _port = port
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      _port,
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestStartTLSHandshakeFailureServer =>
+    _TestStartTLSHandshakeFailureServer(fd, _h)
+
+  fun ref _on_closed() =>
+    try
+      (_client as _TestStartTLSHandshakeFailureClient).dispose()
+    end
+
+  fun ref _on_listening() =>
+    _client = _TestStartTLSHandshakeFailureClient(
+      _port, _sslctx, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestStartTLSHandshakeFailureListener")

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -41,17 +41,13 @@ class TCPConnection
   var _ssl: (SSL ref | None) = None
   var _ssl_ready: Bool = false
   var _ssl_failed: Bool = false
-  // Distinguishes "initial SSL from constructor" vs "upgraded SSL from
-  // start_tls()". Used by _ssl_poll() and hard_close() to route to the
-  // correct callbacks (_on_tls_ready/_on_tls_failure vs
-  // _on_connected/_on_started/_on_connection_failure/_on_start_failure).
-  var _tls_upgrade: Bool = false
   // Set when PonyTCP.connect returned > 0, meaning at least one TCP
   // connection attempt was made. Used by the failure callback to distinguish
   // DNS failure (no attempts) from TCP failure (all attempts failed).
   var _had_inflight: Bool = false
   // Set when _ssl_poll() sees SSLAuthFail before calling hard_close().
-  // hard_close() reads this to pass TLSAuthFailed vs TLSGeneralError.
+  // _hard_close_tls_upgrading() reads this to pass TLSAuthFailed vs
+  // TLSGeneralError.
   var _ssl_auth_failed: Bool = false
 
   // Per-connection idle timeout via ASIO timer
@@ -62,8 +58,8 @@ class TCPConnection
   var _connect_timer_event: AsioEventID = AsioEvent.none()
   var _connect_timeout_nsec: U64 = 0
   // COUPLING: Set by _fire_connect_timeout() before calling hard_close().
-  // Read by _hard_close_connecting() and _hard_close_connected() to route
-  // the failure reason to ConnectionFailedTimeout. Same pattern as
+  // Read by _hard_close_connecting() and _hard_close_ssl_handshaking() to
+  // route the failure reason to ConnectionFailedTimeout. Same pattern as
   // _ssl_auth_failed.
   var _connect_timed_out: Bool = false
 
@@ -370,20 +366,14 @@ class TCPConnection
     match \exhaustive\ duration
     | let t: IdleTimeout =>
       _idle_timeout_nsec = t() * 1_000_000
+      // _SSLHandshaking.is_open() = false blocks arming; the timer starts
+      // at ssl_handshake_complete. _TLSUpgrading.is_open() = true allows
+      // arming — the timer is already running from the plaintext phase.
       if _state.is_open() then
-        // Don't arm during initial SSL handshake — the timer would fire
-        // before _on_connected()/_on_started(). _ssl_poll will arm at
-        // SSLReady. TLS upgrades are excluded: the timer is already
-        // running from the plaintext phase and should be reset normally.
-        match _ssl
-        | let _: SSL ref if (not _ssl_ready) and (not _tls_upgrade) =>
-          None
+        if _timer_event.is_null() then
+          _arm_idle_timer()
         else
-          if _timer_event.is_null() then
-            _arm_idle_timer()
-          else
-            _reset_idle_timer()
-          end
+          _reset_idle_timer()
         end
       end
     | None =>
@@ -415,15 +405,10 @@ class TCPConnection
     The timer survives `close()` (graceful shutdown) but is cancelled by
     `hard_close()`.
     """
+    // _SSLHandshaking.is_open() = false blocks timers during initial SSL
+    // handshake. _TLSUpgrading.is_open() = true allows them — the
+    // application already received _on_connected/_on_started.
     if not is_open() then return SetTimerNotOpen end
-    // Don't allow during initial SSL handshake — the application hasn't
-    // received _on_connected/_on_started yet. TLS upgrades are excluded:
-    // the application already received _on_connected/_on_started for the
-    // plaintext connection.
-    match _ssl
-    | let _: SSL ref if (not _ssl_ready) and (not _tls_upgrade) =>
-      return SetTimerNotOpen
-    end
     if _user_timer_token isnt None then return SetTimerAlreadyActive end
 
     let nsec = duration() * 1_000_000
@@ -676,13 +661,17 @@ class TCPConnection
     _cancel_connect_timer()
     _cancel_user_timer()
 
-  fun ref _hard_close_connected() =>
+  fun ref _hard_close_cleanup() =>
     """
-    Hard close for an established connection. Fires `_on_send_failed` for
-    any pending token, clears pending buffers, cancels idle, connect, and
-    user timers, unsubscribes the event, closes the fd, disposes SSL, and
-    fires the appropriate lifecycle callbacks. The caller must set
-    `_state = _Closed` before calling this.
+    Common teardown for hard-closing an established connection. Handles
+    shutdown flags, send_failed for pending token, clearing pending buffers,
+    cancelling all timers, unsubscribing the event, closing the fd, and
+    disposing SSL. Order is load-bearing: timer cancel before event
+    unsubscribe, SSL dispose after fd close.
+
+    Does NOT set `_ssl = None` — the connection is terminal and nothing
+    accesses it afterward. The caller must set `_state = _Closed` before
+    calling this.
     """
     _shutdown = true
     _shutdown_peer = true
@@ -719,51 +708,11 @@ class TCPConnection
       ssl.dispose()
     end
 
-    match \exhaustive\ _lifecycle_event_receiver
-    | let s: EitherLifecycleEventReceiver ref =>
-      match \exhaustive\ _ssl
-      | let _: SSL ref =>
-        if not _ssl_ready then
-          // _tls_upgrade distinguishes initial SSL (constructor) from
-          // mid-stream TLS upgrade (start_tls). Changing _tls_upgrade
-          // semantics or removing it would break the callback routing
-          // here and in _ssl_poll().
-          if _tls_upgrade then
-            // TLS upgrade handshake failed. The application already received
-            // _on_connected/_on_started for the original plaintext connection,
-            // so _on_closed must follow for cleanup.
-            let reason = if _ssl_auth_failed then
-              TLSAuthFailed
-            else
-              TLSGeneralError
-            end
-            s._on_tls_failure(reason)
-            s._on_closed()
-          else
-            // Initial SSL handshake never completed. For clients, the
-            // application never learned the connection existed. For servers,
-            // the connection never started.
-            match \exhaustive\ s
-            | let c: ClientLifecycleEventReceiver ref =>
-              if _connect_timed_out then
-                c._on_connection_failure(ConnectionFailedTimeout)
-              else
-                c._on_connection_failure(ConnectionFailedSSL)
-              end
-            | let srv: ServerLifecycleEventReceiver ref =>
-              srv._on_start_failure(StartFailedSSL)
-            end
-          end
-        else
-          s._on_closed()
-        end
-      | None =>
-        s._on_closed()
-      end
-    | None =>
-      _Unreachable()
-    end
-
+  fun ref _spawner_notification() =>
+    """
+    Notify the spawning listener (if any) that this server connection has
+    closed. For client connections, this is a no-op.
+    """
     match _lifecycle_event_receiver
     | let e: ServerLifecycleEventReceiver ref =>
       match \exhaustive\ _spawned_by
@@ -777,6 +726,77 @@ class TCPConnection
       end
     end
 
+  fun ref _hard_close_connected() =>
+    """
+    Hard close for an established connection where the application has been
+    notified (i.e., _on_connected/_on_started has already fired). Only
+    reachable from `_Open` and `_Closing` — handshake states have their own
+    hard-close methods. Fires `_on_closed` and notifies the spawner. The
+    caller must set `_state = _Closed` before calling this.
+    """
+    _hard_close_cleanup()
+
+    match \exhaustive\ _lifecycle_event_receiver
+    | let s: EitherLifecycleEventReceiver ref =>
+      s._on_closed()
+    | None =>
+      _Unreachable()
+    end
+
+    _spawner_notification()
+
+  fun ref _hard_close_ssl_handshaking() =>
+    """
+    Hard close during the initial SSL handshake (state: `_SSLHandshaking`).
+    The application has not been notified — fires `_on_connection_failure`
+    (client) or `_on_start_failure` (server). The caller must set
+    `_state = _Closed` before calling this.
+    """
+    _hard_close_cleanup()
+
+    match \exhaustive\ _lifecycle_event_receiver
+    | let s: EitherLifecycleEventReceiver ref =>
+      match \exhaustive\ s
+      | let c: ClientLifecycleEventReceiver ref =>
+        if _connect_timed_out then
+          c._on_connection_failure(ConnectionFailedTimeout)
+        else
+          c._on_connection_failure(ConnectionFailedSSL)
+        end
+      | let srv: ServerLifecycleEventReceiver ref =>
+        srv._on_start_failure(StartFailedSSL)
+      end
+    | None =>
+      _Unreachable()
+    end
+
+    _spawner_notification()
+
+  fun ref _hard_close_tls_upgrading() =>
+    """
+    Hard close during a TLS upgrade handshake (state: `_TLSUpgrading`).
+    The application was already notified of the plaintext connection, so
+    `_on_tls_failure` fires followed by `_on_closed`. The caller must set
+    `_state = _Closed` before calling this.
+    """
+    _hard_close_cleanup()
+
+    let reason = if _ssl_auth_failed then
+      TLSAuthFailed
+    else
+      TLSGeneralError
+    end
+
+    match \exhaustive\ _lifecycle_event_receiver
+    | let s: EitherLifecycleEventReceiver ref =>
+      s._on_tls_failure(reason)
+      s._on_closed()
+    | None =>
+      _Unreachable()
+    end
+
+    _spawner_notification()
+
   fun is_open(): Bool =>
     _state.is_open()
 
@@ -786,17 +806,9 @@ class TCPConnection
   fun is_writeable(): Bool =>
     """
     Returns whether the connection can currently accept a `send()` call.
-    Checks that the connection is open, the socket is writeable, and any
-    SSL layer has completed its handshake.
+    Checks that the state allows sends and the socket is writeable.
     """
-    if not (is_open() and _writeable) then
-      return false
-    end
-
-    match \exhaustive\ _ssl
-    | let _: SSL box => _ssl_ready
-    | None => true
-    end
+    _state.sends_allowed() and _writeable
 
   fun ref start_tls(ssl_ctx: SSLContext val, host: String = ""):
     (None | StartTLSError)
@@ -859,9 +871,8 @@ class TCPConnection
       return StartTLSSessionFailed
     end
 
-    _tls_upgrade = true
     _ssl = consume ssl
-    _ssl_ready = false
+    _state = _TLSUpgrading
     _ssl_flush_sends()
     None
 
@@ -879,15 +890,10 @@ class TCPConnection
     _state.send(this, data)
 
   fun ref _do_send(data: (ByteSeq | ByteSeqIter)): (SendToken | SendError) =>
+    // Only reachable from _Open.send() — the handshake states return
+    // SendErrorNotConnected directly without calling this method.
     if not _writeable then
       return SendErrorNotWriteable
-    end
-
-    match _ssl
-    | let _: SSL ref =>
-      if not _ssl_ready then
-        return SendErrorNotConnected
-      end
     end
 
     _next_token_id = _next_token_id + 1
@@ -967,9 +973,14 @@ class TCPConnection
     Add a buffer to the pending write queue. Callers must call the
     platform-specific flush after enqueuing: `_send_pending_writes()` on
     POSIX, `_iocp_submit_pending()` on Windows.
+
+    Uses `not is_closed()` rather than `is_open()` because `_ssl_flush_sends()`
+    calls `_enqueue()` during `_SSLHandshaking` (where `is_open() = false`)
+    to push handshake protocol data. The wider guard allows handshake data
+    through while still blocking enqueue after the connection closes.
     """
     if data.size() == 0 then return end
-    if is_open() then
+    if not is_closed() then
       _pending_data.push(data)
       _pending_writev_total = _pending_writev_total + data.size()
     end
@@ -1623,27 +1634,7 @@ class TCPConnection
       | SSLReady =>
         if not _ssl_ready then
           _ssl_ready = true
-          _cancel_connect_timer()
-          // Arm idle timer now that the handshake is complete. Not for
-          // TLS upgrades — the timer is already running from the
-          // plaintext phase.
-          if not _tls_upgrade then
-            _arm_idle_timer()
-          end
-          // _tls_upgrade distinguishes initial SSL (constructor) from
-          // mid-stream TLS upgrade (start_tls). Changing _tls_upgrade
-          // semantics or removing it would break the callback routing
-          // here and in hard_close().
-          if _tls_upgrade then
-            s._on_tls_ready()
-          else
-            match \exhaustive\ s
-            | let c: ClientLifecycleEventReceiver ref =>
-              c._on_connected()
-            | let srv: ServerLifecycleEventReceiver ref =>
-              srv._on_started()
-            end
-          end
+          _state.ssl_handshake_complete(this, s)
         end
       | SSLAuthFail =>
         _ssl_auth_failed = true
@@ -1676,6 +1667,29 @@ class TCPConnection
   fun ref read_again() =>
     _state.read_again(this)
 
+  fun ref _dispatch_io_event(flags: U32, arg: U32) =>
+    """
+    Common I/O dispatch logic for socket events. Shared by all states that
+    have a connected socket and need to process I/O notifications.
+    """
+    if AsioEvent.writeable(flags) then
+      _set_writeable()
+      ifdef windows then
+        _write_completed(arg)
+      else
+        _send_pending_writes()
+      end
+    end
+
+    if AsioEvent.readable(flags) then
+      _set_readable()
+      ifdef windows then
+        _read_completed(arg)
+      else
+        _read()
+      end
+    end
+
   fun ref _do_read_again() =>
     ifdef posix then
       _read()
@@ -1693,21 +1707,23 @@ class TCPConnection
   fun ref _establish_connection(event: AsioEventID, fd: U32) =>
     """
     Called by _ClientConnecting when a Happy Eyeballs connection succeeds.
-    Promotes the event to the connection's own event, transitions to _Open,
-    and sets up the connection for I/O.
+    Promotes the event to the connection's own event, transitions to the
+    appropriate state, and sets up the connection for I/O.
     """
     _event = event
     _fd = fd
-    _state = _Open
     _set_writeable()
     _set_readable()
 
     match \exhaustive\ _ssl
     | let _: SSL ref =>
-      // Flush ClientHello to initiate SSL handshake
+      _state = _SSLHandshaking
+      // Flush ClientHello to initiate SSL handshake.
+      // _on_connected() and _arm_idle_timer() deferred until
+      // ssl_handshake_complete.
       _ssl_flush_sends()
-      // _on_connected() and _arm_idle_timer() deferred until _ssl_ready
     | None =>
+      _state = _Open
       _arm_idle_timer()
       _cancel_connect_timer()
       match _lifecycle_event_receiver
@@ -1887,16 +1903,18 @@ class TCPConnection
     match \exhaustive\ _enclosing
     | let e: TCPConnectionActor ref =>
       _event = PonyAsio.create_event(e, _fd)
-      _state = _Open
       _set_readable()
       _set_writeable()
 
       match \exhaustive\ _ssl
       | let _: SSL ref =>
-        // Flush any initial SSL data (usually no-op for servers)
+        _state = _SSLHandshaking
+        // Flush any initial SSL data (usually no-op for servers).
+        // _on_started() and _arm_idle_timer() deferred until
+        // ssl_handshake_complete.
         _ssl_flush_sends()
-        // _on_started() and _arm_idle_timer() deferred until _ssl_ready
       | None =>
+        _state = _Open
         _arm_idle_timer()
         s._on_started()
       end


### PR DESCRIPTION
Replace `_ssl_ready` and `_tls_upgrade` boolean flags with two explicit state classes: `_SSLHandshaking` (initial SSL from constructor) and `_TLSUpgrading` (mid-stream upgrade via `start_tls()`). Both transition to `_Open` when `ssl.state()` returns `SSLReady`, dispatched through the new `ssl_handshake_complete()` trait method.

Each handshake state has its own hard-close method with appropriate callback routing, eliminating the compound boolean checks that previously lived in `_hard_close_connected()` and `_ssl_poll()`.

Also extracts `_dispatch_io_event` (shared I/O logic for connected states), `_hard_close_cleanup` (common teardown), and `_spawner_notification` (spawner notification pattern) to support the new state classes without duplication.

Design: #252