### PR TITLE
Cache root .lib files instead of build/libs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,8 +65,11 @@ jobs:
         id: restore-libs
         uses: actions/cache@v5.0.3
         with:
-          path: build/libs
-          key: libs-windows-2025-${{ hashFiles('make.ps1') }}
+          path: |
+            ssl.lib
+            crypto.lib
+            tls.lib
+          key: rootlibs-windows-2025-${{ hashFiles('make.ps1') }}
       - name: build SSL libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
         run: .\make.ps1 -Command libs  2>&1;

--- a/.github/workflows/update-lib-cache.yml
+++ b/.github/workflows/update-lib-cache.yml
@@ -22,8 +22,11 @@ jobs:
         id: restore-libs
         uses: actions/cache@v5.0.3
         with:
-          path: build/libs
-          key: libs-windows-2025-${{ hashFiles('make.ps1') }}
+          path: |
+            ssl.lib
+            crypto.lib
+            tls.lib
+          key: rootlibs-windows-2025-${{ hashFiles('make.ps1') }}
       - name: build SSL libs
         if: steps.restore-libs.outputs.cache-hit != 'true'
         run: .\make.ps1 -Command libs  2>&1;


### PR DESCRIPTION
The Windows CI caches `build/libs` (the full LibreSSL source + build tree) but the linker needs `ssl.lib`, `crypto.lib`, and `tls.lib` in the project root. The copy from `build/libs/lib/` to the root only happens inside `BuildLibs`, which is skipped entirely on cache hit — so the link fails.

Cache the destination files directly. Key prefix changed from `libs-` to `rootlibs-` to invalidate stale caches that stored the old path layout.

Closes #256