### PR TITLE
Add tests for is_writeable() during SSL handshake

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,6 +19,8 @@ make config=debug ssl=3.0.x  # debug build
 
 Uses `corral` for dependency management. `make` automatically runs `corral fetch` before compiling.
 
+**Windows uses `make.ps1`, not the Makefile.** Both run tests with `--sequential`. When making build/test changes, update both files.
+
 ## Dependencies
 
 - `github.com/ponylang/ssl.git` — SSL/TLS support
@@ -395,6 +397,7 @@ POSIX and Windows (IOCP) have distinct code paths throughout `TCPConnection`, gu
 - Auth hierarchy: `AmbientAuth` > `NetAuth` > `TCPAuth` > `TCPListenAuth` > `TCPServerAuth`, with `TCPConnectAuth` as a separate leaf under `TCPAuth`
 - Core lifecycle callbacks are prefixed with `_on_` (private by convention)
 - Tests use hardcoded ports per test
+- Test listeners must store references to ALL actors created in `_on_accept` and `_on_listening`, and dispose every one of them in `_on_closed`. The Pony runtime won't exit while actors with live I/O resources exist, causing CI hangs (especially on macOS).
 - `\nodoc\` annotation on test classes
 - New tests go in the appropriate `_test_*.pony` file by functional area, not in `_test.pony` (which contains only the `Main` test runner). Register the test class in `Main.tests()` in `_test.pony`.
 - Examples have a file-level docstring explaining what they demonstrate

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -76,5 +76,7 @@ actor \nodoc\ Main is TestList
     test(_TestSSLHandshakeFailureClient)
     test(_TestSSLHandshakeFailureServer)
     test(_TestSSLHandshakeCompleteTransitionsToOpen)
+    test(_TestSSLIsWriteableDuringHandshake)
     test(_TestStartTLSSendDuringUpgrade)
+    test(_TestStartTLSIsWriteableDuringUpgrade)
     test(_TestStartTLSHandshakeFailure)

--- a/lori/_test_ssl.pony
+++ b/lori/_test_ssl.pony
@@ -650,3 +650,130 @@ actor \nodoc\ _TestSSLTransitionToOpenServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+class \nodoc\ iso _TestSSLIsWriteableDuringHandshake is UnitTest
+  """
+  Test that is_writeable() returns false during the initial SSL handshake
+  (state: _SSLHandshaking). A plain TCP client connects to an SSL server;
+  the server enters _SSLHandshaking but the handshake never completes
+  because the client doesn't speak TLS. The server calls check_writeable()
+  on itself from its constructor; both this and _finish_initialization are
+  self-sends (FIFO), so check_writeable fires after _finish_initialization
+  when the server is in _SSLHandshaking.
+  """
+  fun name(): String => "SSLIsWriteableDuringHandshake"
+
+  fun apply(h: TestHelper) ? =>
+    let port = "9763"
+    let file_auth = FileAuth(h.env.root)
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(file_auth, "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(file_auth, "assets/cert.pem"),
+            FilePath(file_auth, "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    h.expect_action("is_writeable false during ssl handshake")
+
+    let listener = _TestSSLIsWriteableListener(
+      port, consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestSSLIsWriteableListener is TCPListenerActor
+  let _port: String
+  let _sslctx: SSLContext val
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _client: (_TestSSLIsWriteablePlainClient | None) = None
+  var _server: (_TestSSLIsWriteableServer | None) = None
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _port = port
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      _port,
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestSSLIsWriteableServer =>
+    let server = _TestSSLIsWriteableServer(_sslctx, fd, _h)
+    _server = server
+    server
+
+  fun ref _on_closed() =>
+    try (_server as _TestSSLIsWriteableServer).dispose() end
+    try (_client as _TestSSLIsWriteablePlainClient).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestSSLIsWriteablePlainClient(_port, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestSSLIsWriteableListener")
+
+actor \nodoc\ _TestSSLIsWriteableServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  """
+  SSL server whose handshake stalls because the peer is a plain TCP client.
+  The constructor calls check_writeable() after creating the ssl_server
+  TCPConnection; both _finish_initialization (from the TCPConnection
+  constructor) and check_writeable are self-sends, so FIFO ordering
+  guarantees check_writeable fires in _SSLHandshaking.
+  """
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(sslctx: SSLContext val, fd: U32, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.ssl_server(
+      TCPServerAuth(_h.env.root),
+      sslctx,
+      fd,
+      this,
+      this)
+    check_writeable()
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  be check_writeable() =>
+    _h.assert_false(
+      _tcp_connection.is_writeable(),
+      "is_writeable should be false during SSL handshake")
+    _h.complete_action("is_writeable false during ssl handshake")
+    _tcp_connection.hard_close()
+
+  fun ref _on_started() =>
+    _h.fail("SSL handshake should not complete against plain TCP client")
+
+actor \nodoc\ _TestSSLIsWriteablePlainClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  """
+  Plain TCP client (no SSL) — the SSL server's handshake will stall.
+  """
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(port: String, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(_h.env.root),
+      "localhost",
+      port,
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection

--- a/lori/_test_start_tls.pony
+++ b/lori/_test_start_tls.pony
@@ -637,3 +637,105 @@ actor \nodoc\ _TestStartTLSHandshakeFailureListener is TCPListenerActor
 
   fun ref _on_listen_failure() =>
     _h.fail("Unable to open _TestStartTLSHandshakeFailureListener")
+
+class \nodoc\ iso _TestStartTLSIsWriteableDuringUpgrade is UnitTest
+  """
+  Test that is_writeable() returns false during a TLS upgrade handshake
+  (state: _TLSUpgrading). After start_tls() succeeds, the connection is
+  in _TLSUpgrading where sends_allowed() = false.
+  """
+  fun name(): String => "StartTLSIsWriteableDuringUpgrade"
+
+  fun apply(h: TestHelper) ? =>
+    let port = "9762"
+    let file_auth = FileAuth(h.env.root)
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(file_auth, "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(file_auth, "assets/cert.pem"),
+            FilePath(file_auth, "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    h.expect_action("is_writeable false during upgrade")
+
+    let listener = _TestStartTLSIsWriteableListener(
+      port, consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestStartTLSIsWriteableClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _sslctx: SSLContext val
+  let _h: TestHelper
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _sslctx = sslctx
+    _h = h
+
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(h.env.root),
+      "localhost",
+      port,
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    // Initiate TLS upgrade
+    match _tcp_connection.start_tls(_sslctx, "localhost")
+    | None =>
+      // Now in _TLSUpgrading — is_writeable() should be false
+      _h.assert_false(
+        _tcp_connection.is_writeable(),
+        "is_writeable should be false during TLS upgrade")
+      _h.complete_action("is_writeable false during upgrade")
+    | let _: StartTLSError =>
+      _h.fail("start_tls should have succeeded")
+    end
+
+actor \nodoc\ _TestStartTLSIsWriteableListener is TCPListenerActor
+  let _port: String
+  let _sslctx: SSLContext val
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _client: (_TestStartTLSIsWriteableClient | None) = None
+  var _server: (_TestDoNothingServerActor | None) = None
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _port = port
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      _port,
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestDoNothingServerActor =>
+    let server = _TestDoNothingServerActor(fd, _h)
+    _server = server
+    server
+
+  fun ref _on_closed() =>
+    try (_server as _TestDoNothingServerActor).dispose() end
+    try (_client as _TestStartTLSIsWriteableClient).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestStartTLSIsWriteableClient(
+      _port, _sslctx, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestStartTLSIsWriteableListener")

--- a/make.ps1
+++ b/make.ps1
@@ -224,7 +224,7 @@ switch ($Command.ToLower())
   {
     $testFile = (BuildTest)[-1]
     Write-Host "$testFile"
-    $rawOutput = & "$testFile" 2>&1
+    $rawOutput = & "$testFile" --sequential 2>&1
     $exitCode = $LastExitCode
     foreach ($line in $rawOutput) { Write-Host $line }
     if ($exitCode -ne 0)


### PR DESCRIPTION
Two new tests verify that `is_writeable()` returns `false` during both SSL handshake states, where `sends_allowed()` is `false`.

**`StartTLSIsWriteableDuringUpgrade`** — Client connects plaintext, calls `start_tls()`, checks `is_writeable()` synchronously while in `_TLSUpgrading`. Modeled after `StartTLSSendDuringUpgrade`.

**`SSLIsWriteableDuringHandshake`** — Plain TCP client connects to an SSL server whose handshake stalls. The server calls `check_writeable()` on itself from its constructor; both this and `_finish_initialization` are self-sends (FIFO), so the check runs in `_SSLHandshaking`.

Closes #255