### PR TITLE
Update ponylang/ssl to 2.0.1

### DIFF
--- a/corral.json
+++ b/corral.json
@@ -5,7 +5,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/ssl.git",
-      "version": "2.0.0"
+      "version": "2.0.1"
     },
     {
       "locator": "github.com/ponylang/logger.git",


### PR DESCRIPTION
Updates the ponylang/ssl dependency to 2.0.1 to pick up a bug fix.