### PR TITLE
Switch PR and stress test CI from ponyc nightly to release

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
     name: Linux
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release
     steps:
       - uses: actions/checkout@v6.0.2
       - name: config=debug
@@ -60,7 +60,7 @@ jobs:
       - name: Tune Windows Networking
         run: .ci-scripts\windows-configure-networking.ps1
       - name: Install Pony tools
-        run: .ci-scripts\windows-install-pony-tools.ps1 nightlies
+        run: .ci-scripts\windows-install-pony-tools.ps1 releases
       - name: cache SSL libs
         id: restore-libs
         uses: actions/cache@v5.0.3

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     name: Linux
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install pony tools
-        run: bash .ci-scripts/macOS-install-nightly-pony-tools.bash
+        run: bash .ci-scripts/macOS-install-release-pony-tools.bash
       - name: Configure networking
         run: bash .ci-scripts/macOS-configure-networking.bash
       - name: Build
@@ -72,7 +72,7 @@ jobs:
       - name: Tune Windows Networking
         run: .ci-scripts\windows-configure-networking.ps1
       - name: Install Pony tools
-        run: .ci-scripts\windows-install-pony-tools.ps1 nightlies
+        run: .ci-scripts\windows-install-pony-tools.ps1 releases
       - name: Cache SSL libs
         id: restore-libs
         uses: actions/cache@v5.0.3


### PR DESCRIPTION
PR and stress test workflows were using ponyc nightly builds. Switch them to release ponyc — breakage detection against nightly remains in `breakage-against-ponyc-latest.yml`.

Changes:
- `pr.yml`: Linux container and Windows install switched from nightly to release (macOS was already on release)
- `stress-tests.yml`: All three platforms switched from nightly to release