### PR TITLE
Disable Windows Defender in CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,6 +55,8 @@ jobs:
     name: Windows
     runs-on: windows-2025
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Tune Windows Networking

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -67,6 +67,8 @@ jobs:
 
     name: Windows
     steps:
+      - name: Disable Windows Defender
+        run: Set-MpPreference -DisableRealtimeMonitoring $true
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Tune Windows Networking


### PR DESCRIPTION
Disable Windows Defender real-time monitoring as the first step in all Windows CI jobs.