### PR TITLE
Store and dispose server actors in StartTLS test listeners

### DIFF
--- a/lori/_test_start_tls.pony
+++ b/lori/_test_start_tls.pony
@@ -452,6 +452,7 @@ actor \nodoc\ _TestStartTLSSendDuringUpgradeListener is TCPListenerActor
   var _tcp_listener: TCPListener = TCPListener.none()
   let _h: TestHelper
   var _client: (_TestStartTLSSendDuringUpgradeClient | None) = None
+  var _server: (_TestDoNothingServerActor | None) = None
 
   new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
     _port = port
@@ -467,12 +468,13 @@ actor \nodoc\ _TestStartTLSSendDuringUpgradeListener is TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _TestDoNothingServerActor =>
-    _TestDoNothingServerActor(fd, _h)
+    let server = _TestDoNothingServerActor(fd, _h)
+    _server = server
+    server
 
   fun ref _on_closed() =>
-    try
-      (_client as _TestStartTLSSendDuringUpgradeClient).dispose()
-    end
+    try (_server as _TestDoNothingServerActor).dispose() end
+    try (_client as _TestStartTLSSendDuringUpgradeClient).dispose() end
 
   fun ref _on_listening() =>
     _client = _TestStartTLSSendDuringUpgradeClient(
@@ -609,6 +611,7 @@ actor \nodoc\ _TestStartTLSHandshakeFailureListener is TCPListenerActor
   var _tcp_listener: TCPListener = TCPListener.none()
   let _h: TestHelper
   var _client: (_TestStartTLSHandshakeFailureClient | None) = None
+  var _server: (_TestStartTLSHandshakeFailureServer | None) = None
 
   new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
     _port = port
@@ -624,12 +627,13 @@ actor \nodoc\ _TestStartTLSHandshakeFailureListener is TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _TestStartTLSHandshakeFailureServer =>
-    _TestStartTLSHandshakeFailureServer(fd, _h)
+    let server = _TestStartTLSHandshakeFailureServer(fd, _h)
+    _server = server
+    server
 
   fun ref _on_closed() =>
-    try
-      (_client as _TestStartTLSHandshakeFailureClient).dispose()
-    end
+    try (_server as _TestStartTLSHandshakeFailureServer).dispose() end
+    try (_client as _TestStartTLSHandshakeFailureClient).dispose() end
 
   fun ref _on_listening() =>
     _client = _TestStartTLSHandshakeFailureClient(


### PR DESCRIPTION
StartTLSHandshakeFailure and StartTLSSendDuringUpgrade listeners created server actors in `_on_accept` without storing them, and `_on_closed` never disposed them. On macOS with DualStack, Happy Eyeballs can trigger multiple `_on_accept` calls, creating orphaned actors with live I/O resources that are never cleaned up.

The arm64 macOS nightly breakage test is crashing with `_ConnectionNone.hard_close()` during StartTLSHandshakeFailure. The orphaned server actors are the likeliest cause.

Several other test listeners across the codebase have the same pattern (server created in `_on_accept` but not stored or disposed). Those haven't triggered a crash yet but should be addressed separately.