### PR TITLE
Fix crash when dispose() arrives before connection initialization

### DIFF
--- a/.release-notes/fix-connection-none-hard-close.md
+++ b/.release-notes/fix-connection-none-hard-close.md
@@ -1,0 +1,3 @@
+## Fix crash when dispose() arrives before connection initialization
+
+Calling `dispose()` on a connection actor before its internal initialization completed would crash with an unreachable state error. This could happen because `_finish_initialization` is a self-to-self message queued during the actor's constructor, while `dispose()` arrives from an external actor — and Pony's causal messaging provides no ordering guarantee between different senders. The race is unlikely but was observed on macOS arm64 CI.

--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -47,7 +47,11 @@ class _ConnectionNone is _ConnectionState
     _Unreachable()
 
   fun ref hard_close(conn: TCPConnection ref) =>
-    _Unreachable()
+    // _finish_initialization is a self→self message queued during the
+    // constructor. dispose() comes from an external actor. Different senders
+    // have no ordering guarantee, so dispose() can arrive first — unlikely
+    // but possible.
+    None
 
   fun ref start_tls(conn: TCPConnection ref, ssl_ctx: SSLContext val,
     host: String): (None | StartTLSError)


### PR DESCRIPTION
`_finish_initialization` is a self-to-self message queued during the actor's constructor. `dispose()` arrives from an external actor. Pony's causal messaging guarantees ordering only between the same sender-receiver pair, so `dispose()` can be processed first. When that happens, `hard_close()` is called on a connection still in `_ConnectionNone` state, which was `_Unreachable()`.

The race is unlikely but was observed on macOS arm64 CI (nightly breakage test). Changed `_ConnectionNone.hard_close()` from `_Unreachable()` to a no-op — there's nothing to tear down on an uninitialized connection.