### PR TITLE
Route is_open() gated operations through the state machine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ _Open → _TLSUpgrading (start_tls) → _Open (ssl_handshake_complete)
 
 | State | `is_open()` | `is_closed()` | `sends_allowed()` | Description |
 |---|---|---|---|---|
-| `_ConnectionNone` | false | false | false | Before `_finish_initialization`. All methods call `_Unreachable()`. |
+| `_ConnectionNone` | false | false | false | Before `_finish_initialization`. Most dispatch methods call `_Unreachable()`. Socket options return error values; `idle_timeout` stores the value; `set_timer` returns `SetTimerNotOpen`. `hard_close` is a no-op (dispose can race with initialization). |
 | `_ClientConnecting` | false | false | false | Happy Eyeballs in progress. `close()` transitions to `_UnconnectedClosing`. |
 | `_UnconnectedClosing` | false | true | false | Draining inflight Happy Eyeballs after `close()` during connecting. Fires `_on_connection_failure` when all drain. `hard_close()` short-circuits to `_Closed`. |
 | `_SSLHandshaking` | false | false | false | TCP connected, initial SSL handshake in progress. Application not notified yet. `close()` delegates to `hard_close()`. |
@@ -191,7 +191,7 @@ _Open → _TLSUpgrading (start_tls) → _Open (ssl_handshake_complete)
 | `_Closing` | false | true | false | Graceful shutdown in progress — waiting for peer FIN. Still reads to detect FIN. |
 | `_Closed` | false | true | false | Fully closed. Handles straggler event cleanup only. |
 
-State classes dispatch lifecycle-gated operations (`send`, `close`, `hard_close`, `start_tls`, `read_again`, `ssl_handshake_complete`, `own_event`, `foreign_event`) and delegate to TCPConnection methods for the actual work. All I/O, SSL, buffer, and flow control logic remains on TCPConnection.
+State classes dispatch lifecycle-gated operations (`send`, `close`, `hard_close`, `start_tls`, `read_again`, `ssl_handshake_complete`, `own_event`, `foreign_event`, `keepalive`, `getsockopt`, `getsockopt_u32`, `setsockopt`, `setsockopt_u32`, `idle_timeout`, `set_timer`) and delegate to TCPConnection methods for the actual work. All I/O, SSL, buffer, and flow control logic remains on TCPConnection.
 
 **Private field access**: Pony restricts private field access to the defining type. State classes use helper methods on TCPConnection (`_set_state`, `_decrement_inflight`, `_establish_connection`, `_straggler_cleanup`, etc.) rather than accessing fields directly.
 
@@ -223,7 +223,7 @@ Design: Discussion #252.
 - **`_TLSUpgrading.hard_close()`**: Calls `_hard_close_tls_upgrading()`, which fires `_on_tls_failure(reason)` (where `reason` is `TLSAuthFailed` or `TLSGeneralError` based on `_ssl_auth_failed`) then `_on_closed()` (the application already knew about the plaintext connection).
 - **`_TLSUpgrading.send()`**: Returns `SendErrorNotConnected` — sends are blocked during the TLS handshake.
 - **`_TLSUpgrading.close()`**: Delegates to `hard_close()` — can't send FIN during TLS handshake.
-- **`_TLSUpgrading.is_open()`**: Returns `true` — the application has already been notified. This allows `idle_timeout()` and `set_timer()` to work during TLS upgrades.
+- **`_TLSUpgrading.is_open()`**: Returns `true` — the application has already been notified. `_TLSUpgrading` delegates socket option, `idle_timeout`, and `set_timer` operations to the same helpers as `_Open`.
 - **`_TLSUpgrading.sends_allowed()`**: Returns `false` — prevents `is_writeable()` from returning true during handshake.
 
 Preconditions enforced synchronously: connection must be open, not already TLS, not muted, no buffered read data (CVE-2021-23222), no pending writes. Returns `StartTLSError` on failure (connection unchanged). The "no pending writes" check is platform-aware: on POSIX it checks `_has_pending_writes()` (any unconfirmed bytes); on Windows IOCP it checks for un-submitted data only (`_pending_data.size() > _pending_sent`), since submitted-but-unconfirmed writes are already in the kernel's send buffer.
@@ -285,7 +285,7 @@ Per-connection idle timeout via ASIO timer events. The duration is an `IdleTimeo
 
 Lifecycle:
 
-- **Arm points**: plaintext branch of `_establish_connection` and `_complete_server_initialization`; `_SSLHandshaking.ssl_handshake_complete()` for initial SSL connections. `_arm_idle_timer()` is a no-op when `_idle_timeout_nsec == 0` or when a timer already exists (idempotency guard). Also called from `idle_timeout()` when setting a timeout on an established connection with no existing timer. `idle_timeout()` gates on `is_open()` — `_SSLHandshaking.is_open() = false` blocks arming during initial SSL handshake, while `_TLSUpgrading.is_open() = true` allows it (timer continues from plaintext phase).
+- **Arm points**: plaintext branch of `_establish_connection` and `_complete_server_initialization`; `_SSLHandshaking.ssl_handshake_complete()` for initial SSL connections. `_arm_idle_timer()` is a no-op when `_idle_timeout_nsec == 0` or when a timer already exists (idempotency guard). Also called from `_do_idle_timeout()` when setting a timeout on an established connection with no existing timer. `idle_timeout()` dispatches through the state machine — `_Open` and `_TLSUpgrading` delegate to `_do_idle_timeout()` (stores nsec and manages the timer), while all other states delegate to `_store_idle_timeout()` (stores nsec only).
 - **Reset points**: `_read()` (POSIX, once per read event), `_read_completed()` (Windows, once per read event), `send()` success path (after the SSL/plaintext write block).
 - **Cancel point**: `_hard_close_connecting()` and `_hard_close_cleanup()` (shared by all connected hard-close paths: `_hard_close_connected`, `_hard_close_ssl_handshaking`, `_hard_close_tls_upgrading`).
 - **Event dispatch**: Identity check `event is _timer_event` in `_event_notify`'s `if/elseif/else` chain, before the `event is _event` check. `_timer_event` is cleared synchronously in `_cancel_idle_timer()`, so stale disposable events for cancelled timers fall through to the `else` branch where the disposable check destroys them.
@@ -315,7 +315,7 @@ One-shot general-purpose timer per connection, independent of the idle timeout. 
 - `_user_timer_token: (TimerToken | None)` — the active timer's token, or `None`.
 
 API:
-- `set_timer(duration: TimerDuration): (TimerToken | SetTimerError)` — creates a one-shot timer. Returns `SetTimerNotOpen` if `is_open()` is false (`_SSLHandshaking.is_open() = false` blocks during initial SSL handshake; `_TLSUpgrading.is_open() = true` allows during TLS upgrades). Returns `SetTimerAlreadyActive` if a timer is already active.
+- `set_timer(duration: TimerDuration): (TimerToken | SetTimerError)` — creates a one-shot timer. Dispatches through the state machine: `_Open` and `_TLSUpgrading` delegate to `_do_set_timer()`, all other states return `SetTimerNotOpen`. Returns `SetTimerAlreadyActive` if a timer is already active.
 - `cancel_timer(token: TimerToken)` — cancels the timer if the token matches. No-op for stale/wrong tokens. No connection state check (can cancel during `_Closing`).
 
 Internals:
@@ -381,9 +381,9 @@ For options without dedicated methods, four general-purpose methods expose the f
 - `setsockopt(level, option_name, option): U32` — raw bytes set.
 - `setsockopt_u32(level, option_name, option): U32` — U32 convenience set.
 
-All methods guard with `is_open()`. Setters return 0 on success or errno on failure. Getters return `(errno, value)`. When the connection is not open, setters return 1 and getters return `(1, 0)`. All delegate to `_OSSocket` methods in `ossocket.pony`. Use `OSSockOpt` constants for level and option name parameters.
+All socket option methods dispatch through the state machine. `_Open` and `_TLSUpgrading` delegate to `_do_*` helpers (which call `_OSSocket` methods); all other states return error values. Setters return 0 on success or errno on failure. Getters return `(errno, value)`. When the connection is not open, setters return 1 and getters return `(1, 0)`. Use `OSSockOpt` constants for level and option name parameters.
 
-Note: `keepalive()` predates these methods and uses `_state.is_open()` (updated from the original `_connected` check when the lifecycle state machine was introduced).
+The general-purpose methods (`getsockopt`, `getsockopt_u32`, `setsockopt`, `setsockopt_u32`) and `keepalive` each have their own dispatch method on `_ConnectionState`. The convenience methods (`set_nodelay`, `get_so_rcvbuf`, etc.) are thin wrappers that delegate to the dispatched general methods, mirroring `_OSSocket`'s wrapper structure.
 
 ### Platform differences
 

--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -13,6 +13,19 @@ trait _ConnectionState
   fun ref read_again(conn: TCPConnection ref)
   fun ref ssl_handshake_complete(conn: TCPConnection ref,
     s: EitherLifecycleEventReceiver ref)
+  fun keepalive(conn: TCPConnection box, secs: U32)
+  fun getsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option_max_size: USize): (U32, Array[U8] iso^)
+  fun getsockopt_u32(conn: TCPConnection box, level: I32,
+    option_name: I32): (U32, U32)
+  fun setsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option: Array[U8]): U32
+  fun setsockopt_u32(conn: TCPConnection box, level: I32, option_name: I32,
+    option: U32): U32
+  fun ref idle_timeout(conn: TCPConnection ref,
+    duration: (IdleTimeout | None))
+  fun ref set_timer(conn: TCPConnection ref,
+    duration: TimerDuration): (TimerToken | SetTimerError)
   fun is_open(): Bool
   fun is_closed(): Bool
   fun sends_allowed(): Bool
@@ -67,6 +80,38 @@ class _ConnectionNone is _ConnectionState
   =>
     _Unreachable()
 
+  fun keepalive(conn: TCPConnection box, secs: U32) => None
+
+  fun getsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option_max_size: USize): (U32, Array[U8] iso^)
+  =>
+    (1, recover Array[U8] end)
+
+  fun getsockopt_u32(conn: TCPConnection box, level: I32,
+    option_name: I32): (U32, U32)
+  =>
+    (1, 0)
+
+  fun setsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option: Array[U8]): U32
+  =>
+    1
+
+  fun setsockopt_u32(conn: TCPConnection box, level: I32, option_name: I32,
+    option: U32): U32
+  =>
+    1
+
+  fun ref idle_timeout(conn: TCPConnection ref,
+    duration: (IdleTimeout | None))
+  =>
+    conn._store_idle_timeout(duration)
+
+  fun ref set_timer(conn: TCPConnection ref,
+    duration: TimerDuration): (TimerToken | SetTimerError)
+  =>
+    SetTimerNotOpen
+
   fun is_open(): Bool => false
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
@@ -116,6 +161,38 @@ class _ClientConnecting is _ConnectionState
   =>
     _Unreachable()
 
+  fun keepalive(conn: TCPConnection box, secs: U32) => None
+
+  fun getsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option_max_size: USize): (U32, Array[U8] iso^)
+  =>
+    (1, recover Array[U8] end)
+
+  fun getsockopt_u32(conn: TCPConnection box, level: I32,
+    option_name: I32): (U32, U32)
+  =>
+    (1, 0)
+
+  fun setsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option: Array[U8]): U32
+  =>
+    1
+
+  fun setsockopt_u32(conn: TCPConnection box, level: I32, option_name: I32,
+    option: U32): U32
+  =>
+    1
+
+  fun ref idle_timeout(conn: TCPConnection ref,
+    duration: (IdleTimeout | None))
+  =>
+    conn._store_idle_timeout(duration)
+
+  fun ref set_timer(conn: TCPConnection ref,
+    duration: TimerDuration): (TimerToken | SetTimerError)
+  =>
+    SetTimerNotOpen
+
   fun is_open(): Bool => false
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
@@ -162,6 +239,39 @@ class _Open is _ConnectionState
     s: EitherLifecycleEventReceiver ref)
   =>
     _Unreachable()
+
+  fun keepalive(conn: TCPConnection box, secs: U32) =>
+    conn._do_keepalive(secs)
+
+  fun getsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option_max_size: USize): (U32, Array[U8] iso^)
+  =>
+    conn._do_getsockopt(level, option_name, option_max_size)
+
+  fun getsockopt_u32(conn: TCPConnection box, level: I32,
+    option_name: I32): (U32, U32)
+  =>
+    conn._do_getsockopt_u32(level, option_name)
+
+  fun setsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option: Array[U8]): U32
+  =>
+    conn._do_setsockopt(level, option_name, option)
+
+  fun setsockopt_u32(conn: TCPConnection box, level: I32, option_name: I32,
+    option: U32): U32
+  =>
+    conn._do_setsockopt_u32(level, option_name, option)
+
+  fun ref idle_timeout(conn: TCPConnection ref,
+    duration: (IdleTimeout | None))
+  =>
+    conn._do_idle_timeout(duration)
+
+  fun ref set_timer(conn: TCPConnection ref,
+    duration: TimerDuration): (TimerToken | SetTimerError)
+  =>
+    conn._do_set_timer(duration)
 
   fun is_open(): Bool => true
   fun is_closed(): Bool => false
@@ -212,6 +322,38 @@ class _Closing is _ConnectionState
     s: EitherLifecycleEventReceiver ref)
   =>
     _Unreachable()
+
+  fun keepalive(conn: TCPConnection box, secs: U32) => None
+
+  fun getsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option_max_size: USize): (U32, Array[U8] iso^)
+  =>
+    (1, recover Array[U8] end)
+
+  fun getsockopt_u32(conn: TCPConnection box, level: I32,
+    option_name: I32): (U32, U32)
+  =>
+    (1, 0)
+
+  fun setsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option: Array[U8]): U32
+  =>
+    1
+
+  fun setsockopt_u32(conn: TCPConnection box, level: I32, option_name: I32,
+    option: U32): U32
+  =>
+    1
+
+  fun ref idle_timeout(conn: TCPConnection ref,
+    duration: (IdleTimeout | None))
+  =>
+    conn._store_idle_timeout(duration)
+
+  fun ref set_timer(conn: TCPConnection ref,
+    duration: TimerDuration): (TimerToken | SetTimerError)
+  =>
+    SetTimerNotOpen
 
   fun is_open(): Bool => false
   fun is_closed(): Bool => true
@@ -267,6 +409,38 @@ class _UnconnectedClosing is _ConnectionState
   =>
     _Unreachable()
 
+  fun keepalive(conn: TCPConnection box, secs: U32) => None
+
+  fun getsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option_max_size: USize): (U32, Array[U8] iso^)
+  =>
+    (1, recover Array[U8] end)
+
+  fun getsockopt_u32(conn: TCPConnection box, level: I32,
+    option_name: I32): (U32, U32)
+  =>
+    (1, 0)
+
+  fun setsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option: Array[U8]): U32
+  =>
+    1
+
+  fun setsockopt_u32(conn: TCPConnection box, level: I32, option_name: I32,
+    option: U32): U32
+  =>
+    1
+
+  fun ref idle_timeout(conn: TCPConnection ref,
+    duration: (IdleTimeout | None))
+  =>
+    conn._store_idle_timeout(duration)
+
+  fun ref set_timer(conn: TCPConnection ref,
+    duration: TimerDuration): (TimerToken | SetTimerError)
+  =>
+    SetTimerNotOpen
+
   fun is_open(): Bool => false
   fun is_closed(): Bool => true
   fun sends_allowed(): Bool => false
@@ -309,6 +483,38 @@ class _Closed is _ConnectionState
     s: EitherLifecycleEventReceiver ref)
   =>
     _Unreachable()
+
+  fun keepalive(conn: TCPConnection box, secs: U32) => None
+
+  fun getsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option_max_size: USize): (U32, Array[U8] iso^)
+  =>
+    (1, recover Array[U8] end)
+
+  fun getsockopt_u32(conn: TCPConnection box, level: I32,
+    option_name: I32): (U32, U32)
+  =>
+    (1, 0)
+
+  fun setsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option: Array[U8]): U32
+  =>
+    1
+
+  fun setsockopt_u32(conn: TCPConnection box, level: I32, option_name: I32,
+    option: U32): U32
+  =>
+    1
+
+  fun ref idle_timeout(conn: TCPConnection ref,
+    duration: (IdleTimeout | None))
+  =>
+    conn._store_idle_timeout(duration)
+
+  fun ref set_timer(conn: TCPConnection ref,
+    duration: TimerDuration): (TimerToken | SetTimerError)
+  =>
+    SetTimerNotOpen
 
   fun is_open(): Bool => false
   fun is_closed(): Bool => true
@@ -370,6 +576,38 @@ class _SSLHandshaking is _ConnectionState
       srv._on_started()
     end
 
+  fun keepalive(conn: TCPConnection box, secs: U32) => None
+
+  fun getsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option_max_size: USize): (U32, Array[U8] iso^)
+  =>
+    (1, recover Array[U8] end)
+
+  fun getsockopt_u32(conn: TCPConnection box, level: I32,
+    option_name: I32): (U32, U32)
+  =>
+    (1, 0)
+
+  fun setsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option: Array[U8]): U32
+  =>
+    1
+
+  fun setsockopt_u32(conn: TCPConnection box, level: I32, option_name: I32,
+    option: U32): U32
+  =>
+    1
+
+  fun ref idle_timeout(conn: TCPConnection ref,
+    duration: (IdleTimeout | None))
+  =>
+    conn._store_idle_timeout(duration)
+
+  fun ref set_timer(conn: TCPConnection ref,
+    duration: TimerDuration): (TimerToken | SetTimerError)
+  =>
+    SetTimerNotOpen
+
   fun is_open(): Bool => false
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
@@ -424,6 +662,39 @@ class _TLSUpgrading is _ConnectionState
     // already running from the plaintext phase).
     conn._set_state(_Open)
     s._on_tls_ready()
+
+  fun keepalive(conn: TCPConnection box, secs: U32) =>
+    conn._do_keepalive(secs)
+
+  fun getsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option_max_size: USize): (U32, Array[U8] iso^)
+  =>
+    conn._do_getsockopt(level, option_name, option_max_size)
+
+  fun getsockopt_u32(conn: TCPConnection box, level: I32,
+    option_name: I32): (U32, U32)
+  =>
+    conn._do_getsockopt_u32(level, option_name)
+
+  fun setsockopt(conn: TCPConnection box, level: I32, option_name: I32,
+    option: Array[U8]): U32
+  =>
+    conn._do_setsockopt(level, option_name, option)
+
+  fun setsockopt_u32(conn: TCPConnection box, level: I32, option_name: I32,
+    option: U32): U32
+  =>
+    conn._do_setsockopt_u32(level, option_name, option)
+
+  fun ref idle_timeout(conn: TCPConnection ref,
+    duration: (IdleTimeout | None))
+  =>
+    conn._do_idle_timeout(duration)
+
+  fun ref set_timer(conn: TCPConnection ref,
+    duration: TimerDuration): (TimerToken | SetTimerError)
+  =>
+    conn._do_set_timer(duration)
 
   fun is_open(): Bool => true
   fun is_closed(): Bool => false

--- a/lori/lori.pony
+++ b/lori/lori.pony
@@ -417,8 +417,8 @@ back to the minimum size.
 ## Socket Options
 
 `TCPConnection` exposes commonly-tuned socket options for connected sockets.
-All methods guard with `is_open()` and return an error indicator when the
-connection is not open.
+All methods dispatch through the connection state machine and return an error
+indicator when the connection is not open.
 
 **TCP_NODELAY** disables Nagle's algorithm so small writes are sent immediately:
 

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -202,9 +202,7 @@ class TCPConnection
     keepalive is disabled by default. This can only be set on a connected
     socket.
     """
-    if _state.is_open() then
-      PonyTCP.keepalive(_fd, secs)
-    end
+    _state.keepalive(this, secs)
 
   fun set_nodelay(state: Bool): U32 =>
     """
@@ -216,9 +214,8 @@ class TCPConnection
     Returns 0 on success, or a non-zero errno on failure. Only meaningful
     on a connected socket — returns non-zero if the connection is not open.
     """
-    if not is_open() then return 1 end
-    _OSSocket.setsockopt_u32(_fd, OSSockOpt.ipproto_tcp(),
-      OSSockOpt.tcp_nodelay(), if state then 1 else 0 end)
+    setsockopt_u32(OSSockOpt.ipproto_tcp(), OSSockOpt.tcp_nodelay(),
+      if state then 1 else 0 end)
 
   fun get_so_rcvbuf(): (U32, U32) =>
     """
@@ -229,8 +226,7 @@ class TCPConnection
     be ignored. Only meaningful on a connected socket — returns (1, 0) if
     the connection is not open.
     """
-    if not is_open() then return (1, 0) end
-    _OSSocket.get_so_rcvbuf(_fd)
+    getsockopt_u32(OSSockOpt.sol_socket(), OSSockOpt.so_rcvbuf())
 
   fun set_so_rcvbuf(bufsize: U32): U32 =>
     """
@@ -240,8 +236,7 @@ class TCPConnection
     Returns 0 on success, or a non-zero errno on failure. Only meaningful
     on a connected socket — returns non-zero if the connection is not open.
     """
-    if not is_open() then return 1 end
-    _OSSocket.set_so_rcvbuf(_fd, bufsize)
+    setsockopt_u32(OSSockOpt.sol_socket(), OSSockOpt.so_rcvbuf(), bufsize)
 
   fun get_so_sndbuf(): (U32, U32) =>
     """
@@ -252,8 +247,7 @@ class TCPConnection
     be ignored. Only meaningful on a connected socket — returns (1, 0) if
     the connection is not open.
     """
-    if not is_open() then return (1, 0) end
-    _OSSocket.get_so_sndbuf(_fd)
+    getsockopt_u32(OSSockOpt.sol_socket(), OSSockOpt.so_sndbuf())
 
   fun set_so_sndbuf(bufsize: U32): U32 =>
     """
@@ -263,8 +257,7 @@ class TCPConnection
     Returns 0 on success, or a non-zero errno on failure. Only meaningful
     on a connected socket — returns non-zero if the connection is not open.
     """
-    if not is_open() then return 1 end
-    _OSSocket.set_so_sndbuf(_fd, bufsize)
+    setsockopt_u32(OSSockOpt.sol_socket(), OSSockOpt.so_sndbuf(), bufsize)
 
   fun getsockopt(level: I32, option_name: I32,
     option_max_size: USize = 4): (U32, Array[U8] iso^)
@@ -287,8 +280,7 @@ class TCPConnection
     non-blocking mode — lori's event-driven I/O requires non-blocking
     sockets.
     """
-    if not is_open() then return (1, recover Array[U8] end) end
-    _OSSocket.getsockopt(_fd, level, option_name, option_max_size)
+    _state.getsockopt(this, level, option_name, option_max_size)
 
   fun getsockopt_u32(level: I32, option_name: I32): (U32, U32) =>
     """
@@ -304,8 +296,7 @@ class TCPConnection
     non-blocking mode — lori's event-driven I/O requires non-blocking
     sockets.
     """
-    if not is_open() then return (1, 0) end
-    _OSSocket.getsockopt_u32(_fd, level, option_name)
+    _state.getsockopt_u32(this, level, option_name)
 
   fun setsockopt(level: I32, option_name: I32, option: Array[U8]): U32 =>
     """
@@ -324,8 +315,7 @@ class TCPConnection
     non-blocking mode — lori's event-driven I/O requires non-blocking
     sockets.
     """
-    if not is_open() then return 1 end
-    _OSSocket.setsockopt(_fd, level, option_name, option)
+    _state.setsockopt(this, level, option_name, option)
 
   fun setsockopt_u32(level: I32, option_name: I32, option: U32): U32 =>
     """
@@ -340,8 +330,7 @@ class TCPConnection
     non-blocking mode — lori's event-driven I/O requires non-blocking
     sockets.
     """
-    if not is_open() then return 1 end
-    _OSSocket.setsockopt_u32(_fd, level, option_name, option)
+    _state.setsockopt_u32(this, level, option_name, option)
 
   fun ref idle_timeout(duration: (IdleTimeout | None)) =>
     """
@@ -363,25 +352,7 @@ class TCPConnection
     application-level inactivity detection — it fires whether or not the
     peer is alive.
     """
-    match \exhaustive\ duration
-    | let t: IdleTimeout =>
-      _idle_timeout_nsec = t() * 1_000_000
-      // _SSLHandshaking.is_open() = false blocks arming; the timer starts
-      // at ssl_handshake_complete. _TLSUpgrading.is_open() = true allows
-      // arming — the timer is already running from the plaintext phase.
-      if _state.is_open() then
-        if _timer_event.is_null() then
-          _arm_idle_timer()
-        else
-          _reset_idle_timer()
-        end
-      end
-    | None =>
-      _idle_timeout_nsec = 0
-      if _state.is_open() then
-        _cancel_idle_timer()
-      end
-    end
+    _state.idle_timeout(this, duration)
 
   fun ref set_timer(duration: TimerDuration): (TimerToken | SetTimerError) =>
     """
@@ -398,29 +369,14 @@ class TCPConnection
     already active returns `SetTimerAlreadyActive` — call `cancel_timer()`
     first. This prevents silent token invalidation.
 
-    Requires the connection to be application-level connected: `is_open()` must
-    be true and the initial SSL handshake (if any) must have completed. TLS
-    upgrades via `start_tls()` do not block timer creation.
+    Requires the connection to be application-level connected: the connection
+    must be open and the initial SSL handshake (if any) must have completed.
+    TLS upgrades via `start_tls()` do not block timer creation.
 
     The timer survives `close()` (graceful shutdown) but is cancelled by
     `hard_close()`.
     """
-    // _SSLHandshaking.is_open() = false blocks timers during initial SSL
-    // handshake. _TLSUpgrading.is_open() = true allows them — the
-    // application already received _on_connected/_on_started.
-    if not is_open() then return SetTimerNotOpen end
-    if _user_timer_token isnt None then return SetTimerAlreadyActive end
-
-    let nsec = duration() * 1_000_000
-    match \exhaustive\ _enclosing
-    | let e: TCPConnectionActor ref =>
-      _user_timer_event = PonyAsio.create_timer_event(e, nsec)
-    | None =>
-      _Unreachable()
-    end
-    let token = TimerToken._create(_next_timer_id = _next_timer_id + 1)
-    _user_timer_token = token
-    token
+    _state.set_timer(this, duration)
 
   fun ref cancel_timer(token: TimerToken) =>
     """
@@ -832,6 +788,23 @@ class TCPConnection
     not needed.
     """
     _state.start_tls(this, ssl_ctx, host)
+
+  fun _do_keepalive(secs: U32) =>
+    PonyTCP.keepalive(_fd, secs)
+
+  fun _do_getsockopt(level: I32, option_name: I32,
+    option_max_size: USize): (U32, Array[U8] iso^)
+  =>
+    _OSSocket.getsockopt(_fd, level, option_name, option_max_size)
+
+  fun _do_getsockopt_u32(level: I32, option_name: I32): (U32, U32) =>
+    _OSSocket.getsockopt_u32(_fd, level, option_name)
+
+  fun _do_setsockopt(level: I32, option_name: I32, option: Array[U8]): U32 =>
+    _OSSocket.setsockopt(_fd, level, option_name, option)
+
+  fun _do_setsockopt_u32(level: I32, option_name: I32, option: U32): U32 =>
+    _OSSocket.setsockopt_u32(_fd, level, option_name, option)
 
   fun ref _do_start_tls(ssl_ctx: SSLContext val, host: String):
     (None | StartTLSError)
@@ -1470,6 +1443,44 @@ class TCPConnection
     | None =>
       _Unreachable()
     end
+
+  fun ref _do_idle_timeout(duration: (IdleTimeout | None)) =>
+    match \exhaustive\ duration
+    | let t: IdleTimeout =>
+      _idle_timeout_nsec = t() * 1_000_000
+      if _timer_event.is_null() then
+        _arm_idle_timer()
+      else
+        _reset_idle_timer()
+      end
+    | None =>
+      _idle_timeout_nsec = 0
+      _cancel_idle_timer()
+    end
+
+  fun ref _store_idle_timeout(duration: (IdleTimeout | None)) =>
+    match \exhaustive\ duration
+    | let t: IdleTimeout =>
+      _idle_timeout_nsec = t() * 1_000_000
+    | None =>
+      _idle_timeout_nsec = 0
+    end
+
+  fun ref _do_set_timer(duration: TimerDuration):
+    (TimerToken | SetTimerError)
+  =>
+    if _user_timer_token isnt None then return SetTimerAlreadyActive end
+
+    let nsec = duration() * 1_000_000
+    match \exhaustive\ _enclosing
+    | let e: TCPConnectionActor ref =>
+      _user_timer_event = PonyAsio.create_timer_event(e, nsec)
+    | None =>
+      _Unreachable()
+    end
+    let token = TimerToken._create(_next_timer_id = _next_timer_id + 1)
+    _user_timer_token = token
+    token
 
   fun ref _arm_idle_timer() =>
     """


### PR DESCRIPTION
Socket options, `idle_timeout`, and `set_timer` bypassed the state class pattern by checking `is_open()` directly instead of dispatching through `_ConnectionState`. Now each state class decides whether the operation is valid, consistent with `send`/`close`/`hard_close`/`start_tls`/`read_again`.

**Socket options** (`keepalive`, `getsockopt`, `getsockopt_u32`, `setsockopt`, `setsockopt_u32`): 5 new dispatch methods on the trait. `_Open` and `_TLSUpgrading` delegate to `_do_*` helpers; all other states return error values. Convenience methods (`set_nodelay`, `get_so_rcvbuf`, etc.) become thin wrappers over the dispatched general methods.

**Timers** (`idle_timeout`, `set_timer`): 2 new dispatch methods. `idle_timeout` stores the timeout value in all states but only manages the ASIO timer in `_Open`/`_TLSUpgrading`. `set_timer` returns `SetTimerNotOpen` in non-open states.

No behavioral changes — every state/operation combination produces identical results to the previous `is_open()` gating.

Closes #270