### PR TITLE
Add timer ASIO subscription failure callbacks

### DIFF
--- a/.release-notes/timer-failure-callbacks.md
+++ b/.release-notes/timer-failure-callbacks.md
@@ -1,0 +1,28 @@
+## Add timer ASIO subscription failure callbacks
+
+Previously, when the idle timer or a user timer's ASIO event subscription failed (e.g. `ENOMEM` from the kernel's `kevent` or `epoll_ctl`), lori would silently cancel the timer with no notification. The connection would keep running without the protection the application had configured. There was no way for the application to know the timer subsystem had failed or to retry.
+
+Two new lifecycle callbacks now surface these failures.
+
+`_on_idle_timer_failure()` fires when the idle timer's ASIO subscription fails. Before the callback runs, the idle timer has been cancelled and its duration cleared. The connection continues to run — the application decides whether to re-arm via `idle_timeout(duration)`, close the connection, or take some other action.
+
+`_on_timer_failure()` fires when a user timer's ASIO subscription fails. Before the callback runs, the user timer has been cancelled and the token cleared. As with the idle failure callback, the application decides how to recover — call `set_timer(duration)` to create a new timer, close the connection, etc.
+
+Both callbacks have default no-op implementations, so applications that don't override them keep the current silent-cancel behavior.
+
+```pony
+actor MyConnection is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  // ...
+
+  fun ref _on_idle_timer_failure() =>
+    // Idle detection is off. Try to bring it back up.
+    match MakeIdleTimeout(30_000)
+    | let t: IdleTimeout => _tcp_connection.idle_timeout(t)
+    end
+
+  fun ref _on_timer_failure() =>
+    // The query timer never armed. Give up on this request.
+    _tcp_connection.close()
+```
+
+Connect timers are unaffected — their ASIO subscription failures already route to `_on_connection_failure(ConnectionFailedTimerError)`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,7 +100,7 @@ Lori separates connection logic (class) from actor scheduling (trait):
 
 1. **`TCPConnection`** (class) — All TCP state and I/O logic including SSL. Created with `TCPConnection.client(...)`, `TCPConnection.server(...)`, `TCPConnection.ssl_client(...)`, or `TCPConnection.ssl_server(...)`. All four real constructors accept an optional `read_buffer_size: ReadBufferSize = DefaultReadBufferSize()` parameter that sets both the initial buffer allocation and the shrink-back minimum. Client and SSL client constructors also accept an optional `ip_version: IPVersion = DualStack` parameter to restrict to IPv4 (`IP4`) or IPv6 (`IP6`), and an optional `connection_timeout: (ConnectionTimeout | None) = None` parameter to bound the connect-to-ready phase. Existing plaintext connections can be upgraded to TLS via `start_tls()`. Not an actor itself.
 2. **`TCPConnectionActor`** (trait) — The actor trait users implement. Requires `fun ref _connection(): TCPConnection`. Provides behaviors that delegate to the TCPConnection: `_event_notify`, `_read_again`, `dispose`, etc.
-3. **Lifecycle event receivers** — `ClientLifecycleEventReceiver` (callbacks: `_on_connected`, `_on_connecting`, `_on_connection_failure(reason)`, `_on_received`, `_on_closed`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure(reason)`, etc.) and `ServerLifecycleEventReceiver` (callbacks: `_on_started`, `_on_start_failure(reason)`, `_on_received`, `_on_closed`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure(reason)`, etc.). Both share common callbacks like `_on_received`, `_on_closed`, `_on_throttled`/`_on_unthrottled`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure`, `_on_idle_timeout`, `_on_timer`.
+3. **Lifecycle event receivers** — `ClientLifecycleEventReceiver` (callbacks: `_on_connected`, `_on_connecting`, `_on_connection_failure(reason)`, `_on_received`, `_on_closed`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure(reason)`, etc.) and `ServerLifecycleEventReceiver` (callbacks: `_on_started`, `_on_start_failure(reason)`, `_on_received`, `_on_closed`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure(reason)`, etc.). Both share common callbacks like `_on_received`, `_on_closed`, `_on_throttled`/`_on_unthrottled`, `_on_sent`, `_on_send_failed`, `_on_tls_ready`, `_on_tls_failure`, `_on_idle_timeout`, `_on_idle_timer_failure`, `_on_timer`, `_on_timer_failure`.
 
 ### How to implement a server
 
@@ -289,7 +289,7 @@ Lifecycle:
 - **Arm points**: plaintext branch of `_establish_connection` and `_complete_server_initialization`; `_SSLHandshaking.ssl_handshake_complete()` for initial SSL connections. `_arm_idle_timer()` is a no-op when `_idle_timeout_nsec == 0` or when a timer already exists (idempotency guard). Also called from `_do_idle_timeout()` when setting a timeout on an established connection with no existing timer. `idle_timeout()` dispatches through the state machine — `_Open` and `_TLSUpgrading` delegate to `_do_idle_timeout()` (stores nsec and manages the timer), while all other states delegate to `_store_idle_timeout()` (stores nsec only).
 - **Reset points**: `_read()` (POSIX, once per read event), `_read_completed()` (Windows, once per read event), `send()` success path (after the SSL/plaintext write block).
 - **Cancel point**: `_hard_close_connecting()` and `_hard_close_cleanup()` (shared by all connected hard-close paths: `_hard_close_connected`, `_hard_close_ssl_handshaking`, `_hard_close_tls_upgrading`).
-- **Event dispatch**: Identity check `event is _timer_event` in `_event_notify`'s `if/elseif/else` chain, before the `event is _event` check. `_timer_event` is cleared synchronously in `_cancel_idle_timer()`, so stale disposable events for cancelled timers fall through to the `else` branch where the disposable check destroys them.
+- **Event dispatch**: Identity check `event is _timer_event` in `_event_notify`'s `if/elseif/else` chain, before the `event is _event` check. Checks `AsioEvent.errored(flags)` first — if errored, calls `_fire_idle_timer_failure()` which cancels the timer via `_cancel_idle_timer()` (unsubscribing the event and zeroing `_idle_timeout_nsec`) before dispatching `_on_idle_timer_failure`. Cancelling before dispatch lets the callback call `idle_timeout(duration)` to re-arm without hitting the `_arm_idle_timer` idempotency guard. `_timer_event` is cleared synchronously in `_cancel_idle_timer()`, so stale disposable events for cancelled timers fall through to the `else` branch where the disposable check destroys them.
 
 ### Connection timeout
 
@@ -320,11 +320,16 @@ API:
 - `set_timer(duration: TimerDuration): (TimerToken | SetTimerError)` — creates a one-shot timer. Dispatches through the state machine: `_Open` and `_TLSUpgrading` delegate to `_do_set_timer()`, all other states return `SetTimerNotOpen`. Returns `SetTimerAlreadyActive` if a timer is already active.
 - `cancel_timer(token: TimerToken)` — cancels the timer if the token matches. No-op for stale/wrong tokens. No connection state check (can cancel during `_Closing`).
 
+Error paths:
+- **Synchronous**: `set_timer()` returns a `SetTimerError` when preconditions fail — `SetTimerNotOpen` (any non-`_Open`/`_TLSUpgrading` state) or `SetTimerAlreadyActive` (a timer is already armed).
+- **Asynchronous**: `_on_timer_failure` fires when `set_timer()` succeeded but the ASIO event subscription later failed (e.g. `ENOMEM` from `kevent`/`epoll_ctl`). The timer is cancelled before dispatch, so the callback can call `set_timer()` to create a new timer without hitting `SetTimerAlreadyActive`.
+
 Internals:
 - `_fire_user_timer()` — clears token and event before the callback, then dispatches `_on_timer(token)`. Clearing before dispatch prevents aliasing when the callback calls `set_timer()`.
+- `_fire_user_timer_failure()` — cancels the timer via `_cancel_user_timer()` (unsubscribing the event and clearing the token) before dispatching `_on_timer_failure`. Cancel-before-dispatch mirrors `_fire_user_timer` and enables immediate re-arm from the callback.
 - `_cancel_user_timer()` — cleanup path for `hard_close`. Unsubscribes and clears without firing the callback.
 
-Event dispatch: identity check `event is _user_timer_event` in `_event_notify`'s `if/elseif/else` chain, after the idle timer check and before the `event is _event` check.
+Event dispatch: identity check `event is _user_timer_event` in `_event_notify`'s `if/elseif/else` chain, after the idle timer check and before the `event is _event` check. Checks `AsioEvent.errored(flags)` first — if errored, calls `_fire_user_timer_failure()` instead of `_fire_user_timer()`.
 
 Cleanup: `_cancel_user_timer()` called from `_hard_close_connecting()` (defensive) and `_hard_close_cleanup()` (shared by all connected hard-close paths). Timers survive `close()` (graceful shutdown) but are cancelled by `hard_close()`.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,8 @@ Length-prefixed message framing with `buffer_until()`. Each message has a 4-byte
 
 Server that closes connections after 10 seconds of inactivity. Demonstrates
 `idle_timeout()` for setting a per-connection timer and `_on_idle_timeout()`
-for handling the expiration — no extra actors or shared timers needed.
+for handling the expiration — no extra actors or shared timers needed. Also
+shows `_on_idle_timer_failure()` for handling ASIO subscription failures.
 
 ## [connection-timeout](connection-timeout/)
 
@@ -30,7 +31,7 @@ Client that connects to a non-routable address (192.0.2.1, RFC 5737 TEST-NET-1) 
 
 ## [timer](timer/)
 
-Query-timeout simulation using `set_timer()`. A client connects, sends a "query", and sets a 3-second timer. The server never responds. When the timer fires, `_on_timer()` logs the timeout and closes the connection. Shows how `set_timer()` fires unconditionally regardless of I/O activity, unlike `idle_timeout()` which resets on every send/receive.
+Query-timeout simulation using `set_timer()`. A client connects, sends a "query", and sets a 3-second timer. The server never responds. When the timer fires, `_on_timer()` logs the timeout and closes the connection. Shows how `set_timer()` fires unconditionally regardless of I/O activity, unlike `idle_timeout()` which resets on every send/receive. Also shows `_on_timer_failure()` for handling ASIO subscription failures.
 
 ## [backpressure](backpressure/)
 

--- a/examples/idle-timeout/idle-timeout.pony
+++ b/examples/idle-timeout/idle-timeout.pony
@@ -71,5 +71,8 @@ actor IdleTimeoutEchoer
     _out.print("Connection idle for 10 seconds. Closing.")
     _tcp_connection.close()
 
+  fun ref _on_idle_timer_failure() =>
+    _out.print("Idle timer subscription failed. Idle detection disabled.")
+
   fun ref _on_closed() =>
     _out.print("Connection closed.")

--- a/examples/timer/timer.pony
+++ b/examples/timer/timer.pony
@@ -114,6 +114,10 @@ actor QueryTimeoutClient
       _tcp_connection.close()
     end
 
+  fun ref _on_timer_failure() =>
+    _query_timer = None
+    _out.print("[client] Query timer subscription failed. No timeout armed.")
+
   fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
     _out.print("[client] Connection failed.")
 

--- a/lori/lifecycle_event_receiver.pony
+++ b/lori/lifecycle_event_receiver.pony
@@ -102,6 +102,28 @@ trait ServerLifecycleEventReceiver
     The timer automatically re-arms after each firing. Call
     `idle_timeout(None)` to disable it. The application decides what action
     to take — close the connection, send a keepalive, log a warning, etc.
+
+    If the idle timer's ASIO event subscription fails,
+    `_on_idle_timer_failure()` is delivered instead of this callback.
+    """
+    None
+
+  fun ref _on_idle_timer_failure() =>
+    """
+    Called when the idle timer's ASIO event subscription fails. This is
+    typically caused by the kernel returning an error (e.g. `ENOMEM`) from
+    `kevent` or `epoll_ctl` when the runtime tries to register the timer.
+
+    Before this callback fires, the idle timer has already been cancelled:
+    the ASIO event is unsubscribed and the configured timeout duration is
+    cleared. Idle timeout detection is no longer active on this connection.
+
+    The connection itself is unaffected and continues running. The
+    application decides how to recover — for example, call
+    `idle_timeout(duration)` from within this callback to re-arm, or
+    `close()` the connection. A re-armed timer can itself fail
+    asynchronously under sustained pressure; if the new subscription also
+    errors, this callback fires again.
     """
     None
 
@@ -113,6 +135,36 @@ trait ServerLifecycleEventReceiver
     Fires once per `set_timer()` call. The timer is consumed before the
     callback, so it is safe to call `set_timer()` from within `_on_timer()`
     to re-arm. No automatic re-arming occurs.
+
+    If the user timer's ASIO event subscription fails, `_on_timer_failure()`
+    is delivered instead of this callback.
+    """
+    None
+
+  fun ref _on_timer_failure() =>
+    """
+    Called when the user timer's ASIO event subscription fails. This is
+    typically caused by the kernel returning an error (e.g. `ENOMEM`) from
+    `kevent` or `epoll_ctl` when the runtime tries to register the timer.
+
+    User timers have two error paths:
+
+    - Synchronous: `set_timer()` returns a `SetTimerError`
+      (`SetTimerNotOpen` or `SetTimerAlreadyActive`) when preconditions
+      prevent the timer from being created at all.
+    - Asynchronous: this callback fires when `set_timer()` succeeded but
+      the ASIO event subscription later failed.
+
+    Before this callback fires, the user timer has already been cancelled:
+    the ASIO event is unsubscribed and the timer token is cleared. The
+    token that the application was waiting on is no longer valid.
+
+    The connection itself is unaffected and continues running. The
+    application decides how to recover — for example, call
+    `set_timer(duration)` from within this callback to create a new timer,
+    or `close()` the connection. A new timer can itself fail
+    asynchronously under sustained pressure; if the new subscription also
+    errors, this callback fires again.
     """
     None
 
@@ -234,6 +286,28 @@ trait ClientLifecycleEventReceiver
     The timer automatically re-arms after each firing. Call
     `idle_timeout(None)` to disable it. The application decides what action
     to take — close the connection, send a keepalive, log a warning, etc.
+
+    If the idle timer's ASIO event subscription fails,
+    `_on_idle_timer_failure()` is delivered instead of this callback.
+    """
+    None
+
+  fun ref _on_idle_timer_failure() =>
+    """
+    Called when the idle timer's ASIO event subscription fails. This is
+    typically caused by the kernel returning an error (e.g. `ENOMEM`) from
+    `kevent` or `epoll_ctl` when the runtime tries to register the timer.
+
+    Before this callback fires, the idle timer has already been cancelled:
+    the ASIO event is unsubscribed and the configured timeout duration is
+    cleared. Idle timeout detection is no longer active on this connection.
+
+    The connection itself is unaffected and continues running. The
+    application decides how to recover — for example, call
+    `idle_timeout(duration)` from within this callback to re-arm, or
+    `close()` the connection. A re-armed timer can itself fail
+    asynchronously under sustained pressure; if the new subscription also
+    errors, this callback fires again.
     """
     None
 
@@ -245,6 +319,36 @@ trait ClientLifecycleEventReceiver
     Fires once per `set_timer()` call. The timer is consumed before the
     callback, so it is safe to call `set_timer()` from within `_on_timer()`
     to re-arm. No automatic re-arming occurs.
+
+    If the user timer's ASIO event subscription fails, `_on_timer_failure()`
+    is delivered instead of this callback.
+    """
+    None
+
+  fun ref _on_timer_failure() =>
+    """
+    Called when the user timer's ASIO event subscription fails. This is
+    typically caused by the kernel returning an error (e.g. `ENOMEM`) from
+    `kevent` or `epoll_ctl` when the runtime tries to register the timer.
+
+    User timers have two error paths:
+
+    - Synchronous: `set_timer()` returns a `SetTimerError`
+      (`SetTimerNotOpen` or `SetTimerAlreadyActive`) when preconditions
+      prevent the timer from being created at all.
+    - Asynchronous: this callback fires when `set_timer()` succeeded but
+      the ASIO event subscription later failed.
+
+    Before this callback fires, the user timer has already been cancelled:
+    the ASIO event is unsubscribed and the timer token is cleared. The
+    token that the application was waiting on is no longer valid.
+
+    The connection itself is unaffected and continues running. The
+    application decides how to recover — for example, call
+    `set_timer(duration)` from within this callback to create a new timer,
+    or `close()` the connection. A new timer can itself fail
+    asynchronously under sustained pressure; if the new subscription also
+    errors, this callback fires again.
     """
     None
 

--- a/lori/lori.pony
+++ b/lori/lori.pony
@@ -282,6 +282,11 @@ The timer resets on every successful `send()` and every received data event.
 It automatically re-arms after each firing — the application decides what to
 do (close, send a keepalive, log, etc.). Call `idle_timeout(None)` to disable.
 
+If the idle timer's ASIO event subscription fails (e.g. under kernel memory
+pressure), the timer is cancelled and `_on_idle_timer_failure()` fires instead
+of `_on_idle_timeout()`. Override it to log, close, or retry
+`idle_timeout(duration)` — the default is a silent no-op.
+
 Idle timeout uses a per-connection ASIO timer event, requiring no extra actors
 or shared state. This avoids the muting-livelock problem that occurs with
 shared `Timers` actors under backpressure.
@@ -348,6 +353,14 @@ calling `set_timer()` while one is active returns
 [`SetTimerAlreadyActive`](/lori/lori-SetTimerAlreadyActive/). Cancel with
 `cancel_timer(token)` before setting a new one. The timer is cancelled by
 `hard_close()` but survives `close()`.
+
+Timers have two error paths. `set_timer()` returns a
+[`SetTimerError`](/lori/lori-SetTimerError/) synchronously when preconditions
+prevent the timer from being created. If `set_timer()` succeeded but the
+ASIO event subscription later fails (e.g. under kernel memory pressure),
+the timer is cancelled and `_on_timer_failure()` fires instead of
+`_on_timer()`. The token the application was waiting on is no longer
+valid; override the callback to retry or close as appropriate.
 
 ## Read Yielding
 

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -356,6 +356,11 @@ class TCPConnection
     is a transport-level probe that detects dead peers. Idle timeout is
     application-level inactivity detection — it fires whether or not the
     peer is alive.
+
+    If the idle timer's ASIO event subscription fails asynchronously
+    (e.g. `ENOMEM` from `kevent`/`epoll_ctl`), the timer is cancelled and
+    `_on_idle_timer_failure()` is dispatched to the lifecycle event
+    receiver.
     """
     _state.idle_timeout(this, duration)
 
@@ -380,6 +385,13 @@ class TCPConnection
 
     The timer survives `close()` (graceful shutdown) but is cancelled by
     `hard_close()`.
+
+    User timers have two error paths. This method returns a
+    `SetTimerError` synchronously when preconditions prevent the timer
+    from being created (see the return type). When creation succeeds but
+    the ASIO event subscription later fails (e.g. `ENOMEM` from
+    `kevent`/`epoll_ctl`), `_on_timer_failure()` is dispatched to the
+    lifecycle event receiver.
     """
     _state.set_timer(this, duration)
 
@@ -1477,6 +1489,9 @@ class TCPConnection
   fun ref _do_set_timer(duration: TimerDuration):
     (TimerToken | SetTimerError)
   =>
+    // COUPLING: `_fire_user_timer_failure` relies on `_cancel_user_timer`
+    // clearing `_user_timer_token` so that `_on_timer_failure` callbacks can
+    // call `set_timer(duration)` without hitting this guard.
     if _user_timer_token isnt None then return SetTimerAlreadyActive end
 
     let nsec = duration() * 1_000_000
@@ -1499,6 +1514,11 @@ class TCPConnection
     Idempotent — if a timer already exists, this is a no-op. Prevents ASIO
     timer event leaks from double-arm scenarios.
     """
+    // COUPLING: `_fire_idle_timer_failure` relies on `_cancel_idle_timer`
+    // clearing both `_idle_timeout_nsec` and `_timer_event` so that
+    // `_on_idle_timer_failure` callbacks can call `idle_timeout(duration)`
+    // (which runs through `_do_idle_timeout` → `_arm_idle_timer`) without
+    // hitting these guards.
     if _idle_timeout_nsec == 0 then return end
     if not _timer_event.is_null() then return end
     match \exhaustive\ _enclosing
@@ -1525,6 +1545,10 @@ class TCPConnection
     matches `_timer_event` and is destroyed by `_event_notify`'s else
     branch disposable check.
     """
+    // COUPLING: `_fire_idle_timer_failure` depends on this clearing both
+    // `_timer_event` and `_idle_timeout_nsec` so that `_on_idle_timer_failure`
+    // callbacks can re-arm via `idle_timeout(duration)` without tripping
+    // `_arm_idle_timer`'s idempotency guards.
     if not _timer_event.is_null() then
       PonyAsio.unsubscribe(_timer_event)
       _timer_event = AsioEvent.none()
@@ -1545,6 +1569,22 @@ class TCPConnection
     end
     if is_open() and (_idle_timeout_nsec > 0) then
       _reset_idle_timer()
+    end
+
+  fun ref _fire_idle_timer_failure() =>
+    """
+    The idle timer's ASIO subscription failed. Cancel the timer (which
+    unsubscribes the event and zeroes `_idle_timeout_nsec`), then dispatch
+    `_on_idle_timer_failure` to the lifecycle event receiver. Cancelling
+    before dispatch means the callback can call `idle_timeout(duration)`
+    to re-arm without hitting the idempotency guard in `_arm_idle_timer`.
+    """
+    _cancel_idle_timer()
+    match \exhaustive\ _lifecycle_event_receiver
+    | let s: EitherLifecycleEventReceiver ref =>
+      s._on_idle_timer_failure()
+    | None =>
+      _Unreachable()
     end
 
   fun ref _arm_connect_timer() =>
@@ -1627,10 +1667,30 @@ class TCPConnection
     longer match `_user_timer_event` and are destroyed by
     `_event_notify`'s else branch disposable check.
     """
+    // COUPLING: `_fire_user_timer_failure` depends on this clearing
+    // `_user_timer_token` so that `_on_timer_failure` callbacks can call
+    // `set_timer(duration)` without hitting the `SetTimerAlreadyActive`
+    // guard in `_do_set_timer`.
     if not _user_timer_event.is_null() then
       PonyAsio.unsubscribe(_user_timer_event)
       _user_timer_event = AsioEvent.none()
       _user_timer_token = None
+    end
+
+  fun ref _fire_user_timer_failure() =>
+    """
+    The user timer's ASIO subscription failed. Cancel the timer (which
+    unsubscribes the event and clears `_user_timer_token`), then dispatch
+    `_on_timer_failure` to the lifecycle event receiver. Cancelling before
+    dispatch means the callback can call `set_timer(duration)` to create
+    a new timer without hitting the `SetTimerAlreadyActive` guard.
+    """
+    _cancel_user_timer()
+    match \exhaustive\ _lifecycle_event_receiver
+    | let s: EitherLifecycleEventReceiver ref =>
+      s._on_timer_failure()
+    | None =>
+      _Unreachable()
     end
 
   fun ref _ssl_flush_sends() =>
@@ -1814,6 +1874,13 @@ class TCPConnection
     // before `event is _event`. The else branch checks disposable first
     // (stale timer disposables, straggler disposables), otherwise dispatches
     // to foreign_event for Happy Eyeballs stragglers.
+    //
+    // Timer branches (connect, idle, user) don't call
+    // `_check_shutdown_complete` after their dispatches. Timer callbacks
+    // can transition state (e.g. `close()` → `_Closing`) but cannot set
+    // `_shutdown_peer` (that requires a zero-byte socket read), so the
+    // graceful-shutdown check would be a no-op. Only `own_event` dispatches
+    // (below) can trigger both flags.
     if event is _connect_timer_event then
       if AsioEvent.errored(flags) then
         _fire_connect_timer_error()
@@ -1822,13 +1889,13 @@ class TCPConnection
       end
     elseif event is _timer_event then
       if AsioEvent.errored(flags) then
-        _cancel_idle_timer()
+        _fire_idle_timer_failure()
       else
         _fire_idle_timeout()
       end
     elseif event is _user_timer_event then
       if AsioEvent.errored(flags) then
-        _cancel_user_timer()
+        _fire_user_timer_failure()
       else
         _fire_user_timer()
       end


### PR DESCRIPTION
When the idle timer or a user timer's ASIO event subscription failed, lori silently cancelled the timer with no application notification. The connection kept running without the protection the application had configured.

This adds `_on_idle_timer_failure` and `_on_timer_failure` callbacks to both lifecycle event receiver traits. Both callbacks fire after the timer has been cancelled and its state cleared, so applications can re-arm the timer from within the callback without tripping idempotency or already-active guards. Default no-op implementations preserve existing behavior for callers that don't override.

Connect timers are unaffected — their ASIO subscription failures already route to `_on_connection_failure(ConnectionFailedTimerError)`.

Closes #279
Design: #275