### PR TITLE
Require ponyc 0.64.0 or later

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -21,7 +21,7 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:release
+      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
     name: Linux
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: config=debug
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run: bash .ci-scripts/macOS-install-release-pony-tools.bash
+        run: bash .ci-scripts/macOS-install-nightly-pony-tools.bash
       - name: configure networking
         run: bash .ci-scripts/macOS-configure-networking.bash
       - name: config=debug
@@ -62,7 +62,7 @@ jobs:
       - name: Tune Windows Networking
         run: .ci-scripts\windows-configure-networking.ps1
       - name: Install Pony tools
-        run: .ci-scripts\windows-install-pony-tools.ps1 releases
+        run: .ci-scripts\windows-install-pony-tools.ps1 nightlies
       - name: Cache LibreSSL libs
         id: cache-libressl
         uses: actions/cache@v5.0.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
     needs:
       - pre-artefact-creation
     container:
-      image: ghcr.io/ponylang/library-documentation-action-v2:release
+      image: ghcr.io/ponylang/library-documentation-action-v2:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -13,7 +13,7 @@ jobs:
 
     name: Linux
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install pony tools
-        run: bash .ci-scripts/macOS-install-release-pony-tools.bash
+        run: bash .ci-scripts/macOS-install-nightly-pony-tools.bash
       - name: Configure networking
         run: bash .ci-scripts/macOS-configure-networking.bash
       - name: Build
@@ -74,7 +74,7 @@ jobs:
       - name: Tune Windows Networking
         run: .ci-scripts\windows-configure-networking.ps1
       - name: Install Pony tools
-        run: .ci-scripts\windows-install-pony-tools.ps1 releases
+        run: .ci-scripts\windows-install-pony-tools.ps1 nightlies
       - name: Cache LibreSSL libs
         id: cache-libressl
         uses: actions/cache@v5.0.3

--- a/.release-notes/require-ponyc-0.64.0.md
+++ b/.release-notes/require-ponyc-0.64.0.md
@@ -1,0 +1,5 @@
+## Require ponyc 0.64.0 or later
+
+lori now requires ponyc 0.64.0 or later. The previous minimum was 0.63.1.
+
+This is driven by changes in ponyc 0.64.0 to FFI declaration syntax and the runtime socket API that lori depends on. Older ponyc versions will fail to compile lori.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,7 @@ lori/
   ossocketopt.pony          -- OSSockOpt: socket option constants (large, generated)
   _connection_state.pony    -- _ConnectionState trait and lifecycle state classes (including _SSLHandshaking, _TLSUpgrading)
   _panics.pony              -- _Unreachable primitive for impossible states
+  socket_result.pony        -- SocketResult primitives + decoder for pony_os_* return values (mirrors ponyc internal type)
   _test.pony                -- Test runner (Main only)
   _test_connection.pony     -- Connection basics, ping-pong, buffer_until, listener tests
   _test_backpressure_drain.pony -- Backpressure drain + unmute read recovery test
@@ -285,7 +286,7 @@ The write path uses an enqueue-then-flush pattern:
 2. Platform flush: `_send_pending_writes()` (POSIX) or `_iocp_submit_pending()` (Windows). Both call `PonyTCP.writev`, which builds the platform-specific IOV array internally.
 3. `_manage_pending_buffer(bytes_sent)` walks `_pending_data`, trims fully-sent entries, and updates `_pending_first_buffer_offset`. Shared across both platforms.
 
-`PonyTCP.writev` takes `Array[ByteSeq] box` and builds `iovec` (POSIX) or `WSABUF` (Windows) arrays internally, hiding the platform-specific tuple layout. Returns bytes sent (POSIX) or buffer count submitted (Windows).
+`PonyTCP.writev` takes `Array[ByteSeq] box` and builds `iovec` (POSIX) or `WSABUF` (Windows) arrays internally, hiding the platform-specific tuple layout. Returns `(SocketResult, USize)`: a tri-state result (`SocketResultOk`, `SocketResultRetry`, `SocketResultError`) plus a count — bytes sent on POSIX, buffer count submitted on Windows. `SocketResultRetry` signals backpressure (EWOULDBLOCK); `SocketResultError` signals an unrecoverable error or peer-close.
 
 Design: Discussion #150.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please note that if this library encounters a state that the programmers thought
 - `use "lori"` to include this package
 - `corral run -- ponyc` to compile your application
 
-Requires ponyc 0.63.1 or later.
+Requires ponyc 0.64.0 or later.
 
 Note: The ssl transitive dependency requires a C SSL library to be installed. Please see the ssl installation instructions for more information.
 

--- a/lori/pony_tcp.pony
+++ b/lori/pony_tcp.pony
@@ -25,21 +25,25 @@ use @pony_os_listen_tcp6[AsioEventID](the_actor: AsioEventNotify,
   host: Pointer[U8] tag,
   port: Pointer[U8] tag)
 use @pony_os_peername[Bool](fd: U32, ip: net.NetAddress ref)
-use @pony_os_recv[USize](event: AsioEventID,
+use @pony_os_recv[U8](event: AsioEventID,
   buffer: Pointer[U8] tag,
-  offset: USize) ?
-use @pony_os_send[USize](event: AsioEventID,
+  size: USize,
+  count_out: Pointer[USize])
+use @pony_os_send[U8](event: AsioEventID,
   buffer: Pointer[U8] tag,
-  from_offset: USize) ?
+  size: USize,
+  count_out: Pointer[USize])
 use @pony_os_socket_close[None](fd: U32)
 use @pony_os_socket_shutdown[None](fd: U32)
 use @pony_os_sockname[Bool](fd: U32, ip: net.NetAddress ref)
-use @pony_os_writev[USize](ev: AsioEventID,
+use @pony_os_writev[U8](ev: AsioEventID,
   wsa: Pointer[(USize, Pointer[U8] tag)] tag,
-  wsacnt: I32) ? if windows
-use @pony_os_writev[USize](ev: AsioEventID,
+  wsacnt: I32,
+  count_out: Pointer[USize]) if windows
+use @pony_os_writev[U8](ev: AsioEventID,
   iov: Pointer[(Pointer[U8] tag, USize)] tag,
-  iovcnt: I32) ? if not windows
+  iovcnt: I32,
+  count_out: Pointer[USize]) if not windows
 use @pony_os_writev_max[I32]()
 
 use net = "net"
@@ -103,19 +107,38 @@ primitive PonyTCP
 
   fun receive(event: AsioEventID,
     buffer: Pointer[U8] tag,
-    offset: USize)
-    : USize ?
+    size: USize)
+    : (SocketResult, USize)
   =>
-    @pony_os_recv(event, buffer, offset)?
+    """
+    Receive up to `size` bytes into `buffer`. Returns the tri-state socket
+    result plus the number of bytes received on `SocketResultOk`. On
+    Windows IOCP, `SocketResultOk` always returns a count of 0 — the
+    actual byte count arrives asynchronously via the read-completion
+    callback.
+    """
+    var count: USize = 0
+    let result = SocketResultDecoder(
+      @pony_os_recv(event, buffer, size, addressof count))
+    (result, count)
 
   fun send(event: AsioEventID,
     buffer: ByteSeq,
     from_offset: USize = 0)
-    : USize ?
+    : (SocketResult, USize)
   =>
-    @pony_os_send(event,
-      buffer.cpointer(from_offset),
-      buffer.size() - from_offset)?
+    """
+    Send bytes from `buffer` starting at `from_offset`. Returns the
+    tri-state socket result plus the number of bytes accepted by the OS
+    (POSIX) or queued for IOCP (Windows) on `SocketResultOk`.
+    """
+    var count: USize = 0
+    let result = SocketResultDecoder(
+      @pony_os_send(event,
+        buffer.cpointer(from_offset),
+        buffer.size() - from_offset,
+        addressof count))
+    (result, count)
 
   fun shutdown(fd: U32) =>
     @pony_os_socket_shutdown(fd)
@@ -125,7 +148,7 @@ primitive PonyTCP
 
   fun writev(event: AsioEventID, data: Array[ByteSeq] box,
     from: USize, count: USize,
-    first_buffer_byte_offset: USize = 0): USize ?
+    first_buffer_byte_offset: USize = 0): (SocketResult, USize) ?
   =>
     """
     Send `count` buffers from `data` starting at index `from` via writev.
@@ -135,37 +158,45 @@ primitive PonyTCP
     `first_buffer_byte_offset` skips bytes in `data(from)` for partial
     write resume.
 
-    Returns bytes sent (POSIX) or buffer count submitted (Windows).
+    Returns the tri-state socket result plus a count: bytes sent on POSIX,
+    buffer count submitted on Windows.
     """
-    ifdef windows then
-      let wsa = Array[(USize, Pointer[U8] tag)](count)
-      var i = from
-      while i < (from + count) do
-        let entry = data(i)?
-        if (i == from) and (first_buffer_byte_offset > 0) then
-          wsa.push((entry.size() - first_buffer_byte_offset,
-            entry.cpointer(first_buffer_byte_offset)))
-        else
-          wsa.push((entry.size(), entry.cpointer()))
+    var bytes_or_buffers: USize = 0
+    let result =
+      ifdef windows then
+        let wsa = Array[(USize, Pointer[U8] tag)](count)
+        var i = from
+        while i < (from + count) do
+          let entry = data(i)?
+          if (i == from) and (first_buffer_byte_offset > 0) then
+            wsa.push((entry.size() - first_buffer_byte_offset,
+              entry.cpointer(first_buffer_byte_offset)))
+          else
+            wsa.push((entry.size(), entry.cpointer()))
+          end
+          i = i + 1
         end
-        i = i + 1
-      end
-      @pony_os_writev(event, wsa.cpointer(), count.i32())?
-    else
-      let iov = Array[(Pointer[U8] tag, USize)](count)
-      var i = from
-      while i < (from + count) do
-        let entry = data(i)?
-        if (i == from) and (first_buffer_byte_offset > 0) then
-          iov.push((entry.cpointer(first_buffer_byte_offset),
-            entry.size() - first_buffer_byte_offset))
-        else
-          iov.push((entry.cpointer(), entry.size()))
+        SocketResultDecoder(
+          @pony_os_writev(event, wsa.cpointer(), count.i32(),
+            addressof bytes_or_buffers))
+      else
+        let iov = Array[(Pointer[U8] tag, USize)](count)
+        var i = from
+        while i < (from + count) do
+          let entry = data(i)?
+          if (i == from) and (first_buffer_byte_offset > 0) then
+            iov.push((entry.cpointer(first_buffer_byte_offset),
+              entry.size() - first_buffer_byte_offset))
+          else
+            iov.push((entry.cpointer(), entry.size()))
+          end
+          i = i + 1
         end
-        i = i + 1
+        SocketResultDecoder(
+          @pony_os_writev(event, iov.cpointer(), count.i32(),
+            addressof bytes_or_buffers))
       end
-      @pony_os_writev(event, iov.cpointer(), count.i32())?
-    end
+    (result, bytes_or_buffers)
 
   fun writev_max(): I32 =>
     """

--- a/lori/socket_result.pony
+++ b/lori/socket_result.pony
@@ -1,0 +1,55 @@
+primitive SocketResultOk
+  """
+  The socket operation completed. For send/writev, the runtime accepted some
+  bytes (POSIX) or queued some buffers (Windows IOCP); for recv, bytes were
+  read into the supplied buffer. The accompanying count is the number of
+  bytes or buffers handled. On Windows IOCP `recv`, the count is always 0 —
+  the actual byte count arrives asynchronously via the read-completion
+  callback.
+  """
+  fun apply(): U8 => 0
+
+primitive SocketResultRetry
+  """
+  The operation could not proceed without blocking (POSIX `EWOULDBLOCK`/
+  `EAGAIN`, Windows `WSAEWOULDBLOCK`). No bytes were transferred. The
+  caller should wait for a readiness event from ASIO and try again.
+  """
+  fun apply(): U8 => 1
+
+primitive SocketResultError
+  """
+  An unrecoverable error occurred, or the peer closed the connection
+  (POSIX `recv` returning 0 is mapped here so the runtime never reports OK
+  with a 0-byte read). The socket should be closed.
+  """
+  fun apply(): U8 => 2
+
+type SocketResult is
+  ( SocketResultOk
+  | SocketResultRetry
+  | SocketResultError )
+
+primitive SocketResultDecoder
+  """
+  Decodes the `U8` returned by the five `pony_os_*` socket runtime functions
+  (`pony_os_writev`, `pony_os_send`, `pony_os_recv`, `pony_os_sendto`,
+  `pony_os_recvfrom`) into a `SocketResult` union.
+
+  This is the Pony-side dual of `pony_socket_result_t` defined in
+  `src/libponyrt/lang/socket.h` of ponyc. The integer values produced by
+  the `SocketResultOk`/`SocketResultRetry`/`SocketResultError` primitives'
+  `apply()` methods must match the C-side `PONY_SOCKET_OK`/
+  `PONY_SOCKET_RETRY`/`PONY_SOCKET_ERROR` constants, which are part of the
+  FFI ABI. Keep both files in sync.
+
+  Any out-of-range `U8` is collapsed to `SocketResultError` so unknown
+  C-side values fail closed. Adding a new wire value on the C side
+  requires updating both the `SocketResult` union and this decoder.
+  """
+  fun apply(v: U8): SocketResult =>
+    match v
+    | SocketResultOk() => SocketResultOk
+    | SocketResultRetry() => SocketResultRetry
+    else SocketResultError
+    end

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -835,8 +835,9 @@ class TCPConnection
     end
 
     // On POSIX, _has_pending_writes() checks whether any data remains
-    // unsent (writev is synchronous — returns bytes written or EWOULDBLOCK).
-    // On Windows IOCP, submitted-but-unconfirmed writes are already in the
+    // unsent (writev is synchronous — returns OK with a byte count,
+    // Retry on EWOULDBLOCK, or Error). On Windows IOCP,
+    // submitted-but-unconfirmed writes are already in the
     // kernel's send buffer, so only un-submitted entries block TLS upgrade.
     // After send("OK") + _iocp_submit_pending(), _pending_writev_total > 0
     // but _pending_data.size() == _pending_sent — the data is in the kernel
@@ -1050,18 +1051,23 @@ class TCPConnection
               total
             end
 
-          // writev syscall — returns bytes sent, 0 on EWOULDBLOCK
-          let len = PonyTCP.writev(_event, _pending_data,
+          // writev syscall — three-state result with bytes-sent count
+          match \exhaustive\ PonyTCP.writev(_event, _pending_data,
             0, num_to_send, _pending_first_buffer_offset)?
-
-          if len < bytes_to_send then
-            _manage_pending_buffer(len)
+          | (SocketResultOk, let len: USize) =>
+            if len < bytes_to_send then
+              _manage_pending_buffer(len)
+              _apply_backpressure()
+            else
+              _manage_pending_buffer(bytes_to_send)
+            end
+          | (SocketResultRetry, _) =>
             _apply_backpressure()
-          else
-            _manage_pending_buffer(bytes_to_send)
+          | (SocketResultError, _) => error
           end
         else
-          // writev error — non-graceful shutdown
+          // writev error or unreachable Array.apply bounds — non-graceful
+          // shutdown
           hard_close()
           return
         end
@@ -1100,13 +1106,14 @@ class TCPConnection
       if num_to_send == 0 then return end
 
       try
-        let len = PonyTCP.writev(_event, _pending_data,
+        match \exhaustive\ PonyTCP.writev(_event, _pending_data,
           0, num_to_send, _pending_first_buffer_offset)?
-
-        if len == 0 then
-          _apply_backpressure()
-        else
+        | (SocketResultOk, let len: USize) =>
+          // On Windows IOCP, the count is wsacnt (buffers submitted), not
+          // bytes. ABI guarantees count > 0 since num_to_send > 0.
           _pending_sent = len
+        | (SocketResultRetry, _) => _apply_backpressure()
+        | (SocketResultError, _) => hard_close()
         end
       else
         hard_close()
@@ -1225,19 +1232,19 @@ class TCPConnection
 
             _resize_read_buffer_if_needed()
 
-            let bytes_read = PonyTCP.receive(_event,
+            match \exhaustive\ PonyTCP.receive(_event,
               _read_buffer.cpointer(_bytes_in_read_buffer),
-              _read_buffer.size() - _bytes_in_read_buffer)?
-
-            if bytes_read == 0 then
+              _read_buffer.size() - _bytes_in_read_buffer)
+            | (SocketResultOk, let bytes_read: USize) =>
+              _bytes_in_read_buffer = _bytes_in_read_buffer + bytes_read
+              total_bytes_read = total_bytes_read + bytes_read
+            | (SocketResultRetry, _) =>
               // would block. try again later
               _set_unreadable()
               PonyAsio.resubscribe_read(_event)
               return
+            | (SocketResultError, _) => error
             end
-
-            _bytes_in_read_buffer = _bytes_in_read_buffer + bytes_read
-            total_bytes_read = total_bytes_read + bytes_read
           end
         else
           // The socket has been closed from the other side.
@@ -1252,12 +1259,14 @@ class TCPConnection
 
   fun ref _iocp_read() =>
     ifdef windows then
-      try
-        PonyTCP.receive(_event,
-          _read_buffer.cpointer(_bytes_in_read_buffer),
-          _read_buffer.size() - _bytes_in_read_buffer)?
-      else
-        close()
+      // Windows IOCP `pony_os_recv` is binary (queued or failed) — Retry is
+      // unreachable per the ABI but `\exhaustive\` requires the arm.
+      match \exhaustive\ PonyTCP.receive(_event,
+        _read_buffer.cpointer(_bytes_in_read_buffer),
+        _read_buffer.size() - _bytes_in_read_buffer)
+      | (SocketResultOk, _) => None
+      | (SocketResultRetry, _) => close()
+      | (SocketResultError, _) => close()
       end
     else
       _Unreachable()


### PR DESCRIPTION
ponyc 0.64.0 made `?` on FFI declarations and calls a syntax error and changed the `pony_os_recv`/`pony_os_send`/`pony_os_writev` socket runtime ABI to a tri-state `(U8 result, USize count_out)` shape. This PR adapts lori's FFI surface and the call sites in `tcp_connection.pony`, switches the four ponyc-dependent workflows to nightly so CI and release jobs pass until 0.64.0 ships, and bumps the documented minimum ponyc to 0.64.0.

Highlights:

- New public `lori/socket_result.pony` — `SocketResult` primitives + decoder, mirroring ponyc's internal type. The file header documents the ABI keep-in-sync requirement.
- `PonyTCP.receive`, `PonyTCP.send`, and `PonyTCP.writev` now return `(SocketResult, USize)` (`writev` is still partial because of internal `data(i)?`).
- Call sites in `lori/tcp_connection.pony` rewritten to `match \exhaustive\` over the tuple. Where outer `try`/`else hard_close()` blocks remain, they cover the wrapper's residual `?` — explicit `SocketResultError` arms raise `error` and let the existing catch run.
- Workflows switched from `:release` to `:nightly` for the ponyc-dependent images: `pr.yml`, `stress-tests.yml`, `release.yml` (doc-generation job), `generate-documentation.yml`.
- Public lori API otherwise unchanged.

Note on verification: `PonyTCP.send` has no callers in `lori/`, `examples/`, or `stress-tests/`, so the local test suite doesn't exercise it directly. The verification is structural: the FFI signature matches ponyc's `pony_os_send(asio_event_t*, const char*, size_t, size_t*)` and the wrapper builds and links against the installed nightly ponyc.

## Follow-up after ponyc 0.64.0 ships

Once ponyc 0.64.0 is released and the lori release that requires it is cut, the four `:nightly` workflows should be reverted to `:release` so we're not tracking future nightly-breaking changes. Separate PR.