### PR TITLE
Remove the dead `--link-ldcmd` Makefile option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,5 @@
 config ?= release
 static ?= false
-linker ?=
 
 PACKAGE := lori
 GET_DEPENDENCIES_WITH := corral fetch
@@ -36,10 +35,6 @@ endif
 
 ifeq ($(static),true)
 	LINKER += --static
-endif
-
-ifneq ($(linker),)
-	LINKER += --link-ldcmd=$(linker)
 endif
 
 ifeq (,$(filter $(MAKECMDGOALS),clean docs realclean TAGS))


### PR DESCRIPTION
ponyc removed the `--linker` and `--link-ldcmd` command line options ([ponylang/ponyc#5452](https://github.com/ponylang/ponyc/pull/5452)) — embedded LLD is now the only linker. lori's Makefile carried the `linker` option that produced `--link-ldcmd`, but nothing ever invoked it, so unlike the released CLI tools lori's CI does not break. This drops the now-meaningless option so it can't produce an invalid ponyc flag if anyone passes `linker=`.