### PR TITLE
Fix connection going silent after a large write under backpressure

### DIFF
--- a/.release-notes/fix-write-only-oneshot-read-deaf.md
+++ b/.release-notes/fix-write-only-oneshot-read-deaf.md
@@ -1,0 +1,5 @@
+## Fix connection going silent after a large write under backpressure
+
+A connection could stop delivering incoming data — `_on_received` would never fire again — after a large write drained under backpressure, when the application kept sending without pausing reads (for example, a relay, proxy, or streaming server). The peer's bytes were acknowledged at the TCP layer but never surfaced to the application, and the connection stayed silent until either side closed it.
+
+A previous fix addressed this for applications that pause reads via `mute()` during backpressure. This completes the fix for applications that send without muting.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,7 @@ lori/
   socket_result.pony        -- SocketResult primitives + decoder for pony_os_* return values (mirrors ponyc internal type)
   _test.pony                -- Test runner (Main only)
   _test_connection.pony     -- Connection basics, ping-pong, buffer_until, listener tests
-  _test_backpressure_drain.pony -- Backpressure drain + unmute read recovery test
+  _test_backpressure_drain.pony -- Backpressure drain + unmute read recovery and write-only oneshot read recovery tests
   _test_flow_control.pony   -- Mute/unmute tests
   _test_send.pony           -- Send, sendv, send-after-close tests
   _test_ssl.pony            -- SSL ping-pong, SSL sendv, and SSL handshake state tests

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -83,3 +83,4 @@ actor \nodoc\ Main is TestList
     test(_TestStartTLSAuthFailure)
     test(_TestSetTimerAfterTLSUpgrade)
     ifdef posix then test(_TestBackpressureDrain) end
+    ifdef posix then test(_TestWriteOnlyEventReadRecovery) end

--- a/lori/_test_backpressure_drain.pony
+++ b/lori/_test_backpressure_drain.pony
@@ -200,3 +200,191 @@ actor \nodoc\ _TestBackpressureDrainClient
       _tcp_connection.send("ping")
       _tcp_connection.close()
     end
+
+class \nodoc\ iso _TestWriteOnlyEventReadRecovery is UnitTest
+  """
+  Verify that a connection still receives data after a write-only oneshot
+  event fully drains its pending writes under backpressure.
+
+  Same shape as BackpressureDrain, but the server sends from outside the read
+  path: it never mutes on throttle or unmutes on unthrottle. The fix for issue
+  #276 restored read interest via unmute()'s _set_readable() + _read(); a relay
+  / proxy / streaming server that never mutes doesn't take that path. When a
+  write-only EPOLLOUT oneshot event drains the last of the payload, the whole
+  fd is disarmed and nothing re-arms reads, so the follow-up "ping" never
+  reaches _on_received.
+
+  Sequence:
+  1. Client connects, sets small SO_RCVBUF, mutes itself, sends "ready"
+  2. Server receives "ready", sends a large payload (never mutes)
+  3. Server gets throttled, tells the listener (does NOT mute)
+  4. Listener tells client to unmute
+  5. Client drains all data, sends "ping"
+  6. Server receives "ping" — passes
+
+  Timeout means the server went read-deaf, reproducing issue #294. POSIX only —
+  the bug is specific to EPOLLONESHOT.
+  """
+  fun name(): String => "WriteOnlyEventReadRecovery"
+
+  fun ref apply(h: TestHelper) =>
+    h.expect_action("listener listening")
+    h.expect_action("server started")
+    h.expect_action("client connected")
+    h.expect_action("server queued payload")
+    h.expect_action("server throttled")
+    h.expect_action("client receiving data")
+    h.expect_action("client sent ping")
+    h.expect_action("server received ping")
+
+    let listener = _TestWriteOnlyEventReadRecoveryListener(h)
+    h.dispose_when_done(listener)
+
+    h.long_test(30_000_000_000)
+
+actor \nodoc\ _TestWriteOnlyEventReadRecoveryListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _server: (_TestWriteOnlyEventReadRecoveryServer | None) = None
+  var _client: (_TestWriteOnlyEventReadRecoveryClient | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      ifdef linux then "127.0.0.2" else "localhost" end,
+      "9771",
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestWriteOnlyEventReadRecoveryServer =>
+    let s = _TestWriteOnlyEventReadRecoveryServer(fd, _h, this)
+    _server = s
+    s
+
+  fun ref _on_listen_failure() =>
+    _h.fail("listener failed to start")
+
+  fun ref _on_listening() =>
+    _h.complete_action("listener listening")
+    _client = _TestWriteOnlyEventReadRecoveryClient(_h)
+
+  be server_throttled(payload_size: USize) =>
+    try
+      (_client as _TestWriteOnlyEventReadRecoveryClient)
+        .start_reading(payload_size)
+    end
+
+  be dispose() =>
+    try (_client as _TestWriteOnlyEventReadRecoveryClient).dispose() end
+    try (_server as _TestWriteOnlyEventReadRecoveryServer).dispose() end
+    _tcp_listener.close()
+
+actor \nodoc\ _TestWriteOnlyEventReadRecoveryServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+  let _listener: _TestWriteOnlyEventReadRecoveryListener
+  var _payload_size: USize = 0
+  var _got_ready: Bool = false
+
+  new create(fd: U32, h: TestHelper,
+    listener: _TestWriteOnlyEventReadRecoveryListener)
+  =>
+    _h = h
+    _listener = listener
+    _tcp_connection = TCPConnection.server(
+      TCPServerAuth(_h.env.root),
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    _h.complete_action("server started")
+    match MakeBufferSize(5)
+    | let b: BufferSize => _tcp_connection.buffer_until(b)
+    else _Unreachable()
+    end
+
+  fun ref _on_throttled() =>
+    // Crucially: do NOT mute. A relay/proxy/streaming server sending from
+    // outside the read path keeps reading enabled while it backpressures.
+    _h.complete_action("server throttled")
+    _listener.server_throttled(_payload_size)
+
+  fun ref _on_unthrottled() =>
+    // Crucially: do NOT unmute. unmute() is what re-armed reads after the
+    // #276 fix; a server that never muted can't rely on it.
+    None
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    if not _got_ready then
+      _got_ready = true
+      match MakeBufferSize(4)
+      | let b: BufferSize => _tcp_connection.buffer_until(b)
+      else _Unreachable()
+      end
+      _tcp_connection.set_so_sndbuf(16384)
+      _payload_size = 256_000
+      let payload = recover iso Array[U8].init('x', _payload_size) end
+      match _tcp_connection.send(consume payload)
+      | let _: SendToken =>
+        _h.complete_action("server queued payload")
+      | let _: SendError =>
+        _h.fail("server send failed")
+      end
+    else
+      _h.complete_action("server received ping")
+      _tcp_connection.close()
+      _h.complete(true)
+    end
+
+actor \nodoc\ _TestWriteOnlyEventReadRecoveryClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+  var _total_received: USize = 0
+  var _payload_size: USize = 0
+  var _sent_ping: Bool = false
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(_h.env.root),
+      ifdef linux then "127.0.0.2" else "localhost" end,
+      "9771",
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _h.complete_action("client connected")
+    _tcp_connection.set_so_rcvbuf(4096)
+    _tcp_connection.mute()
+    _tcp_connection.send("ready")
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    _h.fail("client connect failed")
+
+  be start_reading(payload_size: USize) =>
+    _payload_size = payload_size
+    _tcp_connection.unmute()
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    if _total_received == 0 then
+      _h.complete_action("client receiving data")
+    end
+    _total_received = _total_received + data.size()
+    if not _sent_ping and (_total_received >= _payload_size) then
+      _sent_ping = true
+      _h.complete_action("client sent ping")
+      _tcp_connection.send("ping")
+    end

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -1792,6 +1792,27 @@ class TCPConnection
       else
         _read()
       end
+    else
+      // Runs on every write-only event (EPOLLOUT, no readable flag).
+      // EPOLLONESHOT disarms the whole fd on any event, dropping pending read
+      // interest. When the write fully drains, backpressure isn't re-applied,
+      // so neither read re-arm path runs (_apply_backpressure's resubscribe
+      // and _read's EAGAIN resubscribe are both skipped) and the connection
+      // goes permanently read-deaf (issue #294). Re-arming reads here covers
+      // that case; on a partial drain — where _apply_backpressure already
+      // re-armed reads — this is a harmless redundant resubscribe.
+      //
+      // Skip when _event is disposable: _send_pending_writes() above can
+      // hard_close() on a write error, which unsubscribes _event, and
+      // resubscribing a disposed event asserts in debug builds. We check
+      // disposability rather than is_closed() because is_closed() is also
+      // true during _Closing, where the socket is still open and we must
+      // keep reading to detect the peer FIN.
+      ifdef posix then
+        if not PonyAsio.get_disposable(_event) then
+          PonyAsio.resubscribe_read(_event)
+        end
+      end
     end
 
   fun ref _do_read_again() =>


### PR DESCRIPTION
On POSIX (epoll + EPOLLONESHOT), a connection could stop delivering received data after a large write drained under backpressure, when the application sends from outside the read path (a relay/proxy/streaming server that never mutes). A write-only EPOLLOUT event that fully drained the pending queue left the fd unmonitored — neither the EAGAIN read re-arm nor the backpressure re-arm ran — so reads were never resubscribed. The peer's bytes were ACKed at the TCP layer but never surfaced to the application. The prior backpressure fix did not cover this because its read re-arm rides on `unmute()`.

The fix re-arms reads when a write-only oneshot event fires, guarded against a concurrent `hard_close()` that already unsubscribed the event (which would otherwise assert in debug builds). The guard checks event disposability rather than `is_closed()` so the re-arm still runs during graceful `_Closing`, where we must keep reading to detect the peer FIN.

Adds a regression test (`WriteOnlyEventReadRecovery`) that reproduces the deafness — it is the existing backpressure-drain test minus the server's mute/unmute, which is the load-bearing difference.

**Parked for your input:** the new `else` branch is also live during `_Closing`, `_SSLHandshaking`, and `_TLSUpgrading` (review verified the re-arm is correct in those states by reading, but only `_Open` is exercised by a test). Those write-only-during-close/handshake windows are narrow and hard to trigger deterministically. Add a `_Closing` case to this PR, or file a follow-up issue?

Closes #294