### PR TITLE
Replace Windows IOCP socket I/O with readiness notifications

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,12 +16,15 @@ concurrency:
 permissions:
   packages: read
 
+# These jobs build against nightly ponyc instead of release until ponyc 0.66.0
+# ships (Windows networking needs the readiness backend that replaced IOCP
+# post-0.65.0). Revert all three to release once 0.66.0 is out.
 jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: config=debug
@@ -37,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run: bash .ci-scripts/macOS-install-release-pony-tools.bash
+        run: bash .ci-scripts/macOS-install-nightly-pony-tools.bash
       - name: configure networking
         run: bash .ci-scripts/macOS-configure-networking.bash
       - name: config=debug
@@ -62,7 +65,7 @@ jobs:
       - name: Tune Windows Networking
         run: .ci-scripts\windows-configure-networking.ps1
       - name: Install Pony tools
-        run: .ci-scripts\windows-install-pony-tools.ps1 releases
+        run: .ci-scripts\windows-install-pony-tools.ps1 nightlies
       - name: Cache LibreSSL libs
         id: cache-libressl
         uses: actions/cache@v5.0.3

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -74,7 +74,10 @@ jobs:
       - name: Tune Windows Networking
         run: .ci-scripts\windows-configure-networking.ps1
       - name: Install Pony tools
-        run: .ci-scripts\windows-install-pony-tools.ps1 releases
+        # nightlies until ponyc 0.66.0 ships: Windows networking needs the
+        # readiness backend (IOCP was removed post-0.65.0). Revert to releases
+        # once 0.66.0 is out. Linux/macOS still build against release ponyc.
+        run: .ci-scripts\windows-install-pony-tools.ps1 nightlies
       - name: Cache LibreSSL libs
         id: cache-libressl
         uses: actions/cache@v5.0.3

--- a/.release-notes/replace-windows-iocp-socket-io.md
+++ b/.release-notes/replace-windows-iocp-socket-io.md
@@ -1,0 +1,19 @@
+## Replace Windows IOCP socket I/O with readiness notifications
+
+Lori's Windows networking no longer uses I/O completion ports (IOCP). It now uses readiness notifications, the same model Lori already uses on Linux, macOS, and BSD. This follows ponyc, which removed IOCP from its Windows runtime.
+
+Building Lori for Windows now requires ponyc 0.66.0 or later, the release that made this change. Earlier versions of ponyc will not build Lori on Windows. Non-Windows platforms are unaffected and their version requirement is unchanged.
+
+This change has three consequences for Windows, each covered in its own section under this heading: Windows 10 is no longer supported, write backpressure now reflects the real state of the socket, and a muted connection no longer learns that its peer has closed until it is unmuted.
+
+### Drop support for Windows 10
+
+The Windows readiness API (`ProcessSocketNotifications`) exists only on Windows 11 and Windows Server 2022 and later, so the supported Windows floor is now Windows 11 / Windows Server 2022. Windows 10 is no longer supported.
+
+### Windows TCP write backpressure now reflects real socket writability
+
+On Windows, `_on_throttled` and `_on_unthrottled` now fire based on whether the operating system can actually accept more data, matching the other platforms. Previously the decision used an internal heuristic rather than the real state of the socket.
+
+### A muted Windows connection no longer detects peer close until unmuted
+
+On Windows, a muted connection now behaves like every other platform: while muted, it does not learn that its peer has closed until it is unmuted. You **must** call `unmute()` on a muted connection for it to close — without it the connection will never finish closing. Existing Windows code that relied on a muted connection noticing a peer close must now unmute to make progress.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -250,7 +250,7 @@ Design: Discussion #252.
 - **`_TLSUpgrading.is_open()`**: Returns `true` — the application has already been notified. `_TLSUpgrading` delegates socket option, `idle_timeout`, and `set_timer` operations to the same helpers as `_Open`.
 - **`_TLSUpgrading.sends_allowed()`**: Returns `false` — prevents `is_writeable()` from returning true during handshake.
 
-Preconditions enforced synchronously: connection must be open, not already TLS, not muted, no buffered read data (CVE-2021-23222), no pending writes. Returns `StartTLSError` on failure (connection unchanged). The "no pending writes" check is platform-aware: on POSIX it checks `_has_pending_writes()` (any unconfirmed bytes); on Windows IOCP it checks for un-submitted data only (`_pending_data.size() > _pending_sent`), since submitted-but-unconfirmed writes are already in the kernel's send buffer.
+Preconditions enforced synchronously: connection must be open, not already TLS, not muted, no buffered read data (CVE-2021-23222), no pending writes. Returns `StartTLSError` on failure (connection unchanged). The "no pending writes" check is `_has_pending_writes()` (any unsent bytes) on every platform — writev is synchronous everywhere, so any remaining pending bytes mean the write hasn't fully drained.
 
 Design: Discussion #252.
 
@@ -273,20 +273,19 @@ The library does not queue data on behalf of the application during backpressure
 
 #### Write internals
 
-Pending writes use writev on both POSIX and Windows. The internal fields:
+Pending writes use writev on every platform. The internal fields:
 
 - `_pending_data: Array[ByteSeq]` — buffers awaiting delivery. Also keeps `ByteSeq` values alive for the GC while raw pointers reference them in the IOV array built by `PonyTCP.writev`.
 - `_pending_writev_total: USize` — total bytes remaining (accounts for `_pending_first_buffer_offset`).
 - `_pending_first_buffer_offset: USize` — bytes already sent from `_pending_data(0)`, for partial write resume. COUPLING: points into the buffer owned by `_pending_data(0)` — trimming `_pending_data` without resetting the offset causes a dangling pointer. `_manage_pending_buffer` maintains both.
-- `_pending_sent: USize` — Windows only. IOCP entries submitted but not yet completed. Only one WSASend is outstanding at a time; `_iocp_submit_pending()` is a no-op while `_pending_sent > 0`.
 
 The write path uses an enqueue-then-flush pattern:
 
-1. `_enqueue(data)` pushes to `_pending_data` and updates `_pending_writev_total`. Platform-neutral, no I/O.
-2. Platform flush: `_send_pending_writes()` (POSIX) or `_iocp_submit_pending()` (Windows). Both call `PonyTCP.writev`, which builds the platform-specific IOV array internally.
-3. `_manage_pending_buffer(bytes_sent)` walks `_pending_data`, trims fully-sent entries, and updates `_pending_first_buffer_offset`. Shared across both platforms.
+1. `_enqueue(data)` pushes to `_pending_data` and updates `_pending_writev_total`. No I/O.
+2. `_send_pending_writes()` flushes via `PonyTCP.writev`, which builds the IOV array internally. It loops while writeable and there is pending data, applying backpressure on a partial write or `SocketResultRetry`.
+3. `_manage_pending_buffer(bytes_sent)` walks `_pending_data`, trims fully-sent entries, and updates `_pending_first_buffer_offset`.
 
-`PonyTCP.writev` takes `Array[ByteSeq] box` and builds `iovec` (POSIX) or `WSABUF` (Windows) arrays internally, hiding the platform-specific tuple layout. Returns `(SocketResult, USize)`: a tri-state result (`SocketResultOk`, `SocketResultRetry`, `SocketResultError`) plus a count — bytes sent on POSIX, buffer count submitted on Windows. `SocketResultRetry` signals backpressure (EWOULDBLOCK); `SocketResultError` signals an unrecoverable error or peer-close.
+`PonyTCP.writev` takes `Array[ByteSeq] box` and builds the `(pointer, size)` IOV array internally; the runtime turns it into `iovec` (POSIX) or `WSABUF` (Windows). Returns `(SocketResult, USize)`: a tri-state result (`SocketResultOk`, `SocketResultRetry`, `SocketResultError`) plus the number of bytes sent. `SocketResultRetry` signals backpressure (`EWOULDBLOCK`/`WSAEWOULDBLOCK`); `SocketResultError` signals an unrecoverable error or peer-close. `PonyTCP.writev_max()` is `IOV_MAX` on POSIX and 1 on Windows, so the flush loop batches accordingly.
 
 Design: Discussion #150.
 
@@ -310,7 +309,7 @@ Per-connection idle timeout via ASIO timer events. The duration is an `IdleTimeo
 Lifecycle:
 
 - **Arm points**: plaintext branch of `_establish_connection` and `_complete_server_initialization`; `_SSLHandshaking.ssl_handshake_complete()` for initial SSL connections. `_arm_idle_timer()` is a no-op when `_idle_timeout_nsec == 0` or when a timer already exists (idempotency guard). Also called from `_do_idle_timeout()` when setting a timeout on an established connection with no existing timer. `idle_timeout()` dispatches through the state machine — `_Open` and `_TLSUpgrading` delegate to `_do_idle_timeout()` (stores nsec and manages the timer), while all other states delegate to `_store_idle_timeout()` (stores nsec only).
-- **Reset points**: `_read()` (POSIX, once per read event), `_read_completed()` (Windows, once per read event), `send()` success path (after the SSL/plaintext write block).
+- **Reset points**: `_read()` (once per read event), `send()` success path (after the SSL/plaintext write block).
 - **Cancel point**: `_hard_close_connecting()` and `_hard_close_cleanup()` (shared by all connected hard-close paths: `_hard_close_connected`, `_hard_close_ssl_handshaking`, `_hard_close_tls_upgrading`).
 - **Event dispatch**: Identity check `event is _timer_event` in `_event_notify`'s `if/elseif/else` chain, before the `event is _event` check. Checks `AsioEvent.errored(flags)` first — if errored, calls `_fire_idle_timer_failure()` which cancels the timer via `_cancel_idle_timer()` (unsubscribing the event and zeroing `_idle_timeout_nsec`) before dispatching `_on_idle_timer_failure`. Cancelling before dispatch lets the callback call `idle_timeout(duration)` to re-arm without hitting the `_arm_idle_timer` idempotency guard. `_timer_event` is cleared synchronously in `_cancel_idle_timer()`, so stale disposable events for cancelled timers fall through to the `else` branch where the disposable check destroys them.
 
@@ -378,7 +377,7 @@ API:
 
 `_user_buffer_until()` returns the unwrapped buffer-until value as `USize` (0 when `Streaming`) for invariant checks against buffer sizes. `_tcp_buffer_until()` returns the value the TCP read layer should use — `Streaming` when SSL is active, otherwise `_buffer_until`.
 
-Shrink-back happens in `_resize_read_buffer_if_needed()` when `_bytes_in_read_buffer == 0` and `_read_buffer_size > _read_buffer_min`. On Windows, a post-loop call to `_resize_read_buffer_if_needed()` was added in `_read_completed()` and `_windows_resume_read()` because the existing calls inside the `while _there_is_buffered_read_data()` loop can never see `_bytes_in_read_buffer == 0`.
+Shrink-back happens in `_resize_read_buffer_if_needed()` when `_bytes_in_read_buffer == 0` and `_read_buffer_size > _read_buffer_min`.
 
 Design: Discussion #212 (implementation plan), Discussion #199 section 11 (design).
 
@@ -388,11 +387,7 @@ Design: Discussion #212 (implementation plan), Discussion #199 section 11 (desig
 
 - `_yield_read: Bool` — set by `yield_read()`, cleared by the yield check in the dispatch loop.
 
-The yield check is placed immediately after `_deliver_received()` in three locations:
-
-- **POSIX `_read()`**: Inside the inner `while not _muted and _there_is_buffered_read_data()` loop. When triggered, calls `e._read_again()` and returns, exiting both inner and outer loops. On resume, `_read()` re-enters and processes remaining buffered data before reading from the socket.
-- **Windows `_read_completed()`**: Same position. The return skips the `_queue_read()` at the end — resumption happens via `_read_again()` instead.
-- **Windows `_windows_resume_read()`**: Mirrors the `_read_completed()` dispatch loop. Needed because on Windows, yielding with unprocessed buffered data and just calling `_queue_read()` (which submits an IOCP read) would leave the buffered data unprocessed until new data arrives from the peer. `_windows_resume_read()` processes buffered data first, then submits the IOCP read. The state machine guards against calling this after `hard_close()`: `_Closed.read_again()` is a no-op, while `_Closing.read_again()` correctly calls `_windows_resume_read()` because the socket is still connected and needs an IOCP read to detect the peer's FIN.
+The yield check is placed immediately after `_deliver_received()` in `_read()`'s inner `while not _muted and _there_is_buffered_read_data()` loop. When triggered, it calls `e._read_again()` and returns, exiting both inner and outer loops. On resume, `_read()` re-enters (via `_do_read_again()`) and processes remaining buffered data before reading from the socket. The state machine guards resume against calling after `hard_close()`: `_Closed.read_again()` is a no-op, while `_Closing.read_again()` still calls `_read()` because the socket's read side is open and needs to detect the peer's FIN.
 
 **SSL granularity**: `yield_read()` operates at TCP-read granularity. All SSL-decrypted messages from a single `ssl.receive()` call are delivered inside `_ssl_poll()` before the yield check fires. Per-SSL-message yielding would require changes to `_ssl_poll()` and handling partially-consumed SSL buffers on resume.
 
@@ -417,7 +412,12 @@ The general-purpose methods (`getsockopt`, `getsockopt_u32`, `setsockopt`, `sets
 
 ### Platform differences
 
-POSIX and Windows (IOCP) have distinct code paths throughout `TCPConnection`, guarded by `ifdef posix`/`ifdef windows`. POSIX uses edge-triggered oneshot events with resubscription; Windows uses IOCP completion callbacks.
+POSIX and Windows share a single readiness-based I/O path. Both use one-shot readiness events (epoll/kqueue on POSIX, `ProcessSocketNotifications` on Windows) with resubscription via `PonyAsio.resubscribe_read`/`resubscribe_write`, and call `PonyTCP.receive`/`PonyTCP.writev` synchronously in response. Windows requires ponyc 0.66.0 or later (the release that removed IOCP); the Windows floor is Windows 11 / Windows Server 2022.
+
+Two platform-specific rules remain:
+
+- **writev batch size**: `PonyTCP.writev_max()` is `IOV_MAX` on POSIX, 1 on Windows. The `_send_pending_writes()` loop batches accordingly.
+- **Subscribed-fd close**: a subscribed socket fd (one with an ASIO event) is closed via `PonyTCP.close` only on POSIX. On Windows the readiness backend owns the close — it happens when the deferred `ProcessSocketNotifications` REMOVE from `unsubscribe` is processed, so closing earlier strands the disposal handshake and leaks the fd/event. `_close_event_fd()` (used by all subscribed-fd close sites, including the listener) guards this with `ifdef not windows`. Raw, never-subscribed fds (rejected accepts) are closed cross-platform.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please note that if this library encounters a state that the programmers thought
 - `use "lori"` to include this package
 - `corral run -- ponyc` to compile your application
 
-Requires ponyc 0.64.0 or later.
+Requires ponyc 0.64.0 or later. On Windows, requires ponyc 0.66.0 or later, the release that switched Windows networking from IOCP to readiness notifications.
 
 Note: The ssl transitive dependency requires a C SSL library to be installed. Please see the ssl installation instructions for more information.
 

--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -1,9 +1,9 @@
 use "ssl/net"
 
 trait _ConnectionState
-  fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32)
+  fun ref own_event(conn: TCPConnection ref, flags: U32)
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
-    flags: U32, arg: U32)
+    flags: U32)
   fun ref send(conn: TCPConnection ref,
     data: (ByteSeq | ByteSeqIter)): (SendToken | SendError)
   fun ref close(conn: TCPConnection ref)
@@ -31,11 +31,11 @@ trait _ConnectionState
   fun sends_allowed(): Bool
 
 class _ConnectionNone is _ConnectionState
-  fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
+  fun ref own_event(conn: TCPConnection ref, flags: U32) =>
     _Unreachable()
 
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
-    flags: U32, arg: U32)
+    flags: U32)
   =>
     if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags)
       or AsioEvent.readable(flags))
@@ -50,7 +50,7 @@ class _ConnectionNone is _ConnectionState
     if not PonyAsio.get_disposable(event) then
       PonyAsio.unsubscribe(event)
     end
-    PonyTCP.close(PonyAsio.event_fd(event))
+    conn._close_event_fd(PonyAsio.event_fd(event))
 
   fun ref send(conn: TCPConnection ref,
     data: (ByteSeq | ByteSeqIter)): (SendToken | SendError)
@@ -119,11 +119,11 @@ class _ConnectionNone is _ConnectionState
   fun sends_allowed(): Bool => false
 
 class _ClientConnecting is _ConnectionState
-  fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
+  fun ref own_event(conn: TCPConnection ref, flags: U32) =>
     _Unreachable()
 
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
-    flags: U32, arg: U32)
+    flags: U32)
   =>
     // Check errored before the writeable/readable guard. An errored event
     // must NOT flow into _is_socket_connected — the FD might appear
@@ -211,11 +211,11 @@ class _ClientConnecting is _ConnectionState
   fun sends_allowed(): Bool => false
 
 class _Open is _ConnectionState
-  fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
-    conn._dispatch_io_event(flags, arg)
+  fun ref own_event(conn: TCPConnection ref, flags: U32) =>
+    conn._dispatch_io_event(flags)
 
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
-    flags: U32, arg: U32)
+    flags: U32)
   =>
     // Removing this guard causes the test suite to hang.
     if PonyAsio.get_disposable(event) then return end
@@ -293,11 +293,11 @@ class _Open is _ConnectionState
   fun sends_allowed(): Bool => true
 
 class _Closing is _ConnectionState
-  fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
-    conn._dispatch_io_event(flags, arg)
+  fun ref own_event(conn: TCPConnection ref, flags: U32) =>
+    conn._dispatch_io_event(flags)
 
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
-    flags: U32, arg: U32)
+    flags: U32)
   =>
     // Removing this guard causes the test suite to hang.
     if PonyAsio.get_disposable(event) then return end
@@ -383,11 +383,11 @@ class _UnconnectedClosing is _ConnectionState
   connections drain. hard_close() can interrupt this drain (e.g., connection
   timeout fires during drain), transitioning to _Closed immediately.
   """
-  fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
+  fun ref own_event(conn: TCPConnection ref, flags: U32) =>
     _Unreachable()
 
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
-    flags: U32, arg: U32)
+    flags: U32)
   =>
     if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags)
       or AsioEvent.readable(flags))
@@ -465,11 +465,11 @@ class _UnconnectedClosing is _ConnectionState
   fun sends_allowed(): Bool => false
 
 class _Closed is _ConnectionState
-  fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
+  fun ref own_event(conn: TCPConnection ref, flags: U32) =>
     None
 
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
-    flags: U32, arg: U32)
+    flags: U32)
   =>
     if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags)
       or AsioEvent.readable(flags))
@@ -547,11 +547,11 @@ class _SSLHandshaking is _ConnectionState
   been notified yet — `_on_connected`/`_on_started` fires only after the
   handshake completes.
   """
-  fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
-    conn._dispatch_io_event(flags, arg)
+  fun ref own_event(conn: TCPConnection ref, flags: U32) =>
+    conn._dispatch_io_event(flags)
 
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
-    flags: U32, arg: U32)
+    flags: U32)
   =>
     // Removing this guard causes the test suite to hang.
     if PonyAsio.get_disposable(event) then return end
@@ -641,11 +641,11 @@ class _TLSUpgrading is _ConnectionState
   has already been notified of the plaintext connection — `_on_tls_ready`
   fires when the handshake completes.
   """
-  fun ref own_event(conn: TCPConnection ref, flags: U32, arg: U32) =>
-    conn._dispatch_io_event(flags, arg)
+  fun ref own_event(conn: TCPConnection ref, flags: U32) =>
+    conn._dispatch_io_event(flags)
 
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
-    flags: U32, arg: U32)
+    flags: U32)
   =>
     // Removing this guard causes the test suite to hang.
     if PonyAsio.get_disposable(event) then return end

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -82,5 +82,8 @@ actor \nodoc\ Main is TestList
     test(_TestStartTLSHandshakeFailure)
     test(_TestStartTLSAuthFailure)
     test(_TestSetTimerAfterTLSUpgrade)
+    // POSIX only: these provoke write backpressure with a fixed payload, which
+    // Windows loopback won't trigger (it buffers far beyond SO_SNDBUF/RCVBUF).
+    // The drain and write-only re-arm logic they cover is platform-neutral.
     ifdef posix then test(_TestBackpressureDrain) end
     ifdef posix then test(_TestWriteOnlyEventReadRecovery) end

--- a/lori/_test_backpressure_drain.pony
+++ b/lori/_test_backpressure_drain.pony
@@ -14,7 +14,14 @@ class \nodoc\ iso _TestBackpressureDrain is UnitTest
   6. Server unthrottles, unmutes, receives "ping" (via buffer_until) — passes
 
   Timeout means the server never saw the ping, reproducing the bug from
-  issue #276. POSIX only — the bug is specific to EPOLLONESHOT.
+  issue #276.
+
+  POSIX only. The production drain logic is platform-neutral, but this test
+  needs to provoke write backpressure with a fixed-size payload, and Windows
+  loopback buffers far more than the requested SO_SNDBUF/SO_RCVBUF (a 16 MB
+  send still drains without throttling). Triggering backpressure on Windows
+  requires a send-until-throttled loop rather than a fixed payload; the
+  stdlib's net/TCPThrottle test uses that pattern.
   """
   fun name(): String => "BackpressureDrain"
 
@@ -210,9 +217,11 @@ class \nodoc\ iso _TestWriteOnlyEventReadRecovery is UnitTest
   path: it never mutes on throttle or unmutes on unthrottle. The fix for issue
   #276 restored read interest via unmute()'s _set_readable() + _read(); a relay
   / proxy / streaming server that never mutes doesn't take that path. When a
-  write-only EPOLLOUT oneshot event drains the last of the payload, the whole
-  fd is disarmed and nothing re-arms reads, so the follow-up "ping" never
-  reaches _on_received.
+  write-only (writeable, no readable) one-shot event drains the last of the
+  payload, the whole fd is disarmed and nothing re-arms reads, so the follow-up
+  "ping" never reaches _on_received. The write-only re-arm fix is platform-
+  neutral (every platform now uses one-shot readiness), but see the note on
+  BackpressureDrain for why this test is POSIX only.
 
   Sequence:
   1. Client connects, sets small SO_RCVBUF, mutes itself, sends "ready"
@@ -222,8 +231,7 @@ class \nodoc\ iso _TestWriteOnlyEventReadRecovery is UnitTest
   5. Client drains all data, sends "ping"
   6. Server receives "ping" — passes
 
-  Timeout means the server went read-deaf, reproducing issue #294. POSIX only —
-  the bug is specific to EPOLLONESHOT.
+  Timeout means the server went read-deaf, reproducing issue #294.
   """
   fun name(): String => "WriteOnlyEventReadRecovery"
 

--- a/lori/ossocket.pony
+++ b/lori/ossocket.pony
@@ -28,12 +28,6 @@ primitive _OSSocket
     """
     getsockopt_u32(fd, OSSockOpt.sol_socket(), OSSockOpt.so_sndbuf())
 
-  fun get_so_connect_time(fd: U32): (U32, U32) =>
-    """
-    Wrapper for the FFI call `getsockopt(fd, SOL_SOCKET, SO_CONNECT_TIME, ...)`
-    """
-    getsockopt_u32(fd, OSSockOpt.sol_socket(), OSSockOpt.so_connect_time())
-
   fun set_so_rcvbuf(fd: U32, bufsize: U32): U32 =>
     """
     Wrapper for the FFI call `setsockopt(fd, SOL_SOCKET, SO_RCVBUF, ...)`

--- a/lori/pony_asio.pony
+++ b/lori/pony_asio.pony
@@ -12,13 +12,8 @@ use @pony_asio_event_unsubscribe[None](event: AsioEventID)
 
 primitive PonyAsio
   fun create_event(the_actor: AsioEventNotify, fd: U32): AsioEventID =>
-    let asio_flags = ifdef windows then
-      AsioEvent.read_write()
-    else
-      AsioEvent.read_write_oneshot()
-    end
-
-    @pony_asio_event_create(the_actor, fd, asio_flags, 0, true)
+    @pony_asio_event_create(the_actor, fd, AsioEvent.read_write_oneshot(), 0,
+      true)
 
   fun destroy(event: AsioEventID) =>
     @pony_asio_event_destroy(event)

--- a/lori/pony_tcp.pony
+++ b/lori/pony_tcp.pony
@@ -29,21 +29,13 @@ use @pony_os_recv[U8](event: AsioEventID,
   buffer: Pointer[U8] tag,
   size: USize,
   count_out: Pointer[USize])
-use @pony_os_send[U8](event: AsioEventID,
-  buffer: Pointer[U8] tag,
-  size: USize,
-  count_out: Pointer[USize])
 use @pony_os_socket_close[None](fd: U32)
 use @pony_os_socket_shutdown[None](fd: U32)
 use @pony_os_sockname[Bool](fd: U32, ip: net.NetAddress ref)
 use @pony_os_writev[U8](ev: AsioEventID,
-  wsa: Pointer[(USize, Pointer[U8] tag)] tag,
-  wsacnt: I32,
-  count_out: Pointer[USize]) if windows
-use @pony_os_writev[U8](ev: AsioEventID,
   iov: Pointer[(Pointer[U8] tag, USize)] tag,
   iovcnt: I32,
-  count_out: Pointer[USize]) if not windows
+  count_out: Pointer[USize])
 use @pony_os_writev_max[I32]()
 
 use net = "net"
@@ -112,32 +104,14 @@ primitive PonyTCP
   =>
     """
     Receive up to `size` bytes into `buffer`. Returns the tri-state socket
-    result plus the number of bytes received on `SocketResultOk`. On
-    Windows IOCP, `SocketResultOk` always returns a count of 0 — the
-    actual byte count arrives asynchronously via the read-completion
-    callback.
+    result plus the number of bytes received on `SocketResultOk`. The call is
+    synchronous and non-blocking on every platform: `SocketResultRetry` means
+    no data was available (`EWOULDBLOCK`/`WSAEWOULDBLOCK`), `SocketResultError`
+    means an unrecoverable error or peer close.
     """
     var count: USize = 0
     let result = SocketResultDecoder(
       @pony_os_recv(event, buffer, size, addressof count))
-    (result, count)
-
-  fun send(event: AsioEventID,
-    buffer: ByteSeq,
-    from_offset: USize = 0)
-    : (SocketResult, USize)
-  =>
-    """
-    Send bytes from `buffer` starting at `from_offset`. Returns the
-    tri-state socket result plus the number of bytes accepted by the OS
-    (POSIX) or queued for IOCP (Windows) on `SocketResultOk`.
-    """
-    var count: USize = 0
-    let result = SocketResultDecoder(
-      @pony_os_send(event,
-        buffer.cpointer(from_offset),
-        buffer.size() - from_offset,
-        addressof count))
     (result, count)
 
   fun shutdown(fd: U32) =>
@@ -152,55 +126,37 @@ primitive PonyTCP
   =>
     """
     Send `count` buffers from `data` starting at index `from` via writev.
-    Builds the platform-specific IOV array (iovec on POSIX, WSABUF on
-    Windows) internally.
+    Builds the IOV array of `(pointer, size)` entries internally; the runtime
+    turns it into `iovec` (POSIX) or `WSABUF` (Windows) as needed.
 
     `first_buffer_byte_offset` skips bytes in `data(from)` for partial
     write resume.
 
-    Returns the tri-state socket result plus a count: bytes sent on POSIX,
-    buffer count submitted on Windows.
+    Returns the tri-state socket result plus the number of bytes sent on
+    `SocketResultOk`. The call is synchronous and non-blocking on every
+    platform.
     """
-    var bytes_or_buffers: USize = 0
-    let result =
-      ifdef windows then
-        let wsa = Array[(USize, Pointer[U8] tag)](count)
-        var i = from
-        while i < (from + count) do
-          let entry = data(i)?
-          if (i == from) and (first_buffer_byte_offset > 0) then
-            wsa.push((entry.size() - first_buffer_byte_offset,
-              entry.cpointer(first_buffer_byte_offset)))
-          else
-            wsa.push((entry.size(), entry.cpointer()))
-          end
-          i = i + 1
-        end
-        SocketResultDecoder(
-          @pony_os_writev(event, wsa.cpointer(), count.i32(),
-            addressof bytes_or_buffers))
+    var bytes_sent: USize = 0
+    let iov = Array[(Pointer[U8] tag, USize)](count)
+    var i = from
+    while i < (from + count) do
+      let entry = data(i)?
+      if (i == from) and (first_buffer_byte_offset > 0) then
+        iov.push((entry.cpointer(first_buffer_byte_offset),
+          entry.size() - first_buffer_byte_offset))
       else
-        let iov = Array[(Pointer[U8] tag, USize)](count)
-        var i = from
-        while i < (from + count) do
-          let entry = data(i)?
-          if (i == from) and (first_buffer_byte_offset > 0) then
-            iov.push((entry.cpointer(first_buffer_byte_offset),
-              entry.size() - first_buffer_byte_offset))
-          else
-            iov.push((entry.cpointer(), entry.size()))
-          end
-          i = i + 1
-        end
-        SocketResultDecoder(
-          @pony_os_writev(event, iov.cpointer(), count.i32(),
-            addressof bytes_or_buffers))
+        iov.push((entry.cpointer(), entry.size()))
       end
-    (result, bytes_or_buffers)
+      i = i + 1
+    end
+    let result = SocketResultDecoder(
+      @pony_os_writev(event, iov.cpointer(), count.i32(),
+        addressof bytes_sent))
+    (result, bytes_sent)
 
   fun writev_max(): I32 =>
     """
-    Maximum number of IOV entries per writev call. IOV_MAX on POSIX, 1 on
-    Windows (Windows submits all entries at once, not in batches).
+    Maximum number of `(pointer, size)` entries a single writev call may
+    carry. `IOV_MAX` on POSIX, 1 on Windows.
     """
     @pony_os_writev_max()

--- a/lori/socket_result.pony
+++ b/lori/socket_result.pony
@@ -1,11 +1,11 @@
 primitive SocketResultOk
   """
   The socket operation completed. For send/writev, the runtime accepted some
-  bytes (POSIX) or queued some buffers (Windows IOCP); for recv, bytes were
-  read into the supplied buffer. The accompanying count is the number of
-  bytes or buffers handled. On Windows IOCP `recv`, the count is always 0 —
-  the actual byte count arrives asynchronously via the read-completion
-  callback.
+  bytes; for recv, bytes were read into the supplied buffer. The accompanying
+  count is the number of bytes handled. The operation is synchronous and
+  non-blocking on every platform (the Windows backend uses readiness
+  notifications, not overlapped IOCP), so the count is always the bytes
+  transferred by this call.
   """
   fun apply(): U8 => 0
 

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -26,7 +26,6 @@ class TCPConnection
   embed _pending_data: Array[ByteSeq] = _pending_data.create()
   var _pending_writev_total: USize = 0
   var _pending_first_buffer_offset: USize = 0
-  var _pending_sent: USize = 0
   var _read_buffer: Array[U8] iso = recover Array[U8] end
   var _bytes_in_read_buffer: USize = 0
   var _read_buffer_size: USize = 16384
@@ -640,9 +639,10 @@ class TCPConnection
     """
     Common teardown for hard-closing an established connection. Handles
     shutdown flags, send_failed for pending token, clearing pending buffers,
-    cancelling all timers, unsubscribing the event, closing the fd, and
-    disposing SSL. Order is load-bearing: timer cancel before event
-    unsubscribe, SSL dispose after fd close.
+    cancelling all timers, unsubscribing the event, releasing the fd (see
+    `_close_event_fd` — closed here on POSIX, deferred to the unsubscribe
+    REMOVE on Windows), and disposing SSL. Order is load-bearing: timer cancel
+    before event unsubscribe, SSL dispose after the fd is released.
 
     Does NOT set `_ssl = None` — the connection is terminal and nothing
     accesses it afterward. The caller must set `_state = _Closed` before
@@ -662,9 +662,6 @@ class TCPConnection
     _pending_data.clear()
     _pending_writev_total = 0
     _pending_first_buffer_offset = 0
-    ifdef windows then
-      _pending_sent = 0
-    end
     _pending_token = None
 
     _cancel_idle_timer()
@@ -674,8 +671,7 @@ class TCPConnection
     _set_unreadable()
     _set_unwriteable()
 
-    // On windows, this will also cancel all outstanding IOCP operations.
-    PonyTCP.close(_fd)
+    _close_event_fd(_fd)
     _fd = -1
 
     match _ssl
@@ -834,21 +830,10 @@ class TCPConnection
     | let _: SSL ref => return StartTLSAlreadyTLS
     end
 
-    // On POSIX, _has_pending_writes() checks whether any data remains
-    // unsent (writev is synchronous — returns OK with a byte count,
-    // Retry on EWOULDBLOCK, or Error). On Windows IOCP,
-    // submitted-but-unconfirmed writes are already in the
-    // kernel's send buffer, so only un-submitted entries block TLS upgrade.
-    // After send("OK") + _iocp_submit_pending(), _pending_writev_total > 0
-    // but _pending_data.size() == _pending_sent — the data is in the kernel
-    // and TLS can safely proceed.
-    let has_unsent_writes: Bool = ifdef windows then
-      _pending_data.size() > _pending_sent
-    else
-      _has_pending_writes()
-    end
-
-    if _muted or (_bytes_in_read_buffer > 0) or has_unsent_writes then
+    // writev is synchronous on every platform now — it returns OK with a
+    // byte count, Retry on EWOULDBLOCK, or Error. Any remaining pending
+    // bytes mean the write didn't fully drain, so the TLS upgrade must wait.
+    if _muted or (_bytes_in_read_buffer > 0) or _has_pending_writes() then
       return StartTLSNotReady
     end
 
@@ -919,11 +904,7 @@ class TCPConnection
           _enqueue(v)
         end
       end
-      ifdef windows then
-        _iocp_submit_pending()
-      else
-        _send_pending_writes()
-      end
+      _send_pending_writes()
     end
 
     _reset_idle_timer()
@@ -965,9 +946,8 @@ class TCPConnection
 
   fun ref _enqueue(data: ByteSeq) =>
     """
-    Add a buffer to the pending write queue. Callers must call the
-    platform-specific flush after enqueuing: `_send_pending_writes()` on
-    POSIX, `_iocp_submit_pending()` on Windows.
+    Add a buffer to the pending write queue. Callers must call
+    `_send_pending_writes()` to flush after enqueuing.
 
     Uses `not is_closed()` rather than `is_open()` because `_ssl_flush_sends()`
     calls `_enqueue()` during `_SSLHandshaking` (where `is_open() = false`)
@@ -1024,147 +1004,69 @@ class TCPConnection
 
   fun ref _send_pending_writes() =>
     """
-    Flush pending write data using writev.
-    This is POSIX only.
+    Flush pending write data using writev. Synchronous and non-blocking on
+    every platform: a partial write or `SocketResultRetry` (the kernel send
+    buffer is full) applies backpressure and leaves the rest queued for the
+    next writeable event.
     """
-    ifdef posix then
-      let writev_batch_size: USize = PonyTCP.writev_max().usize()
+    let writev_batch_size: USize = PonyTCP.writev_max().usize()
 
-      while _writeable and (_pending_writev_total > 0) do
-        try
-          // Determine batch size and byte count
-          let num_to_send: USize =
-            _pending_data.size().min(writev_batch_size)
-
-          let bytes_to_send: USize =
-            if num_to_send == _pending_data.size() then
-              _pending_writev_total
-            else
-              var total: USize = 0
-              var i: USize = 0
-              while i < num_to_send do
-                let s = _pending_data(i)?.size()
-                total = total +
-                  if i == 0 then s - _pending_first_buffer_offset else s end
-                i = i + 1
-              end
-              total
-            end
-
-          // writev syscall — three-state result with bytes-sent count
-          match \exhaustive\ PonyTCP.writev(_event, _pending_data,
-            0, num_to_send, _pending_first_buffer_offset)?
-          | (SocketResultOk, let len: USize) =>
-            if len < bytes_to_send then
-              _manage_pending_buffer(len)
-              _apply_backpressure()
-            else
-              _manage_pending_buffer(bytes_to_send)
-            end
-          | (SocketResultRetry, _) =>
-            _apply_backpressure()
-          | (SocketResultError, _) => error
-          end
-        else
-          // writev error or unreachable Array.apply bounds — non-graceful
-          // shutdown
-          hard_close()
-          return
-        end
-      end
-
-      if _pending_writev_total == 0 then
-        _release_backpressure()
-
-        match _pending_token
-        | let t: SendToken =>
-          _pending_token = None
-          match \exhaustive\ _enclosing
-          | let e: TCPConnectionActor ref =>
-            e._notify_sent(t)
-          | None =>
-            _Unreachable()
-          end
-        end
-      end
-    else
-      _Unreachable()
-    end
-
-  fun ref _iocp_submit_pending() =>
-    """
-    Submit all pending write buffers to IOCP in a single WSASend.
-    Only one IOCP write is outstanding at a time — if a previous WSASend
-    hasn't completed yet, this is a no-op and the data waits in
-    `_pending_data` until `_write_completed` resubmits.
-    This is Windows only.
-    """
-    ifdef windows then
-      if _pending_sent > 0 then return end
-
-      let num_to_send = _pending_data.size()
-      if num_to_send == 0 then return end
-
+    while _writeable and (_pending_writev_total > 0) do
       try
+        // Determine batch size and byte count
+        let num_to_send: USize =
+          _pending_data.size().min(writev_batch_size)
+
+        let bytes_to_send: USize =
+          if num_to_send == _pending_data.size() then
+            _pending_writev_total
+          else
+            var total: USize = 0
+            var i: USize = 0
+            while i < num_to_send do
+              let s = _pending_data(i)?.size()
+              total = total +
+                if i == 0 then s - _pending_first_buffer_offset else s end
+              i = i + 1
+            end
+            total
+          end
+
+        // writev syscall — three-state result with bytes-sent count
         match \exhaustive\ PonyTCP.writev(_event, _pending_data,
           0, num_to_send, _pending_first_buffer_offset)?
         | (SocketResultOk, let len: USize) =>
-          // On Windows IOCP, the count is wsacnt (buffers submitted), not
-          // bytes. ABI guarantees count > 0 since num_to_send > 0.
-          _pending_sent = len
-        | (SocketResultRetry, _) => _apply_backpressure()
-        | (SocketResultError, _) => hard_close()
+          if len < bytes_to_send then
+            _manage_pending_buffer(len)
+            _apply_backpressure()
+          else
+            _manage_pending_buffer(bytes_to_send)
+          end
+        | (SocketResultRetry, _) =>
+          _apply_backpressure()
+        | (SocketResultError, _) => error
         end
       else
-        hard_close()
-      end
-    else
-      _Unreachable()
-    end
-
-  fun ref _write_completed(len: U32) =>
-    """
-    The OS has informed us that `len` bytes of pending writes have completed.
-    This occurs only with IOCP on Windows.
-
-    A single WSASend call covers all submitted entries. When the IOCP
-    completion fires, the entire operation is done — none of the entries
-    are in-flight anymore. We reset `_pending_sent` to 0 and resubmit
-    any remaining data.
-    """
-    ifdef windows then
-      if len == 0 then
+        // writev error or unreachable Array.apply bounds — non-graceful
+        // shutdown
         hard_close()
         return
       end
+    end
 
-      _manage_pending_buffer(len.usize())
-      // The WSASend IOCP operation has completed. All entries covered by
-      // this operation are no longer in-flight.
-      _pending_sent = 0
+    if _pending_writev_total == 0 then
+      _release_backpressure()
 
-      if _pending_writev_total == 0 then
-        _release_backpressure()
-
-        match _pending_token
-        | let t: SendToken =>
-          _pending_token = None
-          match \exhaustive\ _enclosing
-          | let e: TCPConnectionActor ref =>
-            e._notify_sent(t)
-          | None =>
-            _Unreachable()
-          end
-        end
-      else
-        // Resubmit remaining data
-        _iocp_submit_pending()
-        if _pending_sent < 16 then
-          _release_backpressure()
+      match _pending_token
+      | let t: SendToken =>
+        _pending_token = None
+        match \exhaustive\ _enclosing
+        | let e: TCPConnectionActor ref =>
+          e._notify_sent(t)
+        | None =>
+          _Unreachable()
         end
       end
-    else
-      _Unreachable()
     end
 
   fun ref _deliver_received(s: EitherLifecycleEventReceiver ref,
@@ -1183,200 +1085,73 @@ class TCPConnection
     end
 
   fun ref _read() =>
-    ifdef posix then
-      _reset_idle_timer()
-      match \exhaustive\ _lifecycle_event_receiver
-      | let s: EitherLifecycleEventReceiver ref =>
-        try
-          var total_bytes_read: USize = 0
+    _reset_idle_timer()
+    match \exhaustive\ _lifecycle_event_receiver
+    | let s: EitherLifecycleEventReceiver ref =>
+      try
+        var total_bytes_read: USize = 0
 
-          while _readable do
-            // exit if muted
-            if _muted then
-              return
+        while _readable do
+          // exit if muted
+          if _muted then
+            return
+          end
+
+          // Handle any data already in the read buffer
+          while not _muted and _there_is_buffered_read_data() do
+            let bytes_to_consume = match \exhaustive\ _tcp_buffer_until()
+            | let e: BufferSize => e()
+            | Streaming => _bytes_in_read_buffer
             end
 
-            // Handle any data already in the read buffer
-            while not _muted and _there_is_buffered_read_data() do
-              let bytes_to_consume = match \exhaustive\ _tcp_buffer_until()
-              | let e: BufferSize => e()
-              | Streaming => _bytes_in_read_buffer
+            let x = _read_buffer = recover Array[U8] end
+            (let data', _read_buffer) = (consume x).chop(bytes_to_consume)
+            _bytes_in_read_buffer = _bytes_in_read_buffer - bytes_to_consume
+
+            _deliver_received(s, consume data')
+
+            // COUPLING: This check must remain immediately after
+            // _deliver_received() — moving it would change when the yield
+            // takes effect relative to application callbacks.
+            if _yield_read then
+              _yield_read = false
+              match \exhaustive\ _enclosing
+              | let e: TCPConnectionActor ref => e._read_again()
+              | None => _Unreachable()
               end
-
-              let x = _read_buffer = recover Array[U8] end
-              (let data', _read_buffer) = (consume x).chop(bytes_to_consume)
-              _bytes_in_read_buffer = _bytes_in_read_buffer - bytes_to_consume
-
-              _deliver_received(s, consume data')
-
-              // COUPLING: This check must remain immediately after
-              // _deliver_received() — moving it would change when the yield
-              // takes effect relative to application callbacks.
-              if _yield_read then
-                _yield_read = false
-                match \exhaustive\ _enclosing
-                | let e: TCPConnectionActor ref => e._read_again()
-                | None => _Unreachable()
-                end
-                return
-              end
-            end
-
-            // Yield after reading a buffer's worth of data to allow GC and
-            // other actors to run. _queue_read() schedules _read_again to
-            // resume.
-            if total_bytes_read >= _read_buffer_size then
-              _queue_read()
               return
-            end
-
-            _resize_read_buffer_if_needed()
-
-            match \exhaustive\ PonyTCP.receive(_event,
-              _read_buffer.cpointer(_bytes_in_read_buffer),
-              _read_buffer.size() - _bytes_in_read_buffer)
-            | (SocketResultOk, let bytes_read: USize) =>
-              _bytes_in_read_buffer = _bytes_in_read_buffer + bytes_read
-              total_bytes_read = total_bytes_read + bytes_read
-            | (SocketResultRetry, _) =>
-              // would block. try again later
-              _set_unreadable()
-              PonyAsio.resubscribe_read(_event)
-              return
-            | (SocketResultError, _) => error
             end
           end
-        else
-          // The socket has been closed from the other side.
-          hard_close()
-        end
-      | None =>
-        _Unreachable()
-      end
-    else
-      _Unreachable()
-    end
 
-  fun ref _iocp_read() =>
-    ifdef windows then
-      // Windows IOCP `pony_os_recv` is binary (queued or failed) — Retry is
-      // unreachable per the ABI but `\exhaustive\` requires the arm.
-      match \exhaustive\ PonyTCP.receive(_event,
-        _read_buffer.cpointer(_bytes_in_read_buffer),
-        _read_buffer.size() - _bytes_in_read_buffer)
-      | (SocketResultOk, _) => None
-      | (SocketResultRetry, _) => close()
-      | (SocketResultError, _) => close()
-      end
-    else
-      _Unreachable()
-    end
-
-  fun ref _read_completed(len: U32) =>
-    """
-    The OS has informed us that `len` bytes of data has been read and is now
-    available.
-    """
-    ifdef windows then
-      _reset_idle_timer()
-      match \exhaustive\ _lifecycle_event_receiver
-      | let s: EitherLifecycleEventReceiver ref =>
-        if len == 0 then
-          // The socket has been closed from the other side, or a hard close has
-          // cancelled the queued read.
-          _set_unreadable()
-          _shutdown_peer = true
-          close()
-          return
-        end
-
-        // Handle the data
-        _bytes_in_read_buffer = _bytes_in_read_buffer + len.usize()
-
-        while not _muted and _there_is_buffered_read_data()
-        do
-          // get data to be distributed and update `_bytes_in_read_buffer`
-          let chop_at = match \exhaustive\ _tcp_buffer_until()
-          | let e: BufferSize => e()
-          | Streaming => _bytes_in_read_buffer
-          end
-          (let data, _read_buffer) = (consume _read_buffer).chop(chop_at)
-          _bytes_in_read_buffer = _bytes_in_read_buffer - chop_at
-
-          _deliver_received(s, consume data)
-
-          // COUPLING: This check must remain immediately after
-          // _deliver_received() — moving it would change when the yield
-          // takes effect relative to application callbacks.
-          if _yield_read then
-            _yield_read = false
-            match \exhaustive\ _enclosing
-            | let e: TCPConnectionActor ref => e._read_again()
-            | None => _Unreachable()
-            end
+          // Yield after reading a buffer's worth of data to allow GC and
+          // other actors to run. _queue_read() schedules _read_again to
+          // resume.
+          if total_bytes_read >= _read_buffer_size then
+            _queue_read()
             return
           end
 
           _resize_read_buffer_if_needed()
-        end
 
-        _resize_read_buffer_if_needed()
-        _queue_read()
-      | None =>
-        _Unreachable()
-      end
-    else
-      _Unreachable()
-    end
-
-  fun ref _windows_resume_read() =>
-    """
-    Resume reading after a yield on Windows. Processes any buffered data first,
-    then submits an IOCP read for new data. Without this, yielding with
-    unprocessed buffered data and calling `_queue_read()` directly would leave
-    the buffered data unprocessed until new data arrives from the peer — which
-    might be never.
-
-    Called via `_do_read_again()` from the `_read_again()` behavior, which is
-    deferred. The state machine guards against calling this after hard_close():
-    `_Closed.read_again()` is a no-op. `_Closing.read_again()` correctly
-    calls this because the socket is still connected and we need an IOCP read
-    to detect the peer's FIN.
-    """
-    ifdef windows then
-      match \exhaustive\ _lifecycle_event_receiver
-      | let s: EitherLifecycleEventReceiver ref =>
-        while not _muted and _there_is_buffered_read_data() do
-          let chop_at = match \exhaustive\ _tcp_buffer_until()
-          | let e: BufferSize => e()
-          | Streaming => _bytes_in_read_buffer
-          end
-          (let data, _read_buffer) = (consume _read_buffer).chop(chop_at)
-          _bytes_in_read_buffer = _bytes_in_read_buffer - chop_at
-
-          _deliver_received(s, consume data)
-
-          // COUPLING: This check must remain immediately after
-          // _deliver_received() — moving it would change when the yield
-          // takes effect relative to application callbacks.
-          if _yield_read then
-            _yield_read = false
-            match \exhaustive\ _enclosing
-            | let e: TCPConnectionActor ref => e._read_again()
-            | None => _Unreachable()
-            end
+          match \exhaustive\ PonyTCP.receive(_event,
+            _read_buffer.cpointer(_bytes_in_read_buffer),
+            _read_buffer.size() - _bytes_in_read_buffer)
+          | (SocketResultOk, let bytes_read: USize) =>
+            _bytes_in_read_buffer = _bytes_in_read_buffer + bytes_read
+            total_bytes_read = total_bytes_read + bytes_read
+          | (SocketResultRetry, _) =>
+            // would block. try again later
+            _set_unreadable()
+            PonyAsio.resubscribe_read(_event)
             return
+          | (SocketResultError, _) => error
           end
-
-          _resize_read_buffer_if_needed()
         end
-
-        _resize_read_buffer_if_needed()
-        _queue_read()
-      | None =>
-        _Unreachable()
+      else
+        // The socket has been closed from the other side.
+        hard_close()
       end
-    else
+    | None =>
       _Unreachable()
     end
 
@@ -1409,16 +1184,16 @@ class TCPConnection
     end
 
   fun ref _queue_read() =>
-    ifdef posix then
-      match \exhaustive\ _enclosing
-      | let e: TCPConnectionActor ref =>
-        e._read_again()
-        return
-      | None =>
-        _Unreachable()
-      end
-    else
-      _iocp_read()
+    """
+    Schedule reading to resume in a later turn via the `_read_again` behavior.
+    Used to yield after a buffer's worth of data and to (re)start reading after
+    establishing a connection or unmuting.
+    """
+    match \exhaustive\ _enclosing
+    | let e: TCPConnectionActor ref =>
+      e._read_again()
+    | None =>
+      _Unreachable()
     end
 
   fun ref _apply_backpressure() =>
@@ -1429,9 +1204,7 @@ class TCPConnection
         // throttled means we are also unwriteable
         // being unthrottled doesn't however mean we are writable
         _set_unwriteable()
-        ifdef not windows then
-          PonyAsio.resubscribe_write(_event)
-        end
+        PonyAsio.resubscribe_write(_event)
         s._on_throttled()
       end
     | None =>
@@ -1715,11 +1488,7 @@ class TCPConnection
           _enqueue(ssl.send()?)
         end
       end
-      ifdef windows then
-        _iocp_submit_pending()
-      else
-        _send_pending_writes()
-      end
+      _send_pending_writes()
     end
 
   fun ref _ssl_poll(s: EitherLifecycleEventReceiver ref) =>
@@ -1766,10 +1535,11 @@ class TCPConnection
   fun ref read_again() =>
     _state.read_again(this)
 
-  fun ref _dispatch_io_event(flags: U32, arg: U32) =>
+  fun ref _dispatch_io_event(flags: U32) =>
     """
     Common I/O dispatch logic for socket events. Shared by all states that
-    have a connected socket and need to process I/O notifications.
+    have a connected socket and need to process I/O notifications. Identical
+    on every platform: readiness edges drive synchronous recv/writev.
     """
     if AsioEvent.errored(flags) then
       hard_close()
@@ -1778,62 +1548,59 @@ class TCPConnection
 
     if AsioEvent.writeable(flags) then
       _set_writeable()
-      ifdef windows then
-        _write_completed(arg)
-      else
-        _send_pending_writes()
-      end
+      _send_pending_writes()
     end
 
     if AsioEvent.readable(flags) then
       _set_readable()
-      ifdef windows then
-        _read_completed(arg)
-      else
-        _read()
-      end
+      _read()
     else
-      // Runs on every write-only event (EPOLLOUT, no readable flag).
-      // EPOLLONESHOT disarms the whole fd on any event, dropping pending read
-      // interest. The write branch above already ran _set_writeable(), which
-      // releases backpressure. So on a full drain _apply_backpressure() is
-      // never re-entered, and neither read re-arm path runs (its resubscribe
-      // and _read's EAGAIN resubscribe are both skipped), leaving the
-      // connection permanently read-deaf (issue #294). Re-arming reads here
-      // covers that. On a partial drain _apply_backpressure() does re-enter,
-      // and because PonyAsio.resubscribe re-arms whichever directions are
-      // not-ready (the read/write names signal intent, not effect), its write
-      // resubscribe also re-arms reads, so the resubscribe here is redundant
-      // but harmless.
+      // Runs on every write-only event (writeable, no readable flag).
+      // One-shot readiness (EPOLLONESHOT on Linux, the equivalent gating on
+      // macOS/BSD kqueue and Windows ProcessSocketNotifications) disarms the
+      // whole fd on any event, dropping pending read interest. The write
+      // branch above already ran _set_writeable(), which releases
+      // backpressure. So on a full drain _apply_backpressure() is never
+      // re-entered, and neither read re-arm path runs (its resubscribe and
+      // _read's EAGAIN resubscribe are both skipped), leaving the connection
+      // permanently read-deaf (issue #294). Re-arming reads here covers that.
+      // On a partial drain _apply_backpressure() does re-enter, and because
+      // PonyAsio.resubscribe re-arms whichever directions are not-ready (the
+      // read/write names signal intent, not effect), its write resubscribe
+      // also re-arms reads, so the resubscribe here is redundant but harmless.
       //
-      // Skip when _event is disposable: _send_pending_writes() above can
-      // hard_close() on a write error, which unsubscribes _event, and
-      // resubscribing a disposed event asserts in debug builds.
+      // Skip the re-arm unless the socket is still healthy and fully drained,
+      // which `_writeable` captures: `_set_writeable()` above set it true, and
+      // nothing cleared it means no hard_close and no backpressure this turn.
+      // `_send_pending_writes()` above can hard_close() on a write error (peer
+      // RST with data queued), and `_hard_close_cleanup` then unsubscribes the
+      // event and calls `_set_unwriteable()`. Resubscribing after that is wrong:
+      // on POSIX the event is already disposable (the resubscribe would assert
+      // in debug); on Windows the close is DEFERRED — `unsubscribe` only marks
+      // the event `removing`, so `get_disposable` still returns false and the
+      // resubscribe would re-enable a socket whose REMOVE is already in flight,
+      // stranding the deferred-close handshake. `_writeable` is false in both
+      // cases, so it is the load-bearing guard; `get_disposable` is kept as
+      // POSIX defense in depth. `_writeable` is also false after a partial-drain
+      // backpressure, where `_apply_backpressure`'s resubscribe already re-arms
+      // reads, so skipping here is redundant, not harmful.
       //
-      // The guard is deliberately disposability, NOT is_closed() or is_open().
-      // This branch is shared by _Open, _Closing, _SSLHandshaking, and
-      // _TLSUpgrading. During _Closing the socket's read side is still open and
-      // we must keep re-arming reads to detect the peer FIN, yet is_closed() is
-      // true there — an is_closed() guard would skip the re-arm and hang the
-      // close. Likewise is_open() is false during _SSLHandshaking, where reads
-      // must stay armed to finish the handshake. Only _Open is exercised by a
-      // test (WriteOnlyEventReadRecovery); the write-only full-drain can't be
-      // triggered deterministically in the other three states, so neither the
-      // compiler nor the suite will catch a regression here. Do not weaken this
-      // guard. See issue #296.
-      ifdef posix then
-        if not PonyAsio.get_disposable(_event) then
-          PonyAsio.resubscribe_read(_event)
-        end
+      // `_writeable` (not is_closed()/is_open()) is deliberate: this branch is
+      // shared by _Open, _Closing, _SSLHandshaking, and _TLSUpgrading. During
+      // _Closing the read side is still open and reads must stay armed to detect
+      // the peer FIN, yet is_closed() is true there; during _SSLHandshaking
+      // is_open() is false but reads must stay armed to finish the handshake.
+      // Only _Open is exercised by a test (WriteOnlyEventReadRecovery, POSIX
+      // only); the full-drain can't be triggered deterministically in the other
+      // states, so neither the compiler nor the suite catches a regression here.
+      // Do not weaken this guard. See issues #294 and #296.
+      if _writeable and not PonyAsio.get_disposable(_event) then
+        PonyAsio.resubscribe_read(_event)
       end
     end
 
   fun ref _do_read_again() =>
-    ifdef posix then
-      _read()
-    else
-      _windows_resume_read()
-    end
+    _read()
 
   fun ref _set_state(state: _ConnectionState ref) =>
     _state = state
@@ -1870,13 +1637,27 @@ class TCPConnection
       end
     end
 
-    ifdef windows then
-      _queue_read()
-    else
-      _read()
-      if _has_pending_writes() then
-        _send_pending_writes()
-      end
+    _read()
+    if _has_pending_writes() then
+      _send_pending_writes()
+    end
+
+  fun ref _close_event_fd(fd: U32) =>
+    """
+    Close the fd backing a subscribed event. On POSIX the stdlib owns the
+    close (the readiness backend never owns fds). On Windows the readiness
+    backend owns it: the fd is closed when the deferred
+    ProcessSocketNotifications REMOVE (issued by the unsubscribe) is seen, so
+    closing here would emit no REMOVE and strand the disposal handshake,
+    leaking the fd and event.
+
+    Use this for every fd whose event was created via
+    `pony_asio_event_create`. Raw, never-subscribed fds (e.g. an accepted fd
+    rejected before an event is created) are closed directly with
+    `PonyTCP.close` on both platforms.
+    """
+    ifdef not windows then
+      PonyTCP.close(fd)
     end
 
   fun ref _connecting_event_failed(event: AsioEventID, fd: U32) =>
@@ -1894,7 +1675,7 @@ class TCPConnection
     if not PonyAsio.get_disposable(event) then
       PonyAsio.unsubscribe(event)
     end
-    PonyTCP.close(fd)
+    _close_event_fd(fd)
     _connecting_callback()
 
   fun ref _straggler_cleanup(event: AsioEventID) =>
@@ -1910,9 +1691,9 @@ class TCPConnection
     if not PonyAsio.get_disposable(event) then
       PonyAsio.unsubscribe(event)
     end
-    PonyTCP.close(PonyAsio.event_fd(event))
+    _close_event_fd(PonyAsio.event_fd(event))
 
-  fun ref _event_notify(event: AsioEventID, flags: U32, arg: U32) =>
+  fun ref _event_notify(event: AsioEventID, flags: U32) =>
     // Explicit dispatch on event identity. Timer identity checks must come
     // before `event is _event`. The else branch checks disposable first
     // (stale timer disposables, straggler disposables), otherwise dispatches
@@ -1943,10 +1724,10 @@ class TCPConnection
         _fire_user_timer()
       end
     elseif event is _event then
-      _state.own_event(this, flags, arg)
-      // A callback during own_event (e.g., _read_completed(0) → close()) can
-      // transition to _Closing and set _shutdown/_shutdown_peer, but
-      // _Open.own_event() won't check for shutdown completion. This ensures
+      _state.own_event(this, flags)
+      // A callback during own_event (e.g., a zero-byte read in _read() →
+      // close()) can transition to _Closing and set _shutdown/_shutdown_peer,
+      // but _Open.own_event() won't check for shutdown completion. This ensures
       // the check runs after every own-event dispatch, regardless of which
       // state handled it.
       _check_shutdown_complete()
@@ -1967,7 +1748,7 @@ class TCPConnection
         // misidentified as a Happy Eyeballs straggler.
         PonyAsio.destroy(event)
       else
-        _state.foreign_event(this, event, flags, arg)
+        _state.foreign_event(this, event, flags)
       end
     end
 
@@ -1986,13 +1767,8 @@ class TCPConnection
     end
 
   fun _is_socket_connected(fd: U32): Bool =>
-    ifdef windows then
-      (let errno: U32, let value: U32) = _OSSocket.get_so_connect_time(fd)
-      (errno == 0) and (value != 0xffffffff)
-    else
-      (let errno: U32, let value: U32) = _OSSocket.get_so_error(fd)
-      (errno == 0) and (value == 0)
-    end
+    (let errno: U32, let value: U32) = _OSSocket.get_so_error(fd)
+    (errno == 0) and (value == 0)
 
   fun ref _register_spawner(listener: TCPListenerActor) =>
     if _spawned_by is None then
@@ -2033,14 +1809,8 @@ class TCPConnection
     | let e: TCPConnectionActor ref =>
       _state = _ClientConnecting
 
-      let asio_flags = ifdef windows then
-        AsioEvent.read_write()
-      else
-        AsioEvent.read_write_oneshot()
-      end
-
       _inflight_connections = PonyTCP.connect(e, _host, _port, _from,
-        asio_flags where ip_version = _ip_version)
+        AsioEvent.read_write_oneshot() where ip_version = _ip_version)
       _had_inflight = _inflight_connections > 0
       if _had_inflight then
         _arm_connect_timer()
@@ -2054,6 +1824,10 @@ class TCPConnection
     s: ServerLifecycleEventReceiver ref)
   =>
     if _ssl_failed then
+      // Raw fd: no ASIO event has been created for it yet (that happens below,
+      // after this early return), so close it directly on every platform. Do
+      // NOT route this through `_close_event_fd` — that defers to the readiness
+      // backend on Windows, which would never close this never-subscribed fd.
       PonyTCP.close(_fd)
       _fd = -1
       _state = _Closed

--- a/lori/tcp_connection_actor.pony
+++ b/lori/tcp_connection_actor.pony
@@ -10,13 +10,14 @@ trait tag TCPConnectionActor is AsioEventNotify
     _connection().hard_close()
 
   be _event_notify(event: AsioEventID, flags: U32, arg: U32) =>
-    _connection()._event_notify(event, flags, arg)
+    // `arg` carried the IOCP completion byte count under the old Windows
+    // backend. With readiness notifications it is unused on every platform.
+    _connection()._event_notify(event, flags)
 
   be _read_again() =>
     """
-    Resume reading. On POSIX, re-enters the read loop which processes buffered
-    data and reads from the socket. On Windows, processes buffered data first
-    then submits a new IOCP read.
+    Resume reading: re-enter the read loop, which processes any buffered data
+    and then reads from the socket. Same on every platform.
     """
     _connection().read_again()
 

--- a/lori/tcp_listener.pony
+++ b/lori/tcp_listener.pony
@@ -40,7 +40,15 @@ class TCPListener
 
         if not _event.is_null() then
           PonyAsio.unsubscribe(_event)
-          PonyTCP.close(_fd)
+          // POSIX closes the listener fd here. On Windows the readiness backend
+          // owns the close: it happens when the deferred
+          // ProcessSocketNotifications REMOVE from the unsubscribe above is
+          // seen, so closing here would strand the disposal handshake. The
+          // accepted/rejected fds in _accept are raw (never subscribed), so
+          // those closes stay cross-platform.
+          ifdef not windows then
+            PonyTCP.close(_fd)
+          end
           _fd = -1
           e._on_closed()
         end
@@ -60,7 +68,7 @@ class TCPListener
       ip
     end
 
-  fun ref _event_notify(event: AsioEventID, flags: U32, arg: U32) =>
+  fun ref _event_notify(event: AsioEventID, flags: U32) =>
     if event isnt _event then
       return
     end
@@ -71,7 +79,7 @@ class TCPListener
     end
 
     if AsioEvent.readable(flags) then
-      _accept(arg)
+      _accept()
     end
 
     if AsioEvent.disposable(flags) then
@@ -80,66 +88,33 @@ class TCPListener
       _listening = false
     end
 
-  fun ref _accept(arg: U32 = 0) =>
+  fun ref _accept() =>
     match \exhaustive\ _enclosing
     | let e: TCPListenerActor ref =>
       if _listening then
-        ifdef windows then
-          // Unsubscribe if we get an invalid socket in an event
-          if arg == -1 then
-            PonyAsio.unsubscribe(_event)
+        while not _at_connection_limit() do
+          var fd = PonyTCP.accept(_event)
+
+          // 0: would block, -1: error
+          if fd <= 0 then
             return
           end
 
           try
-            if arg > 0 then
-              let opened = e._on_accept(arg)?
-              opened._register_spawner(e)
-              _open_connections = _open_connections + 1
-            end
-
-            if not _at_connection_limit() then
-              PonyTCP.accept(_event)
-            else
-              _paused = true
-            end
+            let opened = e._on_accept(fd.u32())?
+            opened._register_spawner(e)
+            _open_connections = _open_connections + 1
           else
-            PonyTCP.close(arg)
+            // Rejected before an event was created — raw fd, close on both
+            // platforms.
+            PonyTCP.close(fd.u32())
           end
-        else
-          while not _at_connection_limit() do
-            var fd = PonyTCP.accept(_event)
-
-            // 0: would block, -1: error
-            if fd <= 0 then
-              return
-            end
-
-            try
-              let opened = e._on_accept(fd.u32())?
-              opened._register_spawner(e)
-              _open_connections = _open_connections + 1
-            else
-              PonyTCP.close(fd.u32())
-            end
-          end
-
-          _paused = true
         end
+
+        _paused = true
       else
         // It's possible that after closing, we got an event for a connection
-        // attempt. If that is the case or the listener is otherwise not open,
-        // return and do not start a new connection
-        ifdef windows then
-          if arg == -1 then
-            PonyAsio.unsubscribe(_event)
-            return
-          end
-
-          if arg > 0 then
-            PonyTCP.close(arg)
-          end
-        end
+        // attempt. If the listener is not open, do not start a new connection.
         return
       end
     | None =>

--- a/lori/tcp_listener_actor.pony
+++ b/lori/tcp_listener_actor.pony
@@ -31,7 +31,9 @@ trait tag TCPListenerActor is AsioEventNotify
     _listener().close()
 
   be _event_notify(event: AsioEventID, flags: U32, arg: U32) =>
-    _listener()._event_notify(event, flags, arg)
+    // `arg` is part of the runtime AsioEventNotify interface; the listener
+    // does not use it (it carried the IOCP accept fd under the old backend).
+    _listener()._event_notify(event, flags)
 
   be _connection_closed() =>
     _listener()._connection_closed()


### PR DESCRIPTION
ponyc removed Windows IOCP socket I/O in 0.66.0; Windows now uses readiness notifications, the same model epoll and kqueue drive on the other platforms. lori's Windows code assumed completion-based IOCP, so it no longer matched the runtime.

This collapses Windows onto the readiness path lori already ran on POSIX. The IOCP-specific methods and fields (`_iocp_submit_pending`, `_write_completed`, `_read_completed`, `_iocp_read`, `_windows_resume_read`, `_pending_sent`) are gone, and the read/write/dispatch paths are now a single platform-neutral implementation. The two genuine platform differences that remain:

- writev carries one buffer per call on Windows (the runtime's `IOV_MAX` is 1 there); the flush loop batches accordingly.
- a subscribed socket fd must not be closed by lori on Windows — the readiness backend owns that close and performs it when it processes the deferred unsubscribe REMOVE. Closing early strands the handshake and leaks the fd and event. `_close_event_fd()` centralizes this POSIX-only-close rule.

`_apply_backpressure`'s write re-arm and the write-only read re-arm are now cross-platform, since Windows is now one-shot readiness with the same disarm-on-any-event behavior. The write-only re-arm is gated on `_writeable` so it is skipped after a hard close — on Windows the deferred close leaves the event non-disposable, so the previous `get_disposable` guard alone would have re-enabled a tearing-down socket.

Building lori for Windows now requires ponyc 0.66.0 or later and Windows 11 / Windows Server 2022. Non-Windows platforms are unaffected.

Verified on Windows against ponyc 0.66.0: unit suite passes in debug and release, all examples build, and the open/close stress test (5000 cycles) completes and quiesces with no fd/event leaks.

---

**For Sean — decisions to weigh in on:**

- **Release sequencing**: this branch makes lori `main` require an unreleased ponyc (0.66.0) on Windows. Don't cut a lori release before ponyc 0.66.0 ships, or Windows users on a released ponyc are stranded.
- **CI scope**: all three PR jobs were switched release → nightly per your instruction. Strictly, only Windows needs nightly (Linux/macOS build fine against 0.65.0 release, since only the IOCP removal is post-0.65.0). Keeping all three on nightly means no PR job currently validates against a released ponyc. A revert reminder is in `pr.yml`; the scheduled stress test's Windows job was also moved to nightly (it would otherwise fail daily). Say the word if you'd rather keep Linux/macOS on release.
- **Follow-up — Windows backpressure test coverage**: `_TestBackpressureDrain` and `_TestWriteOnlyEventReadRecovery` stay POSIX-only because Windows loopback buffers far past `SO_SNDBUF`/`SO_RCVBUF`, so a fixed-payload send never throttles (even 16 MB drains). The drain/re-arm logic they cover now runs on Windows untested. Reworking them to a send-until-throttled loop (like the stdlib's `net/TCPThrottle`) would give Windows coverage — worth a tracked issue if you want it.