### PR TITLE
Switch PR and stress test CI back to release ponyc

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,15 +16,12 @@ concurrency:
 permissions:
   packages: read
 
-# These jobs build against nightly ponyc instead of release until ponyc 0.66.0
-# ships (Windows networking needs the readiness backend that replaced IOCP
-# post-0.65.0). Revert all three to release once 0.66.0 is out.
 jobs:
   linux:
     name: Linux
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
     steps:
       - uses: actions/checkout@v6.0.2
       - name: config=debug
@@ -40,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - name: install pony tools
-        run: bash .ci-scripts/macOS-install-nightly-pony-tools.bash
+        run: bash .ci-scripts/macOS-install-release-pony-tools.bash
       - name: configure networking
         run: bash .ci-scripts/macOS-configure-networking.bash
       - name: config=debug
@@ -65,7 +62,7 @@ jobs:
       - name: Tune Windows Networking
         run: .ci-scripts\windows-configure-networking.ps1
       - name: Install Pony tools
-        run: .ci-scripts\windows-install-pony-tools.ps1 nightlies
+        run: .ci-scripts\windows-install-pony-tools.ps1 releases
       - name: Cache LibreSSL libs
         id: cache-libressl
         uses: actions/cache@v5.0.3

--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -74,10 +74,7 @@ jobs:
       - name: Tune Windows Networking
         run: .ci-scripts\windows-configure-networking.ps1
       - name: Install Pony tools
-        # nightlies until ponyc 0.66.0 ships: Windows networking needs the
-        # readiness backend (IOCP was removed post-0.65.0). Revert to releases
-        # once 0.66.0 is out. Linux/macOS still build against release ponyc.
-        run: .ci-scripts\windows-install-pony-tools.ps1 nightlies
+        run: .ci-scripts\windows-install-pony-tools.ps1 releases
       - name: Cache LibreSSL libs
         id: cache-libressl
         uses: actions/cache@v5.0.3


### PR DESCRIPTION
The PR and stress test workflows were pointed at nightly ponyc during the 0.66.0 release cycle because lori's Windows networking needs the readiness backend that replaced IOCP, and that only landed post-0.65.0. 0.66.0 ships it, so these workflows go back to release ponyc.