### PR TITLE
Deliver a completion callback for every send

### DIFF
--- a/.release-notes/send-completion-per-token.md
+++ b/.release-notes/send-completion-per-token.md
@@ -1,0 +1,7 @@
+## Deliver a completion callback for every send
+
+`_on_sent` used to fire only when the whole write queue drained, reporting a single send. If you sent again while a previous send was still going out under backpressure (the usual move from `_on_unthrottled`), you never got `_on_sent` for the earlier sends. And if the connection dropped with sends still in flight, only the most recent one got `_on_send_failed`, so you had no way to tell how much of your data had actually left.
+
+Now every `send()` that returns a token gets exactly one completion callback: `_on_sent` once its bytes have been handed to the OS, or `_on_send_failed` if the connection drops first. When a connection is lost mid-flight, the split tells you how far your sends got: the ones that got `_on_sent` reached the OS, the ones that got `_on_send_failed` never left. That's the accounting you need to track what's still outstanding and decide what to resend.
+
+"Handed to the OS" means written to the kernel send buffer, not received by the peer. On a drop, bytes sitting in the kernel buffer may never reach the peer, so `_on_sent` bounds what got through rather than confirming it. End-to-end delivery is still your application's job.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,7 @@ examples/
   infinite-ping-pong/       -- Ping-pong client+server
   ip-version/               -- IPv4-only echo server
   read-buffer-size/         -- Configurable read buffer sizing
+  send-completion/          -- Per-send completion tracking with SendToken
   socket-options/           -- TCP_NODELAY and OS buffer size tuning
   net-ssl-echo-server/      -- SSL echo server
   net-ssl-infinite-ping-pong/ -- SSL ping-pong
@@ -258,7 +259,7 @@ Design: Discussion #252.
 
 `send(data: (ByteSeq | ByteSeqIter))` is fallible — it returns `(SendToken | SendError)` instead of silently dropping data:
 
-- `SendToken` — opaque token identifying the send operation. Delivered to `_on_sent(token)` when data is fully handed to the OS.
+- `SendToken` — opaque token identifying the send operation. Each accepted `send()` gets exactly one terminal callback: `_on_sent(token)` when its bytes are handed to the OS (kernel send buffer, not peer receipt), or `_on_send_failed(token)` if the connection closes first. Callbacks fire in send order.
 - `SendErrorNotConnected` — connection not open (permanent).
 - `SendErrorNotWriteable` — socket under backpressure (transient, wait for `_on_unthrottled`).
 During SSL handshake (`_SSLHandshaking` or `_TLSUpgrading`), returns `SendErrorNotConnected` directly from the state class without reaching `_do_send()`.
@@ -267,7 +268,7 @@ During SSL handshake (`_SSLHandshaking` or `_TLSUpgrading`), returns `SendErrorN
 
 `is_writeable()` lets the application check writeability before calling `send()`.
 
-`_on_sent(token)` always fires in a subsequent behavior turn (via `_notify_sent` on `TCPConnectionActor`), never synchronously during `send()`. If the connection closes with a pending partial write, `_on_send_failed(token)` fires (via `_notify_send_failed`) to notify the application that the accepted send could not be delivered. `_on_send_failed` always arrives after `_on_closed`, which fires synchronously during `hard_close()`.
+`_on_sent(token)` always fires in a subsequent behavior turn (via `_notify_sent` on `TCPConnectionActor`), never synchronously during `send()`. On a hard close, every accepted send still pending (not yet `_on_sent`) fires `_on_send_failed(token)` (via `_notify_send_failed`) in send order, so the split between tokens that got `_on_sent` and tokens that got `_on_send_failed` marks exactly how far delivery to the OS reached. `_on_send_failed` always arrives after `_on_closed`, which fires synchronously during `hard_close()`. Because `_on_sent` is delivered by a queued behavior, a token whose bytes reached the OS just as the connection closed can fire `_on_sent` after `_on_closed`.
 
 The library does not queue data on behalf of the application during backpressure. `send()` returns `SendErrorNotWriteable` and the application decides what to do (queue, drop, close, etc.).
 
@@ -278,12 +279,16 @@ Pending writes use writev on every platform. The internal fields:
 - `_pending_data: Array[ByteSeq]` — buffers awaiting delivery. Also keeps `ByteSeq` values alive for the GC while raw pointers reference them in the IOV array built by `PonyTCP.writev`.
 - `_pending_writev_total: USize` — total bytes remaining (accounts for `_pending_first_buffer_offset`).
 - `_pending_first_buffer_offset: USize` — bytes already sent from `_pending_data(0)`, for partial write resume. COUPLING: points into the buffer owned by `_pending_data(0)` — trimming `_pending_data` without resetting the offset causes a dangling pointer. `_manage_pending_buffer` maintains both.
+- `_pending_tokens: List[(USize, SendToken)]` — FIFO of (completion offset, token). Each accepted send records the cumulative enqueued-byte offset — into the wire-byte stream `_pending_data` drains, not an index into the array — at which its bytes finish. For SSL the offsets are over ciphertext (enqueued synchronously by `_ssl_enqueue_sends()`), for plaintext over the application bytes.
+- `_cumulative_enqueued` / `_cumulative_sent: USize` — running byte totals over `_pending_data`. `_fire_completed_sends()` fires `_on_sent` for every token whose completion offset `<= _cumulative_sent`, in FIFO order. Both counters reset to 0 when the queue empties, so the offsets stay small.
 
 The write path uses an enqueue-then-flush pattern:
 
-1. `_enqueue(data)` pushes to `_pending_data` and updates `_pending_writev_total`. No I/O.
-2. `_send_pending_writes()` flushes via `PonyTCP.writev`, which builds the IOV array internally. It loops while writeable and there is pending data, applying backpressure on a partial write or `SocketResultRetry`.
-3. `_manage_pending_buffer(bytes_sent)` walks `_pending_data`, trims fully-sent entries, and updates `_pending_first_buffer_offset`.
+1. `_enqueue(data)` pushes to `_pending_data` and updates `_pending_writev_total` and `_cumulative_enqueued`. No I/O.
+2. `_send_pending_writes()` flushes via `PonyTCP.writev`, which builds the IOV array internally. It loops while writeable and there is pending data, applying backpressure on a partial write or `SocketResultRetry`, then calls `_fire_completed_sends()` to fire `_on_sent` for the tokens the drain completed.
+3. `_manage_pending_buffer(bytes_sent)` walks `_pending_data`, trims fully-sent entries, and updates `_pending_first_buffer_offset` and `_cumulative_sent`.
+
+`hard_close()` drains `_pending_tokens` to `_on_send_failed` (every remaining token, in FIFO order) via `_hard_close_cleanup`. The token-mint step in `_do_send` runs only after the flush and the still-open check, so a send that errored out never burns a token id.
 
 `PonyTCP.writev` takes `Array[ByteSeq] box` and builds the `(pointer, size)` IOV array internally; the runtime turns it into `iovec` (POSIX) or `WSABUF` (Windows). Returns `(SocketResult, USize)`: a tri-state result (`SocketResultOk`, `SocketResultRetry`, `SocketResultError`) plus the number of bytes sent. `SocketResultRetry` signals backpressure (`EWOULDBLOCK`/`WSAEWOULDBLOCK`); `SocketResultError` signals an unrecoverable error or peer-close. `PonyTCP.writev_max()` is `IOV_MAX` on POSIX and 1 on Windows, so the flush loop batches accordingly.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,6 +37,10 @@ Query-timeout simulation using `set_timer()`. A client connects, sends a "query"
 
 Handling `send()` errors and throttle/unthrottle callbacks. A flood client sends 200 chunks of 64KB as fast as possible, demonstrating what happens when the OS send buffer fills: `send()` returns `SendErrorNotWriteable`, `_on_throttled` fires, and the client waits for `_on_unthrottled` to resume. Also shows `_on_sent` for tracking write completion.
 
+## [send-completion](send-completion/)
+
+Per-send completion tracking with `SendToken`. A client sends five labeled messages up front and keeps a map of the ones still outstanding, keyed by token id. `_on_sent(token)` identifies which specific send reached the OS — so the map shrinks to empty as each completes — and `_on_send_failed(token)` would identify which sends didn't make it if the connection dropped. Where `backpressure` counts completions, this tracks them by identity.
+
 ## [yield-read](yield-read/)
 
 Cooperative scheduler fairness with `yield_read()`. A flood client sends 100 four-byte messages and the server yields the read loop every 10 messages, letting other actors run before reading resumes automatically. Shows how to prevent a single connection from monopolizing the scheduler without the persistent pause of `mute()`/`unmute()`.

--- a/examples/send-completion/send-completion.pony
+++ b/examples/send-completion/send-completion.pony
@@ -1,0 +1,134 @@
+"""
+Demonstrates per-send completion tracking.
+
+Every send() that returns a SendToken gets exactly one terminal callback:
+_on_sent(token) once its bytes reach the OS, or _on_send_failed(token) if the
+connection closes first. The token identifies WHICH send completed, so an
+application can track exactly which of several outstanding sends have been
+handed to the OS -- not just how many.
+
+This client sends five labeled messages up front and keeps a map of the ones
+still outstanding, keyed by token id. As each _on_sent arrives it reports which
+message completed and drops it from the map; when the map is empty every send
+has reached the OS and the client closes. If the connection had dropped with
+sends still outstanding, _on_send_failed would report which ones did not make
+it -- the same map, read the other way.
+
+"Reached the OS" means written to the kernel send buffer, not received by the
+peer. End-to-end delivery is still the application's job.
+"""
+use "../../lori"
+use "collections"
+
+actor Main
+  new create(env: Env) =>
+    Listener(TCPListenAuth(env.root), TCPConnectAuth(env.root), env.out)
+
+actor Listener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _out: OutStream
+  let _connect_auth: TCPConnectAuth
+  let _server_auth: TCPServerAuth
+
+  new create(listen_auth: TCPListenAuth, connect_auth: TCPConnectAuth,
+    out: OutStream)
+  =>
+    _connect_auth = connect_auth
+    _out = out
+    _server_auth = TCPServerAuth(listen_auth)
+    _tcp_listener = TCPListener(listen_auth, "127.0.0.1", "7688", this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): Sink =>
+    Sink(_server_auth, fd, _out)
+
+  fun ref _on_listening() =>
+    _out.print("Listener ready, launching client...")
+    Sender(_connect_auth, "127.0.0.1", "7688", _out)
+
+  fun ref _on_listen_failure() =>
+    _out.print("Unable to open listener")
+
+actor Sink is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  """
+  Server-side connection that receives and discards data.
+  """
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _out: OutStream
+
+  new create(auth: TCPServerAuth, fd: U32, out: OutStream) =>
+    _out = out
+    _tcp_connection = TCPConnection.server(auth, fd, this, this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    None
+
+  fun ref _on_closed() =>
+    _out.print("Sink: connection closed")
+
+actor Sender is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  """
+  Sends several labeled messages and tracks which ones have reached the OS by
+  their SendToken.
+  """
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _out: OutStream
+  let _messages: Array[String] val
+  // Sends still waiting for _on_sent, keyed by token id.
+  let _outstanding: Map[USize, String] = _outstanding.create()
+
+  new create(auth: TCPConnectAuth, host: String, port: String,
+    out: OutStream)
+  =>
+    _out = out
+    _messages = recover val
+      ["login"; "subscribe"; "query"; "heartbeat"; "logout"]
+    end
+    _tcp_connection = TCPConnection.client(auth, host, port, "", this, this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _out.print("Sender: connected, sending " + _messages.size().string()
+      + " messages")
+    for msg in _messages.values() do
+      match _tcp_connection.send(msg)
+      | let token: SendToken =>
+        _outstanding(token.id) = msg
+        _out.print("  sent '" + msg + "' (token " + token.id.string()
+          + "), awaiting _on_sent")
+      | let _: SendError =>
+        _out.print("  could not send '" + msg + "'")
+      end
+    end
+
+  fun ref _on_sent(token: SendToken) =>
+    try
+      (_, let msg) = _outstanding.remove(token.id)?
+      _out.print("_on_sent: '" + msg + "' (token " + token.id.string()
+        + ") reached the OS; " + _outstanding.size().string()
+        + " still outstanding")
+    end
+    if _outstanding.size() == 0 then
+      _out.print("Sender: every send reached the OS, closing")
+      _tcp_connection.close()
+    end
+
+  fun ref _on_send_failed(token: SendToken) =>
+    try
+      (_, let msg) = _outstanding.remove(token.id)?
+      _out.print("_on_send_failed: '" + msg + "' (token " + token.id.string()
+        + ") did not reach the OS before the connection closed")
+    end
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    _out.print("Sender: connection failed")
+
+  fun ref _on_closed() =>
+    _out.print("Sender: closed")

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -26,6 +26,7 @@ actor \nodoc\ Main is TestList
     test(_TestSendvEmpty)
     test(_TestSendvMixedEmpty)
     test(_TestSSLSendv)
+    test(_TestSendSSLLargeSingleSend)
     test(_TestIdleTimeout)
     test(_TestIdleTimeoutReset)
     test(_TestIdleTimeoutDisable)
@@ -87,3 +88,8 @@ actor \nodoc\ Main is TestList
     // The drain and write-only re-arm logic they cover is platform-neutral.
     ifdef posix then test(_TestBackpressureDrain) end
     ifdef posix then test(_TestWriteOnlyEventReadRecovery) end
+    ifdef posix then test(_TestSendPerTokenCompletion) end
+    ifdef posix then test(_TestSendMidFlightDropBoundary) end
+    ifdef posix then test(_TestSendSSLPerTokenCompletion) end
+    ifdef posix then test(_TestSendSSLMidFlightDropBoundary) end
+    ifdef posix then test(_TestSendGracefulCloseWithPending) end

--- a/lori/_test_send.pony
+++ b/lori/_test_send.pony
@@ -1,5 +1,7 @@
 use "constrained_types"
+use "files"
 use "pony_test"
+use "ssl/net"
 
 class \nodoc\ iso _TestSendToken is UnitTest
   """
@@ -482,3 +484,1153 @@ actor \nodoc\ _TestSendvMixedEmptyServer
     _h.assert_eq[String]("Helloworld", String.from_array(consume data))
     _h.complete_action("data verified")
     _tcp_connection.close()
+
+class \nodoc\ iso _TestSendPerTokenCompletion is UnitTest
+  """
+  Overlapping sends each get exactly one `_on_sent`, in send order.
+
+  The client mutes with a tiny SO_RCVBUF so the pipe fills. The server (sender)
+  makes three tiny sends that drain immediately (tokens 1-3 -> `_on_sent`), then
+  a 256 KiB send that partial-writes and stays pending (token 4). When the pipe
+  drains enough to unthrottle, the server makes a second 256 KiB send from
+  `_on_unthrottled` -- the one window where `_writeable` is true while earlier
+  data is still queued -- so tokens 4 and 5 are in the pending queue at once.
+  The client then drains everything.
+
+  Asserts every returned token fires `_on_sent` exactly once, in ascending id
+  order (proving none was lost or reordered). A single shared pending token
+  would let the second pending send overwrite the first, so token 4 never fires
+  `_on_sent`: the ordering assertion then sees id 5 where it expects 4.
+
+  POSIX only -- provoking write backpressure with a fixed payload requires
+  honoring the small SO_SNDBUF/SO_RCVBUF, which Windows loopback ignores. See
+  the note on `_TestBackpressureDrain`.
+  """
+  fun name(): String => "SendPerTokenCompletion"
+
+  fun ref apply(h: TestHelper) =>
+    let listener = _TestSendPerTokenListener(h)
+    h.dispose_when_done(listener)
+    h.long_test(30_000_000_000)
+
+actor \nodoc\ _TestSendPerTokenListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _server: (_TestSendPerTokenServer | None) = None
+  var _client: (_TestSendPerTokenClient | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      ifdef linux then "127.0.0.2" else "localhost" end,
+      "7910",
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestSendPerTokenServer =>
+    let s = _TestSendPerTokenServer(fd, _h, this)
+    _server = s
+    s
+
+  fun ref _on_listen_failure() =>
+    _h.fail("listener failed to start")
+
+  fun ref _on_listening() =>
+    _client = _TestSendPerTokenClient(_h)
+
+  fun ref _on_closed() =>
+    try (_client as _TestSendPerTokenClient).dispose() end
+    try (_server as _TestSendPerTokenServer).dispose() end
+
+  be unmute_client() =>
+    try (_client as _TestSendPerTokenClient).resume_reading() end
+
+actor \nodoc\ _TestSendPerTokenClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(_h.env.root),
+      ifdef linux then "127.0.0.2" else "localhost" end,
+      "7910",
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    // Tiny receive buffer + muted reads so the sender's pipe fills fast.
+    _tcp_connection.set_so_rcvbuf(4096)
+    _tcp_connection.mute()
+    _tcp_connection.send("ready")
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    _h.fail("client connect failed")
+
+  be resume_reading() =>
+    _tcp_connection.unmute()
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    None
+
+actor \nodoc\ _TestSendPerTokenServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+  let _listener: _TestSendPerTokenListener
+  let _total_sends: USize = 5
+  var _started: Bool = false
+  var _unmuted_client: Bool = false
+  var _resumed: Bool = false
+  embed _returned: Array[USize] = _returned.create()
+  embed _completed: Array[USize] = _completed.create()
+  var _expected_next: USize = 1
+
+  new create(fd: U32, h: TestHelper, listener: _TestSendPerTokenListener) =>
+    _h = h
+    _listener = listener
+    _tcp_connection = TCPConnection.server(
+      TCPServerAuth(_h.env.root),
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    // Frame the client's "ready" (5 bytes).
+    match MakeBufferSize(5)
+    | let b: BufferSize => _tcp_connection.buffer_until(b)
+    else _Unreachable()
+    end
+
+  fun ref _record_send(r: (SendToken | SendError)) =>
+    match r
+    | let t: SendToken => _returned.push(t.id)
+    | let _: SendError => _h.fail("send() returned an error while flooding")
+    end
+
+  fun ref _large(): Array[U8] val =>
+    recover val Array[U8].init('x', 256_000) end
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    if _started then return end
+    _started = true
+    // Small send buffer so the pipe is tiny and backpressure comes fast.
+    _tcp_connection.set_so_sndbuf(16384)
+    // Three tiny sends fit the pipe and drain immediately -> _on_sent (1-3).
+    _record_send(_tcp_connection.send("t1"))
+    _record_send(_tcp_connection.send("t2"))
+    _record_send(_tcp_connection.send("t3"))
+    // One large send that partial-writes and stays pending (token 4).
+    _record_send(_tcp_connection.send(_large()))
+
+  fun ref _on_throttled() =>
+    if not _unmuted_client then
+      _unmuted_client = true
+      _listener.unmute_client()
+    end
+
+  fun ref _on_unthrottled() =>
+    if not _resumed then
+      _resumed = true
+      // Token 4 (256 KiB) is still pending: _on_unthrottled fires before this
+      // event drains, and 256 KiB won't clear in a single write. This send
+      // (token 5) appends, so the pending queue holds 4 and 5 simultaneously.
+      _record_send(_tcp_connection.send(_large()))
+    end
+
+  fun ref _on_sent(token: SendToken) =>
+    _h.assert_eq[USize](_expected_next, token.id,
+      "_on_sent fired out of order or with a gap")
+    _expected_next = _expected_next + 1
+    _completed.push(token.id)
+    if _completed.size() == _total_sends then
+      _h.assert_eq[USize](_returned.size(), _completed.size(),
+        "every returned token must fire _on_sent exactly once")
+      _tcp_connection.close()
+      _h.complete(true)
+    end
+
+  fun ref _on_send_failed(token: SendToken) =>
+    _h.fail("no send should fail in the drain scenario")
+
+class \nodoc\ iso _TestSendSSLLargeSingleSend is UnitTest
+  """
+  A single large SSL send is delivered in full across multiple writeable
+  events.
+
+  The client makes one 256 KiB SSL send and nothing after it; the server
+  echoes each decrypted chunk. A tiny SO_RCVBUF on both ends forces the
+  ciphertext to partial-write, so it can only reach the wire in pieces on
+  successive writeable events. The echo returns all 256 KiB only if the
+  pending-write drain loop keeps flushing that one send's queued ciphertext
+  as the socket clears, so the test exercises multi-write drain of a single
+  SSL send.
+  """
+  fun name(): String => "SendSSLLargeSingleSend"
+
+  fun apply(h: TestHelper) ? =>
+    let port = "7911"
+    let file_auth = FileAuth(h.env.root)
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(file_auth, "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(file_auth, "assets/cert.pem"),
+            FilePath(file_auth, "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    let listener = _TestSendSSLLargeSingleSendListener(port, consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(30_000_000_000)
+
+actor \nodoc\ _TestSendSSLLargeSingleSendListener is TCPListenerActor
+  let _port: String
+  let _sslctx: SSLContext val
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _client: (_TestSendSSLLargeSingleSendClient | None) = None
+  var _server: (_TestSendSSLLargeSingleSendServer | None) = None
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _port = port
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      _port,
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestSendSSLLargeSingleSendServer =>
+    let s = _TestSendSSLLargeSingleSendServer(_sslctx, fd, _h)
+    _server = s
+    s
+
+  fun ref _on_closed() =>
+    try (_client as _TestSendSSLLargeSingleSendClient).dispose() end
+    try (_server as _TestSendSSLLargeSingleSendServer).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestSendSSLLargeSingleSendClient(_port, _sslctx, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestSendSSLLargeSingleSendListener")
+
+actor \nodoc\ _TestSendSSLLargeSingleSendClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+  let _expected: USize = 262144
+  var _received: USize = 0
+  var _corrupt: Bool = false
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.ssl_client(
+      TCPConnectAuth(h.env.root),
+      sslctx,
+      "localhost",
+      port,
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _tcp_connection.set_so_rcvbuf(4096)
+    match _tcp_connection.send(recover val Array[U8].init('x', _expected) end)
+    | let _: SendToken => None
+    | let _: SendError =>
+      _h.fail("client send failed")
+      _h.complete(false)
+    end
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    _h.fail("client connect failed")
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    let d: Array[U8] val = consume data
+    for b in d.values() do
+      if b != 'x' then _corrupt = true end
+    end
+    _received = _received + d.size()
+    if _received == _expected then
+      _h.assert_false(_corrupt, "echoed bytes must all be 'x'")
+      _tcp_connection.close()
+      _h.complete(true)
+    elseif _received > _expected then
+      _h.fail("received more bytes than were sent")
+      _h.complete(false)
+    end
+
+actor \nodoc\ _TestSendSSLLargeSingleSendServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(sslctx: SSLContext val, fd: U32, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.ssl_server(
+      TCPServerAuth(_h.env.root),
+      sslctx,
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    _tcp_connection.set_so_rcvbuf(4096)
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    match _tcp_connection.send(consume data)
+    | let _: SendToken => None
+    | let _: SendError => _h.fail("server echo failed")
+    end
+
+class \nodoc\ iso _TestSendMidFlightDropBoundary is UnitTest
+  """
+  On a mid-flight drop, the `_on_sent` / `_on_send_failed` split is a clean
+  boundary: every accepted send fires exactly one of the two, in a prefix of
+  `_on_sent` (bytes that reached the OS) followed by a suffix of
+  `_on_send_failed` (bytes that did not).
+
+  Same backpressure setup as `SendPerTokenCompletion`: three tiny sends drain
+  to `_on_sent` (tokens 1-3), a 256 KiB send stays pending (token 4), then a
+  second 256 KiB send from `_on_unthrottled` (token 5) leaves 4 and 5 pending
+  at once. Instead of draining, the server `hard_close()`s immediately after
+  the second send.
+
+  Asserts each of the five tokens fires exactly one terminal callback (none
+  both, none neither), that both pending sends (4 and 5) fire `_on_send_failed`,
+  that `max(_on_sent id) < min(_on_send_failed id)`, and that `_on_send_failed`
+  arrives after `_on_closed`. A single shared pending token would keep only the
+  last one, so token 4 would get neither callback.
+
+  POSIX only, for the same reason as `SendPerTokenCompletion`.
+  """
+  fun name(): String => "SendMidFlightDropBoundary"
+
+  fun ref apply(h: TestHelper) =>
+    let listener = _TestSendMidFlightDropListener(h)
+    h.dispose_when_done(listener)
+    h.long_test(30_000_000_000)
+
+actor \nodoc\ _TestSendMidFlightDropListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _server: (_TestSendMidFlightDropServer | None) = None
+  var _client: (_TestSendMidFlightDropClient | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      ifdef linux then "127.0.0.2" else "localhost" end,
+      "7912",
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestSendMidFlightDropServer =>
+    let s = _TestSendMidFlightDropServer(fd, _h, this)
+    _server = s
+    s
+
+  fun ref _on_listen_failure() =>
+    _h.fail("listener failed to start")
+
+  fun ref _on_listening() =>
+    _client = _TestSendMidFlightDropClient(_h)
+
+  fun ref _on_closed() =>
+    try (_client as _TestSendMidFlightDropClient).dispose() end
+    try (_server as _TestSendMidFlightDropServer).dispose() end
+
+  be unmute_client() =>
+    try (_client as _TestSendMidFlightDropClient).resume_reading() end
+
+actor \nodoc\ _TestSendMidFlightDropClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(_h.env.root),
+      ifdef linux then "127.0.0.2" else "localhost" end,
+      "7912",
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _tcp_connection.set_so_rcvbuf(4096)
+    _tcp_connection.mute()
+    _tcp_connection.send("ready")
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    _h.fail("client connect failed")
+
+  be resume_reading() =>
+    _tcp_connection.unmute()
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    None
+
+actor \nodoc\ _TestSendMidFlightDropServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+  let _listener: _TestSendMidFlightDropListener
+  let _total_sends: USize = 5
+  var _started: Bool = false
+  var _unmuted_client: Bool = false
+  var _resumed: Bool = false
+  var _closed: Bool = false
+  embed _returned: Array[USize] = _returned.create()
+  embed _sent_ids: Array[USize] = _sent_ids.create()
+  embed _failed_ids: Array[USize] = _failed_ids.create()
+
+  new create(fd: U32, h: TestHelper,
+    listener: _TestSendMidFlightDropListener)
+  =>
+    _h = h
+    _listener = listener
+    _tcp_connection = TCPConnection.server(
+      TCPServerAuth(_h.env.root),
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    match MakeBufferSize(5)
+    | let b: BufferSize => _tcp_connection.buffer_until(b)
+    else _Unreachable()
+    end
+
+  fun ref _record_send(r: (SendToken | SendError)) =>
+    match r
+    | let t: SendToken => _returned.push(t.id)
+    | let _: SendError => _h.fail("send() returned an error while flooding")
+    end
+
+  fun ref _large(): Array[U8] val =>
+    recover val Array[U8].init('x', 256_000) end
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    if _started then return end
+    _started = true
+    _tcp_connection.set_so_sndbuf(16384)
+    _record_send(_tcp_connection.send("t1"))
+    _record_send(_tcp_connection.send("t2"))
+    _record_send(_tcp_connection.send("t3"))
+    _record_send(_tcp_connection.send(_large()))
+
+  fun ref _on_throttled() =>
+    if not _unmuted_client then
+      _unmuted_client = true
+      _listener.unmute_client()
+    end
+
+  fun ref _on_unthrottled() =>
+    if not _resumed then
+      _resumed = true
+      // Token 4 (256 KiB) is still pending here; this second large send
+      // (token 5) appends. Both are pending when we drop the connection.
+      _record_send(_tcp_connection.send(_large()))
+      _tcp_connection.hard_close()
+    end
+
+  fun ref _on_closed() =>
+    _closed = true
+
+  fun ref _on_sent(token: SendToken) =>
+    _sent_ids.push(token.id)
+    _maybe_finish()
+
+  fun ref _on_send_failed(token: SendToken) =>
+    _h.assert_true(_closed, "_on_send_failed must arrive after _on_closed")
+    _failed_ids.push(token.id)
+    _maybe_finish()
+
+  fun ref _maybe_finish() =>
+    if (_sent_ids.size() + _failed_ids.size()) != _total_sends then
+      return
+    end
+
+    // Every returned token gets exactly one terminal callback: not both,
+    // not neither.
+    for id in _returned.values() do
+      var count: USize = 0
+      for s in _sent_ids.values() do
+        if s == id then count = count + 1 end
+      end
+      for f in _failed_ids.values() do
+        if f == id then count = count + 1 end
+      end
+      _h.assert_eq[USize](1, count,
+        "each token must fire exactly one terminal callback")
+    end
+
+    // Both undelivered sends must fail (not just the last one).
+    _h.assert_true(_failed_ids.size() >= 2,
+      "every accepted-but-undelivered send must fire _on_send_failed")
+
+    // Clean prefix/suffix: all _on_sent ids precede all _on_send_failed ids.
+    var max_sent: USize = 0
+    for s in _sent_ids.values() do
+      if s > max_sent then max_sent = s end
+    end
+    var min_failed: USize = USize.max_value()
+    for f in _failed_ids.values() do
+      if f < min_failed then min_failed = f end
+    end
+    _h.assert_true(max_sent < min_failed,
+      "_on_sent ids must all precede _on_send_failed ids")
+
+    // _on_send_failed must also fire in send order (ascending token id).
+    var prev_failed: USize = 0
+    for f in _failed_ids.values() do
+      _h.assert_true(f > prev_failed,
+        "_on_send_failed must fire in ascending (send) order")
+      prev_failed = f
+    end
+
+    _h.complete(true)
+
+class \nodoc\ iso _TestSendSSLPerTokenCompletion is UnitTest
+  """
+  Overlapping SSL sends each get exactly one `_on_sent`, in send order.
+
+  The SSL analogue of `SendPerTokenCompletion`. An SSL send's completion
+  offset is captured after its ciphertext is enqueued, so this checks the
+  per-token FIFO fires correctly when several encrypted sends are queued at
+  once. The client mutes with a tiny SO_RCVBUF so the sender's pipe fills.
+  The server (sender) makes three tiny sends that drain immediately (tokens
+  1-3 -> `_on_sent`), then a 256 KiB send whose ciphertext partial-writes and
+  stays pending (token 4). When the pipe drains enough to unthrottle, the
+  server makes a second 256 KiB send from `_on_unthrottled` (token 5), so
+  tokens 4 and 5 are pending at once. The client then drains everything.
+
+  Asserts every returned token fires `_on_sent` exactly once, in ascending id
+  order.
+
+  POSIX only, for the same reason as `SendPerTokenCompletion`.
+  """
+  fun name(): String => "SendSSLPerTokenCompletion"
+
+  fun apply(h: TestHelper) ? =>
+    let port = "7913"
+    let file_auth = FileAuth(h.env.root)
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(file_auth, "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(file_auth, "assets/cert.pem"),
+            FilePath(file_auth, "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    let listener = _TestSendSSLPerTokenListener(port, consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(30_000_000_000)
+
+actor \nodoc\ _TestSendSSLPerTokenListener is TCPListenerActor
+  let _port: String
+  let _sslctx: SSLContext val
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _server: (_TestSendSSLPerTokenServer | None) = None
+  var _client: (_TestSendSSLPerTokenClient | None) = None
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _port = port
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      _port,
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestSendSSLPerTokenServer =>
+    let s = _TestSendSSLPerTokenServer(_sslctx, fd, _h, this)
+    _server = s
+    s
+
+  fun ref _on_closed() =>
+    try (_client as _TestSendSSLPerTokenClient).dispose() end
+    try (_server as _TestSendSSLPerTokenServer).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestSendSSLPerTokenClient(_port, _sslctx, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestSendSSLPerTokenListener")
+
+  be unmute_client() =>
+    try (_client as _TestSendSSLPerTokenClient).resume_reading() end
+
+actor \nodoc\ _TestSendSSLPerTokenClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.ssl_client(
+      TCPConnectAuth(_h.env.root),
+      sslctx,
+      "localhost",
+      port,
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _tcp_connection.set_so_rcvbuf(4096)
+    _tcp_connection.mute()
+    _tcp_connection.send("ready")
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    _h.fail("client connect failed")
+
+  be resume_reading() =>
+    _tcp_connection.unmute()
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    None
+
+actor \nodoc\ _TestSendSSLPerTokenServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+  let _listener: _TestSendSSLPerTokenListener
+  let _total_sends: USize = 5
+  var _started: Bool = false
+  var _unmuted_client: Bool = false
+  var _resumed: Bool = false
+  embed _returned: Array[USize] = _returned.create()
+  embed _completed: Array[USize] = _completed.create()
+  var _expected_next: USize = 1
+
+  new create(sslctx: SSLContext val, fd: U32, h: TestHelper,
+    listener: _TestSendSSLPerTokenListener)
+  =>
+    _h = h
+    _listener = listener
+    _tcp_connection = TCPConnection.ssl_server(
+      TCPServerAuth(_h.env.root),
+      sslctx,
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _record_send(r: (SendToken | SendError)) =>
+    match r
+    | let t: SendToken => _returned.push(t.id)
+    | let _: SendError => _h.fail("send() returned an error while flooding")
+    end
+
+  fun ref _large(): Array[U8] val =>
+    recover val Array[U8].init('x', 256_000) end
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    if _started then return end
+    _started = true
+    _tcp_connection.set_so_sndbuf(16384)
+    _record_send(_tcp_connection.send("t1"))
+    _record_send(_tcp_connection.send("t2"))
+    _record_send(_tcp_connection.send("t3"))
+    _record_send(_tcp_connection.send(_large()))
+
+  fun ref _on_throttled() =>
+    if not _unmuted_client then
+      _unmuted_client = true
+      _listener.unmute_client()
+    end
+
+  fun ref _on_unthrottled() =>
+    if not _resumed then
+      _resumed = true
+      _record_send(_tcp_connection.send(_large()))
+    end
+
+  fun ref _on_sent(token: SendToken) =>
+    _h.assert_eq[USize](_expected_next, token.id,
+      "_on_sent fired out of order or with a gap")
+    _expected_next = _expected_next + 1
+    _completed.push(token.id)
+    if _completed.size() == _total_sends then
+      _h.assert_eq[USize](_returned.size(), _completed.size(),
+        "every returned token must fire _on_sent exactly once")
+      _tcp_connection.close()
+      _h.complete(true)
+    end
+
+  fun ref _on_send_failed(token: SendToken) =>
+    _h.fail("no send should fail in the drain scenario")
+
+class \nodoc\ iso _TestSendSSLMidFlightDropBoundary is UnitTest
+  """
+  The SSL analogue of `SendMidFlightDropBoundary`. On a mid-flight drop of an
+  SSL connection, the `_on_sent` / `_on_send_failed` split is still a clean
+  boundary: every accepted send fires exactly one of the two, a prefix of
+  `_on_sent` followed by a suffix of `_on_send_failed`.
+
+  Same backpressure setup as `SendSSLPerTokenCompletion`: three tiny sends
+  drain to `_on_sent` (tokens 1-3), a 256 KiB send stays pending (token 4),
+  then a second 256 KiB send from `_on_unthrottled` (token 5) leaves 4 and 5
+  pending at once. Instead of draining, the server `hard_close()`s right after
+  the second send.
+
+  Asserts each of the five tokens fires exactly one terminal callback, that
+  both pending sends (4 and 5) fire `_on_send_failed`, that
+  `max(_on_sent id) < min(_on_send_failed id)`, and that `_on_send_failed`
+  arrives after `_on_closed`.
+
+  POSIX only, for the same reason as `SendMidFlightDropBoundary`.
+  """
+  fun name(): String => "SendSSLMidFlightDropBoundary"
+
+  fun apply(h: TestHelper) ? =>
+    let port = "7914"
+    let file_auth = FileAuth(h.env.root)
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(file_auth, "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(file_auth, "assets/cert.pem"),
+            FilePath(file_auth, "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    let listener = _TestSendSSLMidFlightDropListener(port, consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(30_000_000_000)
+
+actor \nodoc\ _TestSendSSLMidFlightDropListener is TCPListenerActor
+  let _port: String
+  let _sslctx: SSLContext val
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _server: (_TestSendSSLMidFlightDropServer | None) = None
+  var _client: (_TestSendSSLMidFlightDropClient | None) = None
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _port = port
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      _port,
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestSendSSLMidFlightDropServer =>
+    let s = _TestSendSSLMidFlightDropServer(_sslctx, fd, _h, this)
+    _server = s
+    s
+
+  fun ref _on_closed() =>
+    try (_client as _TestSendSSLMidFlightDropClient).dispose() end
+    try (_server as _TestSendSSLMidFlightDropServer).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestSendSSLMidFlightDropClient(_port, _sslctx, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestSendSSLMidFlightDropListener")
+
+  be unmute_client() =>
+    try (_client as _TestSendSSLMidFlightDropClient).resume_reading() end
+
+actor \nodoc\ _TestSendSSLMidFlightDropClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.ssl_client(
+      TCPConnectAuth(_h.env.root),
+      sslctx,
+      "localhost",
+      port,
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _tcp_connection.set_so_rcvbuf(4096)
+    _tcp_connection.mute()
+    _tcp_connection.send("ready")
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    _h.fail("client connect failed")
+
+  be resume_reading() =>
+    _tcp_connection.unmute()
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    None
+
+actor \nodoc\ _TestSendSSLMidFlightDropServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+  let _listener: _TestSendSSLMidFlightDropListener
+  let _total_sends: USize = 5
+  var _started: Bool = false
+  var _unmuted_client: Bool = false
+  var _resumed: Bool = false
+  var _closed: Bool = false
+  embed _returned: Array[USize] = _returned.create()
+  embed _sent_ids: Array[USize] = _sent_ids.create()
+  embed _failed_ids: Array[USize] = _failed_ids.create()
+
+  new create(sslctx: SSLContext val, fd: U32, h: TestHelper,
+    listener: _TestSendSSLMidFlightDropListener)
+  =>
+    _h = h
+    _listener = listener
+    _tcp_connection = TCPConnection.ssl_server(
+      TCPServerAuth(_h.env.root),
+      sslctx,
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _record_send(r: (SendToken | SendError)) =>
+    match r
+    | let t: SendToken => _returned.push(t.id)
+    | let _: SendError => _h.fail("send() returned an error while flooding")
+    end
+
+  fun ref _large(): Array[U8] val =>
+    recover val Array[U8].init('x', 256_000) end
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    if _started then return end
+    _started = true
+    _tcp_connection.set_so_sndbuf(16384)
+    _record_send(_tcp_connection.send("t1"))
+    _record_send(_tcp_connection.send("t2"))
+    _record_send(_tcp_connection.send("t3"))
+    _record_send(_tcp_connection.send(_large()))
+
+  fun ref _on_throttled() =>
+    if not _unmuted_client then
+      _unmuted_client = true
+      _listener.unmute_client()
+    end
+
+  fun ref _on_unthrottled() =>
+    if not _resumed then
+      _resumed = true
+      _record_send(_tcp_connection.send(_large()))
+      _tcp_connection.hard_close()
+    end
+
+  fun ref _on_closed() =>
+    _closed = true
+
+  fun ref _on_sent(token: SendToken) =>
+    _sent_ids.push(token.id)
+    _maybe_finish()
+
+  fun ref _on_send_failed(token: SendToken) =>
+    _h.assert_true(_closed, "_on_send_failed must arrive after _on_closed")
+    _failed_ids.push(token.id)
+    _maybe_finish()
+
+  fun ref _maybe_finish() =>
+    if (_sent_ids.size() + _failed_ids.size()) != _total_sends then
+      return
+    end
+
+    // Every returned token gets exactly one terminal callback: not both,
+    // not neither.
+    for id in _returned.values() do
+      var count: USize = 0
+      for s in _sent_ids.values() do
+        if s == id then count = count + 1 end
+      end
+      for f in _failed_ids.values() do
+        if f == id then count = count + 1 end
+      end
+      _h.assert_eq[USize](1, count,
+        "each token must fire exactly one terminal callback")
+    end
+
+    // Both undelivered sends must fail (not just the last one).
+    _h.assert_true(_failed_ids.size() >= 2,
+      "every accepted-but-undelivered send must fire _on_send_failed")
+
+    // Clean prefix/suffix: all _on_sent ids precede all _on_send_failed ids.
+    var max_sent: USize = 0
+    for s in _sent_ids.values() do
+      if s > max_sent then max_sent = s end
+    end
+    var min_failed: USize = USize.max_value()
+    for f in _failed_ids.values() do
+      if f < min_failed then min_failed = f end
+    end
+    _h.assert_true(max_sent < min_failed,
+      "_on_sent ids must all precede _on_send_failed ids")
+
+    // _on_send_failed must also fire in send order (ascending token id).
+    var prev_failed: USize = 0
+    for f in _failed_ids.values() do
+      _h.assert_true(f > prev_failed,
+        "_on_send_failed must fire in ascending (send) order")
+      prev_failed = f
+    end
+
+    _h.complete(true)
+
+class \nodoc\ iso _TestSendGracefulCloseWithPending is UnitTest
+  """
+  A graceful close() with sends still pending resolves every token cleanly.
+
+  Same backpressure setup as SendMidFlightDropBoundary, but the server calls
+  close() (graceful shutdown) instead of hard_close() after the second large
+  send, leaving tokens 4 and 5 pending. Whichever way close() resolves the
+  pending writes -- draining them to `_on_sent` or failing them via
+  `_on_send_failed` -- the invariant must hold: every returned token fires
+  exactly one terminal callback, and `_on_closed` fires.
+
+  POSIX only, for the same reason as `SendPerTokenCompletion`.
+  """
+  fun name(): String => "SendGracefulCloseWithPending"
+
+  fun ref apply(h: TestHelper) =>
+    let listener = _TestSendGracefulCloseListener(h)
+    h.dispose_when_done(listener)
+    h.long_test(30_000_000_000)
+
+actor \nodoc\ _TestSendGracefulCloseListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _server: (_TestSendGracefulCloseServer | None) = None
+  var _client: (_TestSendGracefulCloseClient | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      ifdef linux then "127.0.0.2" else "localhost" end,
+      "7915",
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestSendGracefulCloseServer =>
+    let s = _TestSendGracefulCloseServer(fd, _h, this)
+    _server = s
+    s
+
+  fun ref _on_listen_failure() =>
+    _h.fail("listener failed to start")
+
+  fun ref _on_listening() =>
+    _client = _TestSendGracefulCloseClient(_h)
+
+  fun ref _on_closed() =>
+    try (_client as _TestSendGracefulCloseClient).dispose() end
+    try (_server as _TestSendGracefulCloseServer).dispose() end
+
+  be unmute_client() =>
+    try (_client as _TestSendGracefulCloseClient).resume_reading() end
+
+actor \nodoc\ _TestSendGracefulCloseClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(_h.env.root),
+      ifdef linux then "127.0.0.2" else "localhost" end,
+      "7915",
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _tcp_connection.set_so_rcvbuf(4096)
+    _tcp_connection.mute()
+    _tcp_connection.send("ready")
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    _h.fail("client connect failed")
+
+  be resume_reading() =>
+    _tcp_connection.unmute()
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    None
+
+actor \nodoc\ _TestSendGracefulCloseServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+  let _listener: _TestSendGracefulCloseListener
+  let _total_sends: USize = 5
+  var _started: Bool = false
+  var _unmuted_client: Bool = false
+  var _resumed: Bool = false
+  var _closed: Bool = false
+  embed _returned: Array[USize] = _returned.create()
+  embed _sent_ids: Array[USize] = _sent_ids.create()
+  embed _failed_ids: Array[USize] = _failed_ids.create()
+
+  new create(fd: U32, h: TestHelper,
+    listener: _TestSendGracefulCloseListener)
+  =>
+    _h = h
+    _listener = listener
+    _tcp_connection = TCPConnection.server(
+      TCPServerAuth(_h.env.root),
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    match MakeBufferSize(5)
+    | let b: BufferSize => _tcp_connection.buffer_until(b)
+    else _Unreachable()
+    end
+
+  fun ref _record_send(r: (SendToken | SendError)) =>
+    match r
+    | let t: SendToken => _returned.push(t.id)
+    | let _: SendError => _h.fail("send() returned an error while flooding")
+    end
+
+  fun ref _large(): Array[U8] val =>
+    recover val Array[U8].init('x', 256_000) end
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    if _started then return end
+    _started = true
+    _tcp_connection.set_so_sndbuf(16384)
+    _record_send(_tcp_connection.send("t1"))
+    _record_send(_tcp_connection.send("t2"))
+    _record_send(_tcp_connection.send("t3"))
+    _record_send(_tcp_connection.send(_large()))
+
+  fun ref _on_throttled() =>
+    if not _unmuted_client then
+      _unmuted_client = true
+      _listener.unmute_client()
+    end
+
+  fun ref _on_unthrottled() =>
+    if not _resumed then
+      _resumed = true
+      // Tokens 4 and 5 are pending; graceful close instead of hard_close.
+      _record_send(_tcp_connection.send(_large()))
+      _tcp_connection.close()
+    end
+
+  fun ref _on_closed() =>
+    _closed = true
+
+  fun ref _on_sent(token: SendToken) =>
+    _sent_ids.push(token.id)
+    _maybe_finish()
+
+  fun ref _on_send_failed(token: SendToken) =>
+    _failed_ids.push(token.id)
+    _maybe_finish()
+
+  fun ref _maybe_finish() =>
+    if (_sent_ids.size() + _failed_ids.size()) != _total_sends then
+      return
+    end
+
+    _h.log("graceful close: sent=" + _sent_ids.size().string()
+      + " failed=" + _failed_ids.size().string()
+      + " closed=" + _closed.string())
+
+    // Every returned token gets exactly one terminal callback.
+    for id in _returned.values() do
+      var count: USize = 0
+      for s in _sent_ids.values() do
+        if s == id then count = count + 1 end
+      end
+      for f in _failed_ids.values() do
+        if f == id then count = count + 1 end
+      end
+      _h.assert_eq[USize](1, count,
+        "each token must fire exactly one terminal callback")
+    end
+
+    _h.assert_true(_closed, "_on_closed must fire on graceful close")
+    _h.complete(true)

--- a/lori/lifecycle_event_receiver.pony
+++ b/lori/lifecycle_event_receiver.pony
@@ -37,20 +37,28 @@ trait ServerLifecycleEventReceiver
 
   fun ref _on_sent(token: SendToken) =>
     """
-    Called when data from a successful `send()` has been fully handed to
-    the OS. The token matches the one returned by the `send()` call.
+    Called when the bytes from a successful `send()` have been handed to the
+    OS: written to the kernel send buffer, not necessarily received by the
+    peer. The token matches the one returned by that `send()` call, and this
+    callback fires exactly once for it.
 
     Always fires in a subsequent behavior turn, never synchronously during
-    `send()`. This guarantees the caller has received and processed the
-    `SendToken` return value before the callback arrives.
+    `send()`, so the caller has the `SendToken` return value before the
+    callback arrives. Callbacks arrive in send order. If a send's bytes reach
+    the OS just as the connection closes, its `_on_sent` can arrive after
+    `_on_closed`.
     """
     None
 
   fun ref _on_send_failed(token: SendToken) =>
     """
-    Called when data from a successful `send()` could not be delivered to
-    the OS. The token matches the one returned by the `send()` call. This
-    happens when a connection closes while a partial write is still pending.
+    Called when the bytes from a successful `send()` could not be handed to
+    the OS before the connection closed. The token matches the one returned
+    by that `send()` call, and this callback fires exactly once for it. Every
+    accepted send whose bytes had not yet been handed to the OS when the
+    connection closes fires this instead, so the split between sends that got
+    `_on_sent` and sends that got `_on_send_failed` marks exactly how far
+    delivery to the OS reached.
 
     Always fires in a subsequent behavior turn, never synchronously during
     `hard_close()`. Always arrives after `_on_closed`, which fires
@@ -234,20 +242,28 @@ trait ClientLifecycleEventReceiver
 
   fun ref _on_sent(token: SendToken) =>
     """
-    Called when data from a successful `send()` has been fully handed to
-    the OS. The token matches the one returned by the `send()` call.
+    Called when the bytes from a successful `send()` have been handed to the
+    OS: written to the kernel send buffer, not necessarily received by the
+    peer. The token matches the one returned by that `send()` call, and this
+    callback fires exactly once for it.
 
     Always fires in a subsequent behavior turn, never synchronously during
-    `send()`. This guarantees the caller has received and processed the
-    `SendToken` return value before the callback arrives.
+    `send()`, so the caller has the `SendToken` return value before the
+    callback arrives. Callbacks arrive in send order. If a send's bytes reach
+    the OS just as the connection closes, its `_on_sent` can arrive after
+    `_on_closed`.
     """
     None
 
   fun ref _on_send_failed(token: SendToken) =>
     """
-    Called when data from a successful `send()` could not be delivered to
-    the OS. The token matches the one returned by the `send()` call. This
-    happens when a connection closes while a partial write is still pending.
+    Called when the bytes from a successful `send()` could not be handed to
+    the OS before the connection closed. The token matches the one returned
+    by that `send()` call, and this callback fires exactly once for it. Every
+    accepted send whose bytes had not yet been handed to the OS when the
+    connection closes fires this instead, so the split between sends that got
+    `_on_sent` and sends that got `_on_send_failed` marks exactly how far
+    delivery to the OS reached.
 
     Always fires in a subsequent behavior turn, never synchronously during
     `hard_close()`. Always arrives after `_on_closed`, which fires

--- a/lori/lori.pony
+++ b/lori/lori.pony
@@ -131,7 +131,7 @@ Unlike many networking libraries, `send()` is fallible. It returns
 ```pony
 match _tcp_connection.send("some data")
 | let token: SendToken =>
-  // Data accepted. token will arrive in _on_sent when fully written.
+  // Accepted. The token comes back in _on_sent, or _on_send_failed on a drop.
   None
 | SendErrorNotConnected =>
   // Connection is not open.
@@ -143,10 +143,11 @@ end
 ```
 
 [`SendToken`](/lori/lori-SendToken/) is an opaque value identifying the send
-operation. When the data has been fully handed to the OS, lori delivers the
-same token to `_on_sent`. If the connection closes while a write is still
-partially pending, `_on_send_failed` fires instead. Both callbacks always arrive
-in a subsequent behavior turn, never during `send()` itself.
+operation. Each accepted `send()` gets exactly one terminal callback: the
+token comes back to `_on_sent` once its bytes reach the OS, or to
+`_on_send_failed` if the connection closes first. Callbacks arrive in send
+order, always in a later behavior turn, never during `send()`. "Handed to the
+OS" means written to the kernel send buffer, not received by the peer.
 
 The library does not queue data during backpressure. When `send()` returns
 [`SendErrorNotWriteable`](/lori/lori-SendErrorNotWriteable/), the application

--- a/lori/send_token.pony
+++ b/lori/send_token.pony
@@ -1,7 +1,13 @@
 class val SendToken is Equatable[SendToken]
   """
-  Identifies a send operation. Returned by `send()` on success and delivered
-  to `_on_sent()` when the data has been fully handed to the OS.
+  Identifies a single `send()`. Returned by `send()` on success, then
+  delivered exactly once: to `_on_sent()` when that send's bytes have been
+  handed to the OS, or to `_on_send_failed()` if the connection closes before
+  then.
+
+  "Handed to the OS" means written to the kernel send buffer, not received by
+  the peer. End-to-end delivery is an application concern -- use your own
+  acknowledgements if you need it.
 
   Tokens use structural equality based on their ID, which is scoped per
   connection. Applications managing multiple connections should pair tokens

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -1,4 +1,5 @@
 use net = "net"
+use "collections"
 use "ssl/net"
 
 use @printf[I32](fmt: Pointer[U8] tag, ...)
@@ -32,9 +33,16 @@ class TCPConnection
   var _read_buffer_min: USize = 16384
   var _buffer_until: (BufferSize | Streaming) = Streaming
 
-  // Send token tracking
+  // Send token tracking. _pending_tokens is a FIFO of (completion offset,
+  // token): each accepted send records the cumulative byte offset -- into the
+  // wire-byte stream _pending_data drains (ciphertext for SSL, plaintext
+  // otherwise) -- at which its bytes finish. _on_sent fires for a token once
+  // _cumulative_sent reaches its offset. Both counters reset to 0 whenever the
+  // queue empties, so the offsets stay small.
   var _next_token_id: USize = 0
-  var _pending_token: (SendToken | None) = None
+  embed _pending_tokens: List[(USize, SendToken)] = _pending_tokens.create()
+  var _cumulative_enqueued: USize = 0
+  var _cumulative_sent: USize = 0
 
   // Built-in SSL support
   var _ssl: (SSL ref | None) = None
@@ -638,9 +646,9 @@ class TCPConnection
   fun ref _hard_close_cleanup() =>
     """
     Common teardown for hard-closing an established connection. Handles
-    shutdown flags, send_failed for pending token, clearing pending buffers,
-    cancelling all timers, unsubscribing the event, releasing the fd (see
-    `_close_event_fd` — closed here on POSIX, deferred to the unsubscribe
+    shutdown flags, send_failed for every pending token, clearing pending
+    buffers, cancelling all timers, unsubscribing the event, releasing the fd
+    (see `_close_event_fd` — closed here on POSIX, deferred to the unsubscribe
     REMOVE on Windows), and disposing SSL. Order is load-bearing: timer cancel
     before event unsubscribe, SSL dispose after the fd is released.
 
@@ -651,18 +659,27 @@ class TCPConnection
     _shutdown = true
     _shutdown_peer = true
 
-    // Fire _on_send_failed for any accepted-but-undelivered send before
-    // clearing the pending buffer. This is deferred via _notify_send_failed
-    // so it arrives in a subsequent turn, after _on_closed.
-    match (_pending_token, _enclosing)
-    | (let t: SendToken, let e: TCPConnectionActor ref) =>
-      e._notify_send_failed(t)
+    // Fire _on_send_failed for every accepted-but-undelivered send before
+    // clearing the pending buffer. Deferred via _notify_send_failed so each
+    // arrives in a subsequent turn, after _on_closed.
+    match _enclosing
+    | let e: TCPConnectionActor ref =>
+      try
+        while _pending_tokens.size() > 0 do
+          (_, let token) = _pending_tokens.shift()?
+          e._notify_send_failed(token)
+        end
+      else
+        // Guarded by size() > 0, so shift() never errors.
+        _Unreachable()
+      end
     end
 
     _pending_data.clear()
     _pending_writev_total = 0
     _pending_first_buffer_offset = 0
-    _pending_token = None
+    _cumulative_enqueued = 0
+    _cumulative_sent = 0
 
     _cancel_idle_timer()
     _cancel_connect_timer()
@@ -864,8 +881,10 @@ class TCPConnection
     syscall overhead and the cost of copying into a contiguous buffer.
 
     Returns a `SendToken` on success, or a `SendError` explaining the
-    failure. When successful, `_on_sent(token)` will fire in a subsequent
-    behavior turn once the data has been fully handed to the OS.
+    failure. On success the token gets exactly one terminal callback in a
+    later behavior turn: `_on_sent(token)` once the data has been handed to
+    the OS (written to the kernel send buffer, not received by the peer), or
+    `_on_send_failed(token)` if the connection closes first.
     """
     _state.send(this, data)
 
@@ -876,25 +895,21 @@ class TCPConnection
       return SendErrorNotWriteable
     end
 
-    _next_token_id = _next_token_id + 1
-    let token = SendToken._create(_next_token_id)
-
+    // Enqueue this send's wire bytes (ciphertext for SSL, plaintext otherwise).
+    // For SSL, ssl.write encrypts the whole plaintext synchronously, so all of
+    // this send's ciphertext is enqueued here; on an ssl.write error the send
+    // failed, so tell the caller and do nothing else.
     match \exhaustive\ _ssl
     | let ssl: SSL ref =>
       match \exhaustive\ data
       | let d: ByteSeq =>
-        try ssl.write(d)? end
+        try ssl.write(d)? else return SendErrorNotWriteable end
       | let d: ByteSeqIter =>
         for v in d.values() do
-          try ssl.write(v)? end
+          try ssl.write(v)? else return SendErrorNotWriteable end
         end
       end
-      _ssl_flush_sends()
-
-      // Check if SSL error triggered close
-      if not is_open() then
-        return SendErrorNotConnected
-      end
+      _ssl_enqueue_sends()
     | None =>
       match \exhaustive\ data
       | let d: ByteSeq =>
@@ -904,12 +919,28 @@ class TCPConnection
           _enqueue(v)
         end
       end
-      _send_pending_writes()
     end
 
-    // Determine when to fire _on_sent
+    // This send's bytes finish at the current cumulative-enqueued offset.
+    // Flush; that fires any earlier sends this drain completed.
+    let offset = _cumulative_enqueued
+    _send_pending_writes()
+
+    // A flush that hits a write error hard-closes. Return the error -- the send
+    // never took hold, no callback.
+    if not is_open() then
+      return SendErrorNotConnected
+    end
+
+    // Mint the token only now, so a send that failed above never burns an id.
+    _next_token_id = _next_token_id + 1
+    let token = SendToken._create(_next_token_id)
+
+    // Fire now if this send fully drained during the flush; otherwise track
+    // it so `_on_sent` fires when the queue drains past its offset.
+    // `_has_pending_writes` (not the offset) decides, because a full drain
+    // resets the counters.
     if not _has_pending_writes() then
-      // All data sent to OS immediately; defer _on_sent
       match \exhaustive\ _enclosing
       | let e: TCPConnectionActor ref =>
         e._notify_sent(token)
@@ -917,8 +948,7 @@ class TCPConnection
         _Unreachable()
       end
     else
-      // Partial write; _on_sent fires when pending list drains
-      _pending_token = token
+      _pending_tokens.push((offset, token))
     end
 
     token
@@ -947,22 +977,24 @@ class TCPConnection
     Add a buffer to the pending write queue. Callers must call
     `_send_pending_writes()` to flush after enqueuing.
 
-    Uses `not is_closed()` rather than `is_open()` because `_ssl_flush_sends()`
-    calls `_enqueue()` during `_SSLHandshaking` (where `is_open() = false`)
-    to push handshake protocol data. The wider guard allows handshake data
-    through while still blocking enqueue after the connection closes.
+    Uses `not is_closed()` rather than `is_open()` because
+    `_ssl_enqueue_sends()` calls `_enqueue()` during `_SSLHandshaking` (where
+    `is_open() = false`) to push handshake protocol data. The wider guard
+    allows handshake data through while still blocking enqueue after the
+    connection closes.
     """
     if data.size() == 0 then return end
     if not is_closed() then
       _pending_data.push(data)
       _pending_writev_total = _pending_writev_total + data.size()
+      _cumulative_enqueued = _cumulative_enqueued + data.size()
     end
 
   fun ref _manage_pending_buffer(bytes_sent: USize): USize =>
     """
     Account for `bytes_sent` by walking `_pending_data` entries. Returns
     the number of fully-sent entries. Updates `_pending_first_buffer_offset`,
-    `_pending_writev_total`, and trims `_pending_data`.
+    `_pending_writev_total`, and `_cumulative_sent`, and trims `_pending_data`.
     """
     if bytes_sent == 0 then return 0 end
 
@@ -995,6 +1027,7 @@ class TCPConnection
     end
 
     _pending_writev_total = _pending_writev_total - bytes_sent
+    _cumulative_sent = _cumulative_sent + bytes_sent
     _pending_data.trim_in_place(num_fully_sent)
     _pending_first_buffer_offset = new_offset
 
@@ -1050,7 +1083,10 @@ class TCPConnection
         end
       else
         // writev error or unreachable Array.apply bounds — non-graceful
-        // shutdown
+        // shutdown. Fire _on_sent for sends whose bytes already reached the
+        // OS in an earlier batch of this flush first, so hard_close fails only
+        // the rest.
+        _fire_completed_sends()
         hard_close()
         return
       end
@@ -1061,19 +1097,39 @@ class TCPConnection
       _reset_idle_timer()
     end
 
+    _fire_completed_sends()
+
     if _pending_writev_total == 0 then
       _release_backpressure()
+    end
 
-      match _pending_token
-      | let t: SendToken =>
-        _pending_token = None
+  fun ref _fire_completed_sends() =>
+    """
+    Fire `_on_sent` for each pending send whose bytes have all reached the
+    OS -- its completion offset has been passed by `_cumulative_sent` -- in
+    send order. Once the queue is fully drained and empty, reset the byte
+    counters. They only grow while the queue never fully empties; on a 64-bit
+    target that won't overflow for any real transfer.
+    """
+    try
+      while _pending_tokens.size() > 0 do
+        (let offset, let token) = _pending_tokens(0)?
+        if offset > _cumulative_sent then break end
+        _pending_tokens.shift()?
         match \exhaustive\ _enclosing
         | let e: TCPConnectionActor ref =>
-          e._notify_sent(t)
+          e._notify_sent(token)
         | None =>
           _Unreachable()
         end
       end
+    else
+      // Guarded by size() > 0, so the ? accesses never error.
+      _Unreachable()
+    end
+    if (_pending_tokens.size() == 0) and (_pending_writev_total == 0) then
+      _cumulative_enqueued = 0
+      _cumulative_sent = 0
     end
 
   fun ref _deliver_received(s: EitherLifecycleEventReceiver ref,
@@ -1482,11 +1538,12 @@ class TCPConnection
       _Unreachable()
     end
 
-  fun ref _ssl_flush_sends() =>
+  fun ref _ssl_enqueue_sends() =>
     """
-    Flush any pending encrypted data from the SSL session to the wire.
-    Called after SSL operations that may produce output (handshake, write).
-    Enqueues all SSL chunks, then flushes once via writev.
+    Drain pending encrypted data from the SSL session into the write queue,
+    without flushing. Split out from `_ssl_flush_sends` so `_do_send` can
+    record a send's completion offset after its ciphertext is enqueued but
+    before the flush.
     """
     match _ssl
     | let ssl: SSL ref =>
@@ -1495,8 +1552,18 @@ class TCPConnection
           _enqueue(ssl.send()?)
         end
       end
-      _send_pending_writes()
     end
+
+  fun ref _ssl_flush_sends() =>
+    """
+    Enqueue any pending encrypted data from the SSL session, then flush to the
+    wire. Called after SSL handshake and protocol operations that produce
+    output (ClientHello, handshake responses). The application write path uses
+    `_ssl_enqueue_sends()` plus `_send_pending_writes()` directly so it can
+    record the send's completion offset between the two.
+    """
+    _ssl_enqueue_sends()
+    _send_pending_writes()
 
   fun ref _ssl_poll(s: EitherLifecycleEventReceiver ref) =>
     """


### PR DESCRIPTION
`_on_sent` used to fire only when the whole write queue drained, reporting a single send, so overlapping sends under backpressure lost their `_on_sent` and a dropped connection failed only the latest send. Now every `send()` that returns a token gets exactly one terminal callback: `_on_sent` when its bytes reach the OS, or `_on_send_failed` if the connection drops first, in send order. A single byte counter over the wire-byte queue drives it, so plaintext and SSL share one path.

Adds a `send-completion` example and tests for overlapping sends, mid-flight drops, and graceful close, on both plaintext and SSL.
