### PR TITLE
Fix connection hang under sustained write backpressure

### DIFF
--- a/.release-notes/fix-connection-hang-under-write-backpressure.md
+++ b/.release-notes/fix-connection-hang-under-write-backpressure.md
@@ -1,0 +1,3 @@
+## Fix connection hang under sustained write backpressure
+
+A connection could permanently stop making progress under sustained write backpressure while its peer was still sending — data stopped flowing in both directions and the connection never recovered on its own, staying wedged until it was closed. This affected echo, relay, and proxy-style connections that pause reading with `mute()` while a write is backed up, and was most likely to appear on multi-threaded runtimes. Such a connection now recovers and continues once the backpressure clears.

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -93,3 +93,4 @@ actor \nodoc\ Main is TestList
     ifdef posix then test(_TestSendSSLPerTokenCompletion) end
     ifdef posix then test(_TestSendSSLMidFlightDropBoundary) end
     ifdef posix then test(_TestSendGracefulCloseWithPending) end
+    ifdef posix then test(_TestReadableEventWriteRecovery) end

--- a/lori/_test_backpressure_drain.pony
+++ b/lori/_test_backpressure_drain.pony
@@ -396,3 +396,246 @@ actor \nodoc\ _TestWriteOnlyEventReadRecoveryClient
       _h.complete_action("client sent ping")
       _tcp_connection.send("ping")
     end
+
+class \nodoc\ iso _TestReadableEventWriteRecovery is UnitTest
+  """
+  Verify that a connection still drains its writes after a readable one-shot
+  event arrives while it is throttled and then mutes.
+
+  The write-side mirror of WriteOnlyEventReadRecovery. On backends where one
+  subscription covers the whole fd (Linux epoll, Windows readiness), any event
+  disarms it. When backpressure has armed write interest and a readable event
+  arrives, the read that mutes must NOT reach _read's EAGAIN resubscribe — that
+  resubscribe re-arms every not-ready direction, so it would restore the write
+  interest and self-heal. The read reaches _queue_read instead of EAGAIN when it
+  fills the buffer, which needs more inbound data than one buffer holds. So the
+  poke here is larger than the read buffer: the muting read fills the buffer and
+  returns via _queue_read, nothing re-arms the write, and the connection wedges.
+
+  Sequence:
+  1. Client connects, sets small SO_RCVBUF, mutes itself, sends a 64 KiB frame
+  2. Server receives the whole frame (buffer_until), echoes it — the muted
+     client can't drain it, so the echo backpressures and throttles the server;
+     the server does NOT mute, and its read loop reaches EAGAIN with reads and
+     write both armed
+  3. Server tells the listener it throttled; listener tells the client to poke
+  4. Client sends a poke larger than the server's read buffer (still muted) — a
+     fresh readable event at the throttled server; it reads a bufferful, can't
+     echo the first chunk, stashes it and mutes, and the read exits via
+     _queue_read (buffer full) rather than EAGAIN, so the whole-fd write interest
+     stays dropped
+  5. Server tells the listener it muted; listener tells the client to drain
+  6. Client unmutes and reads; the write re-arm restores the writeable edge, the
+     server unthrottles, echoes the poke, and the client sees all bytes back
+
+  Timeout means the server never unthrottled — the write interest stayed
+  dropped. POSIX only, for the same reason as BackpressureDrain (Windows
+  loopback buffers past SO_SNDBUF/SO_RCVBUF, so a fixed payload won't throttle).
+  """
+  fun name(): String => "ReadableEventWriteRecovery"
+
+  fun ref apply(h: TestHelper) =>
+    h.expect_action("listener listening")
+    h.expect_action("server started")
+    h.expect_action("client connected")
+    h.expect_action("client sent frame")
+    h.expect_action("server throttled")
+    h.expect_action("client sent poke")
+    h.expect_action("server muted after poke")
+    h.expect_action("server unthrottled")
+    h.expect_action("client received all echoes")
+
+    let listener = _TestReadableEventWriteRecoveryListener(h)
+    h.dispose_when_done(listener)
+
+    h.long_test(30_000_000_000)
+
+actor \nodoc\ _TestReadableEventWriteRecoveryListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _server: (_TestReadableEventWriteRecoveryServer | None) = None
+  var _client: (_TestReadableEventWriteRecoveryClient | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      ifdef linux then "127.0.0.2" else "localhost" end,
+      "9772",
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestReadableEventWriteRecoveryServer =>
+    let s = _TestReadableEventWriteRecoveryServer(fd, _h, this)
+    _server = s
+    s
+
+  fun ref _on_listen_failure() =>
+    _h.fail("listener failed to start")
+
+  fun ref _on_listening() =>
+    _h.complete_action("listener listening")
+    _client = _TestReadableEventWriteRecoveryClient(_h)
+
+  be server_throttled() =>
+    try
+      (_client as _TestReadableEventWriteRecoveryClient).send_poke()
+    end
+
+  be server_muted() =>
+    try
+      (_client as _TestReadableEventWriteRecoveryClient).start_draining()
+    end
+
+  be dispose() =>
+    try (_client as _TestReadableEventWriteRecoveryClient).dispose() end
+    try (_server as _TestReadableEventWriteRecoveryServer).dispose() end
+    _tcp_listener.close()
+
+actor \nodoc\ _TestReadableEventWriteRecoveryServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+  let _listener: _TestReadableEventWriteRecoveryListener
+  var _pending: (Array[U8] iso | None) = None
+  var _got_frame: Bool = false
+  var _poke_muted: Bool = false
+
+  new create(fd: U32, h: TestHelper,
+    listener: _TestReadableEventWriteRecoveryListener)
+  =>
+    _h = h
+    _listener = listener
+    // Read buffer large enough to receive the whole frame as one _on_received,
+    // so the server does not mute mid-frame.
+    let rbs =
+      match MakeReadBufferSize(131072)
+      | let r: ReadBufferSize => r
+      else
+        _Unreachable()
+        DefaultReadBufferSize()
+      end
+    _tcp_connection = TCPConnection.server(
+      TCPServerAuth(_h.env.root),
+      fd,
+      this,
+      this,
+      rbs)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    _h.complete_action("server started")
+    // Frame the incoming 64 KiB payload so it arrives as a single _on_received.
+    match MakeBufferSize(65536)
+    | let b: BufferSize => _tcp_connection.buffer_until(b)
+    else _Unreachable()
+    end
+    // Shrink the send buffer so echoing the frame to a muted client throttles.
+    _tcp_connection.set_so_sndbuf(16384)
+
+  fun ref _on_throttled() =>
+    _h.complete_action("server throttled")
+    _listener.server_throttled()
+
+  fun ref _on_unthrottled() =>
+    // Recovery: the writeable edge arrived, so we echo the stashed poke and
+    // resume reading. Without the write re-arm fix this never runs.
+    _h.complete_action("server unthrottled")
+    match _pending = None
+    | let d: Array[U8] iso =>
+      _tcp_connection.send(consume d)
+      _tcp_connection.unmute()
+    end
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    if not _got_frame then
+      _got_frame = true
+      // Stream from here: the poke is larger than the read buffer, so the read
+      // that mutes fills the buffer and exits via _queue_read (not EAGAIN),
+      // which is what leaves the whole-fd write interest dropped.
+      _tcp_connection.buffer_until(Streaming)
+      // Echo the frame. The muted client can't drain it, so this backpressures
+      // and throttles us, but we don't mute — our read loop reaches EAGAIN with
+      // reads and write both armed.
+      _tcp_connection.send(consume data)
+    elseif _tcp_connection.is_writeable() then
+      // A later poke chunk, after we've recovered and drained: echo it
+      // normally. Stashing here (when writeable, not throttled) would strand it
+      // — nothing would fire _on_unthrottled to send it.
+      _tcp_connection.send(consume data)
+    else
+      // The first poke chunk: a fresh readable event while throttled. We can't
+      // echo it, so we stash it and mute. Because the poke overflows the read
+      // buffer, this read returns via _queue_read rather than EAGAIN, so on a
+      // whole-fd one-shot backend the pending write interest stays dropped.
+      // Signal once — later chunks take the writeable branch above.
+      _pending = consume data
+      _tcp_connection.mute()
+      if not _poke_muted then
+        _poke_muted = true
+        _h.complete_action("server muted after poke")
+        _listener.server_muted()
+      end
+    end
+
+actor \nodoc\ _TestReadableEventWriteRecoveryClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+  var _total_received: USize = 0
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(_h.env.root),
+      ifdef linux then "127.0.0.2" else "localhost" end,
+      "9772",
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _h.complete_action("client connected")
+    // Small receive buffer + muted so the server's echo backpressures.
+    _tcp_connection.set_so_rcvbuf(4096)
+    _tcp_connection.mute()
+    let frame = recover iso Array[U8].init('x', 65536) end
+    _tcp_connection.send(consume frame)
+    _h.complete_action("client sent frame")
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    _h.fail("client connect failed")
+
+  be send_poke() =>
+    // Sent while still muted, so it lands at the throttled server as a readable
+    // event before any writeable edge (the server's send buffer is still full).
+    // Several times the server's read buffer, so however the poke fragments,
+    // the server's muting read fills the buffer and exits via _queue_read
+    // instead of EAGAIN — see the test docstring.
+    let poke = recover iso Array[U8].init('y', 524288) end
+    _tcp_connection.send(consume poke)
+    _h.complete_action("client sent poke")
+
+  be start_draining() =>
+    // Only after the server has stashed and muted the poke — so the poke's
+    // readable event has already dropped the write interest — do we unmute and
+    // let the server's send buffer drain.
+    _tcp_connection.unmute()
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    _total_received = _total_received + data.size()
+    // 65536 (frame echo) + 524288 (poke echo). Without the write re-arm the
+    // server stays throttled, the poke is never echoed, and this never
+    // completes.
+    if _total_received >= 589824 then
+      _h.complete_action("client received all echoes")
+      _tcp_connection.close()
+      _h.complete(true)
+    end

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -1630,18 +1630,21 @@ class TCPConnection
       _read()
     else
       // Runs on every write-only event (writeable, no readable flag).
-      // One-shot readiness (EPOLLONESHOT on Linux, the equivalent gating on
-      // macOS/BSD kqueue and Windows ProcessSocketNotifications) disarms the
-      // whole fd on any event, dropping pending read interest. The write
-      // branch above already ran _set_writeable(), which releases
-      // backpressure. So on a full drain _apply_backpressure() is never
-      // re-entered, and neither read re-arm path runs (its resubscribe and
-      // _read's EAGAIN resubscribe are both skipped), leaving the connection
-      // permanently read-deaf (issue #294). Re-arming reads here covers that.
-      // On a partial drain _apply_backpressure() does re-enter, and because
-      // PonyAsio.resubscribe re-arms whichever directions are not-ready (the
-      // read/write names signal intent, not effect), its write resubscribe
-      // also re-arms reads, so the resubscribe here is redundant but harmless.
+      // Where one subscription covers the whole fd (Linux EPOLLONESHOT,
+      // Windows ProcessSocketNotifications), any event disarms it, dropping
+      // pending read interest. (macOS kqueue arms read and write as
+      // independent one-shot filters, so a write-only event leaves reads armed
+      // and this re-arm is a harmless no-op there — issue #294 was a Linux
+      // report.) The write branch above already ran _set_writeable(), which
+      // releases backpressure. So on a full drain _apply_backpressure() is
+      // never re-entered, and neither read re-arm path runs (its resubscribe
+      // and _read's EAGAIN resubscribe are both skipped), leaving the
+      // connection permanently read-deaf. Re-arming reads here covers that.
+      // On a partial drain _apply_backpressure() does re-enter,
+      // and because on the whole-fd backends PonyAsio.resubscribe re-arms
+      // whichever directions are not-ready (the read/write names signal
+      // intent, not effect), its write resubscribe also re-arms reads, so the
+      // resubscribe here is redundant but harmless.
       //
       // Skip the re-arm unless the socket is still healthy and fully drained,
       // which `_writeable` captures: `_set_writeable()` above set it true, and
@@ -1671,6 +1674,44 @@ class TCPConnection
       if _writeable and not PonyAsio.get_disposable(_event) then
         PonyAsio.resubscribe_read(_event)
       end
+    end
+
+    // Mirror image of the read re-arm above, for the write side. On backends
+    // where one subscription covers the whole fd (Linux EPOLLONESHOT, Windows
+    // ProcessSocketNotifications), any event consumes it, so a readable event
+    // drops the write interest a prior `_apply_backpressure()` armed. The read
+    // path re-arms write as a side effect whenever it reaches its EAGAIN
+    // resubscribe (that resubscribe re-arms every not-ready direction), so most
+    // reads self-heal. The one path that does not is a read that ends in
+    // `mute()` before EAGAIN — exactly what a backpressured echo peer does when
+    // it stashes a chunk it cannot echo. Nothing then re-arms the pending
+    // write: if still throttled, the writeable edge never arrives, backpressure
+    // never releases, `_on_unthrottled` never fires, and the connection wedges.
+    // A lost-wakeup deadlock, seen under sustained backpressure with two or
+    // more scheduler threads (the readable edge has to land between the
+    // `resubscribe_write` and the writeable edge). macOS kqueue arms read and
+    // write as independent one-shot filters, so a readable event leaves write
+    // armed and this re-arm is a harmless no-op there. See issues #294 and #296
+    // for the read-side counterpart.
+    //
+    // Guarded by `is_open()`: `_throttled` alone is not enough because
+    // `_hard_close_cleanup` does not clear it. After a hard_close the event is
+    // gone in both regimes — disposable immediately on POSIX (resubscribe would
+    // assert in debug), and on Windows the REMOVE is only deferred so
+    // `get_disposable` still returns false, where resubscribing would strand
+    // the deferred-close handshake. `is_open()` is true only in
+    // `_Open`/`_TLSUpgrading`, never after a hard_close (which moves to
+    // `_Closed`), so it excludes that case on every platform. Excluding the
+    // other dispatching states is safe: `_SSLHandshaking` delivers no data to
+    // the application, so its read path never mutes and reaches EAGAIN (whose
+    // resubscribe re-arms a throttled write). `_Closing` can mute — an app may
+    // call `mute()` from `_on_received` during graceful shutdown — but a muted
+    // `_Closing` connection is already waiting on the peer's FIN it won't read,
+    // so re-arming write cannot move it forward and its absence is not the
+    // wedge this fixes. `get_disposable` is kept as defense in depth, matching
+    // the read guard.
+    if _throttled and is_open() and not PonyAsio.get_disposable(_event) then
+      PonyAsio.resubscribe_write(_event)
     end
 
   fun ref _do_read_again() =>


### PR DESCRIPTION
A connection could hang permanently under sustained write backpressure while its peer was still sending. On whole-fd one-shot readiness backends (Linux epoll, Windows ProcessSocketNotifications), a readable event disarms the fd's write interest that backpressure had armed. When the read that follows ends in `mute()` without reaching the EAGAIN resubscribe — an echo, relay, or proxy peer stashing a chunk it can't echo — nothing re-arms the write. The writeable edge never arrives, backpressure never releases, and the connection wedges.

This is the write-side mirror of the read-side re-arm from #295 (issue #294). It surfaced on Windows under the tcp-swarm stress test with two or more scheduler threads, but the gap is cross-platform: Linux is affected on the same read-then-mute path (its common read paths self-heal via the shared resubscribe, so it shows up less often), and macOS kqueue is immune because it arms read and write as independent one-shot filters — the re-arm is a harmless no-op there.

The fix re-arms write interest after dispatch when the connection is open and still throttled, guarded by `is_open()` so it never resubscribes a torn-down event.

Adds `ReadableEventWriteRecovery`, a deterministic POSIX regression test that mirrors `WriteOnlyEventReadRecovery`. Verified counterfactually on Linux: it times out without the fix and passes with it.