### PR TITLE
Fix a hang when closing a connection while handling received data

### DIFF
--- a/.release-notes/fix-hang-closing-during-receive.md
+++ b/.release-notes/fix-hang-closing-during-receive.md
@@ -1,0 +1,5 @@
+## Fix a hang when closing a connection while handling received data
+
+Closing a connection from inside `_on_received` — for example, closing once you've read a full message — could leave the connection attempting one more read on the socket it had just closed. Under connection churn (many connections opening and closing), that stray read could block one of the runtime's scheduler threads and keep the program from exiting.
+
+Closing a connection while handling received data no longer triggers this hang.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,7 +205,7 @@ _Open → _TLSUpgrading (start_tls) → _Open (ssl_handshake_complete)
                                    ↘ _Closed (hard_close / TLS error)
 ```
 
-| State | `is_open()` | `is_closed()` | `sends_allowed()` | `socket_open()` | Description |
+| State | `is_open()` | `is_closed()` | `sends_allowed()` | `can_receive()` | Description |
 |---|---|---|---|---|---|
 | `_ConnectionNone` | false | false | false | false | Before `_finish_initialization`. Most dispatch methods call `_Unreachable()`. Socket options return error values; `idle_timeout` stores the value; `set_timer` returns `SetTimerNotOpen`. `hard_close` is a no-op (dispose can race with initialization). |
 | `_ClientConnecting` | false | false | false | false | Happy Eyeballs in progress. `close()` transitions to `_UnconnectedClosing`. |
@@ -216,9 +216,9 @@ _Open → _TLSUpgrading (start_tls) → _Open (ssl_handshake_complete)
 | `_Closing` | false | true | false | true | Graceful shutdown in progress — waiting for peer FIN. Still reads to detect FIN. |
 | `_Closed` | false | true | false | false | Fully closed. Handles straggler event cleanup only. |
 
-State classes dispatch lifecycle-gated operations (`send`, `close`, `hard_close`, `start_tls`, `read_again`, `read_socket`, `ssl_handshake_complete`, `own_event`, `foreign_event`, `keepalive`, `getsockopt`, `getsockopt_u32`, `setsockopt`, `setsockopt_u32`, `idle_timeout`, `set_timer`) and delegate to TCPConnection methods for the actual work. All I/O, SSL, buffer, and flow control logic remains on TCPConnection.
+State classes dispatch lifecycle-gated operations (`send`, `close`, `hard_close`, `start_tls`, `read_again`, `receive`, `ssl_handshake_complete`, `own_event`, `foreign_event`, `keepalive`, `getsockopt`, `getsockopt_u32`, `setsockopt`, `setsockopt_u32`, `idle_timeout`, `set_timer`) and delegate to TCPConnection methods for the actual work. All I/O, SSL, buffer, and flow control logic remains on TCPConnection.
 
-Each state also answers `socket_open()`: true while the underlying fd is open (`_Open`, `_Closing`, `_SSLHandshaking`, `_TLSUpgrading`), false otherwise. It is distinct from `is_open()` (app-level, false during `_Closing` and the initial SSL handshake `_SSLHandshaking`, but true during `_TLSUpgrading`). `_read()` consults it after every `_deliver_received()`, because the application's `_on_received` can `hard_close()` mid-loop (transitioning to `_Closed`); on that transition `_read()` breaks its loop instead of falling through to another socket read on the just-closed fd. `_Closing` stays `socket_open()`, so it keeps reading to detect the peer FIN. The socket read itself is the dispatched `read_socket` operation: reading states perform it, non-reading states are `_Unreachable()` — so a read that slips through in a closed state fails loudly rather than reading a dead fd (which under connection churn can block a scheduler thread on a reused fd and hang the runtime).
+Each state also answers `can_receive()`: whether the connection still takes in incoming data in this state. It is the read-side counterpart to `sends_allowed()`, and it is broader than `is_open()` — a connection receives before the app is handed it (the SSL handshake) and after the app has closed it (`_Closing`, reading for the peer's FIN), not just while it is open. `_read()` checks it after every `_deliver_received()`: the application's `_on_received` can `hard_close()` mid-loop, and `_read()` breaks its loop on that transition instead of reading the just-closed fd. The socket read is the dispatched `receive` operation — reading states perform it, the rest are `_Unreachable()`, so a read that reaches a state that can't receive fails loudly instead of reading a dead fd (which under connection churn can block a scheduler thread on a reused fd and hang the runtime). Per-state values are in the table above.
 
 **Private field access**: Pony restricts private field access to the defining type. State classes use helper methods on TCPConnection (`_set_state`, `_decrement_inflight`, `_establish_connection`, `_straggler_cleanup`, etc.) rather than accessing fields directly.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,18 +205,20 @@ _Open → _TLSUpgrading (start_tls) → _Open (ssl_handshake_complete)
                                    ↘ _Closed (hard_close / TLS error)
 ```
 
-| State | `is_open()` | `is_closed()` | `sends_allowed()` | Description |
-|---|---|---|---|---|
-| `_ConnectionNone` | false | false | false | Before `_finish_initialization`. Most dispatch methods call `_Unreachable()`. Socket options return error values; `idle_timeout` stores the value; `set_timer` returns `SetTimerNotOpen`. `hard_close` is a no-op (dispose can race with initialization). |
-| `_ClientConnecting` | false | false | false | Happy Eyeballs in progress. `close()` transitions to `_UnconnectedClosing`. |
-| `_UnconnectedClosing` | false | true | false | Draining inflight Happy Eyeballs after `close()` during connecting. Fires `_on_connection_failure` when all drain. `hard_close()` short-circuits to `_Closed`. |
-| `_SSLHandshaking` | false | false | false | TCP connected, initial SSL handshake in progress. Application not notified yet. `close()` delegates to `hard_close()`. |
-| `_TLSUpgrading` | true | false | false | Established connection upgrading to TLS via `start_tls()`. Application already notified. `close()` delegates to `hard_close()`. |
-| `_Open` | true | false | true | Connection established, application notified, I/O active. |
-| `_Closing` | false | true | false | Graceful shutdown in progress — waiting for peer FIN. Still reads to detect FIN. |
-| `_Closed` | false | true | false | Fully closed. Handles straggler event cleanup only. |
+| State | `is_open()` | `is_closed()` | `sends_allowed()` | `socket_open()` | Description |
+|---|---|---|---|---|---|
+| `_ConnectionNone` | false | false | false | false | Before `_finish_initialization`. Most dispatch methods call `_Unreachable()`. Socket options return error values; `idle_timeout` stores the value; `set_timer` returns `SetTimerNotOpen`. `hard_close` is a no-op (dispose can race with initialization). |
+| `_ClientConnecting` | false | false | false | false | Happy Eyeballs in progress. `close()` transitions to `_UnconnectedClosing`. |
+| `_UnconnectedClosing` | false | true | false | false | Draining inflight Happy Eyeballs after `close()` during connecting. Fires `_on_connection_failure` when all drain. `hard_close()` short-circuits to `_Closed`. |
+| `_SSLHandshaking` | false | false | false | true | TCP connected, initial SSL handshake in progress. Application not notified yet. `close()` delegates to `hard_close()`. |
+| `_TLSUpgrading` | true | false | false | true | Established connection upgrading to TLS via `start_tls()`. Application already notified. `close()` delegates to `hard_close()`. |
+| `_Open` | true | false | true | true | Connection established, application notified, I/O active. |
+| `_Closing` | false | true | false | true | Graceful shutdown in progress — waiting for peer FIN. Still reads to detect FIN. |
+| `_Closed` | false | true | false | false | Fully closed. Handles straggler event cleanup only. |
 
-State classes dispatch lifecycle-gated operations (`send`, `close`, `hard_close`, `start_tls`, `read_again`, `ssl_handshake_complete`, `own_event`, `foreign_event`, `keepalive`, `getsockopt`, `getsockopt_u32`, `setsockopt`, `setsockopt_u32`, `idle_timeout`, `set_timer`) and delegate to TCPConnection methods for the actual work. All I/O, SSL, buffer, and flow control logic remains on TCPConnection.
+State classes dispatch lifecycle-gated operations (`send`, `close`, `hard_close`, `start_tls`, `read_again`, `read_socket`, `ssl_handshake_complete`, `own_event`, `foreign_event`, `keepalive`, `getsockopt`, `getsockopt_u32`, `setsockopt`, `setsockopt_u32`, `idle_timeout`, `set_timer`) and delegate to TCPConnection methods for the actual work. All I/O, SSL, buffer, and flow control logic remains on TCPConnection.
+
+Each state also answers `socket_open()`: true while the underlying fd is open (`_Open`, `_Closing`, `_SSLHandshaking`, `_TLSUpgrading`), false otherwise. It is distinct from `is_open()` (app-level, false during `_Closing` and the initial SSL handshake `_SSLHandshaking`, but true during `_TLSUpgrading`). `_read()` consults it after every `_deliver_received()`, because the application's `_on_received` can `hard_close()` mid-loop (transitioning to `_Closed`); on that transition `_read()` breaks its loop instead of falling through to another socket read on the just-closed fd. `_Closing` stays `socket_open()`, so it keeps reading to detect the peer FIN. The socket read itself is the dispatched `read_socket` operation: reading states perform it, non-reading states are `_Unreachable()` — so a read that slips through in a closed state fails loudly rather than reading a dead fd (which under connection churn can block a scheduler thread on a reused fd and hang the runtime).
 
 **Private field access**: Pony restricts private field access to the defining type. State classes use helper methods on TCPConnection (`_set_state`, `_decrement_inflight`, `_establish_connection`, `_straggler_cleanup`, etc.) rather than accessing fields directly.
 

--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -29,6 +29,20 @@ trait _ConnectionState
   fun is_open(): Bool
   fun is_closed(): Bool
   fun sends_allowed(): Bool
+  // True while the underlying socket fd is open (connected, not yet closed):
+  // `_Open`, `_Closing`, and the SSL handshake/upgrade states. Distinct from
+  // `is_open()`, which is app-level and false during `_Closing` and the initial
+  // SSL handshake (`_SSLHandshaking`). `_read` uses this to break its loop when
+  // a callback transitions the connection to `_Closed` mid-read, while still
+  // reading in `_Closing` (which stays open to detect the peer FIN).
+  fun socket_open(): Bool
+  // Reads up to `size` bytes off the socket into `buffer`. Only states whose
+  // fd is open (`socket_open()`) read; the rest are `_Unreachable()`. `_read`'s
+  // `socket_open()` guard must stop the loop before it reaches here, so a call
+  // in a non-reading state means that guard was bypassed. This is an internal,
+  // ASIO-driven read.
+  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+    size: USize): (SocketResult, USize)
 
 class _ConnectionNone is _ConnectionState
   fun ref own_event(conn: TCPConnection ref, flags: U32) =>
@@ -117,6 +131,13 @@ class _ConnectionNone is _ConnectionState
   fun is_open(): Bool => false
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
+  fun socket_open(): Bool => false
+
+  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+    size: USize): (SocketResult, USize)
+  =>
+    _Unreachable()
+    (SocketResultError, 0)
 
 class _ClientConnecting is _ConnectionState
   fun ref own_event(conn: TCPConnection ref, flags: U32) =>
@@ -209,6 +230,13 @@ class _ClientConnecting is _ConnectionState
   fun is_open(): Bool => false
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
+  fun socket_open(): Bool => false
+
+  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+    size: USize): (SocketResult, USize)
+  =>
+    _Unreachable()
+    (SocketResultError, 0)
 
 class _Open is _ConnectionState
   fun ref own_event(conn: TCPConnection ref, flags: U32) =>
@@ -291,6 +319,12 @@ class _Open is _ConnectionState
   fun is_open(): Bool => true
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => true
+  fun socket_open(): Bool => true
+
+  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+    size: USize): (SocketResult, USize)
+  =>
+    PonyTCP.receive(event, buffer, size)
 
 class _Closing is _ConnectionState
   fun ref own_event(conn: TCPConnection ref, flags: U32) =>
@@ -375,6 +409,12 @@ class _Closing is _ConnectionState
   fun is_open(): Bool => false
   fun is_closed(): Bool => true
   fun sends_allowed(): Bool => false
+  fun socket_open(): Bool => true
+
+  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+    size: USize): (SocketResult, USize)
+  =>
+    PonyTCP.receive(event, buffer, size)
 
 class _UnconnectedClosing is _ConnectionState
   """
@@ -463,6 +503,13 @@ class _UnconnectedClosing is _ConnectionState
   fun is_open(): Bool => false
   fun is_closed(): Bool => true
   fun sends_allowed(): Bool => false
+  fun socket_open(): Bool => false
+
+  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+    size: USize): (SocketResult, USize)
+  =>
+    _Unreachable()
+    (SocketResultError, 0)
 
 class _Closed is _ConnectionState
   fun ref own_event(conn: TCPConnection ref, flags: U32) =>
@@ -540,6 +587,13 @@ class _Closed is _ConnectionState
   fun is_open(): Bool => false
   fun is_closed(): Bool => true
   fun sends_allowed(): Bool => false
+  fun socket_open(): Bool => false
+
+  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+    size: USize): (SocketResult, USize)
+  =>
+    _Unreachable()
+    (SocketResultError, 0)
 
 class _SSLHandshaking is _ConnectionState
   """
@@ -634,6 +688,12 @@ class _SSLHandshaking is _ConnectionState
   fun is_open(): Bool => false
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
+  fun socket_open(): Bool => true
+
+  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+    size: USize): (SocketResult, USize)
+  =>
+    PonyTCP.receive(event, buffer, size)
 
 class _TLSUpgrading is _ConnectionState
   """
@@ -724,3 +784,9 @@ class _TLSUpgrading is _ConnectionState
   fun is_open(): Bool => true
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
+  fun socket_open(): Bool => true
+
+  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+    size: USize): (SocketResult, USize)
+  =>
+    PonyTCP.receive(event, buffer, size)

--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -29,19 +29,8 @@ trait _ConnectionState
   fun is_open(): Bool
   fun is_closed(): Bool
   fun sends_allowed(): Bool
-  // True while the underlying socket fd is open (connected, not yet closed):
-  // `_Open`, `_Closing`, and the SSL handshake/upgrade states. Distinct from
-  // `is_open()`, which is app-level and false during `_Closing` and the initial
-  // SSL handshake (`_SSLHandshaking`). `_read` uses this to break its loop when
-  // a callback transitions the connection to `_Closed` mid-read, while still
-  // reading in `_Closing` (which stays open to detect the peer FIN).
-  fun socket_open(): Bool
-  // Reads up to `size` bytes off the socket into `buffer`. Only states whose
-  // fd is open (`socket_open()`) read; the rest are `_Unreachable()`. `_read`'s
-  // `socket_open()` guard must stop the loop before it reaches here, so a call
-  // in a non-reading state means that guard was bypassed. This is an internal,
-  // ASIO-driven read.
-  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+  fun can_receive(): Bool
+  fun receive(event: AsioEventID, buffer: Pointer[U8] tag,
     size: USize): (SocketResult, USize)
 
 class _ConnectionNone is _ConnectionState
@@ -131,9 +120,9 @@ class _ConnectionNone is _ConnectionState
   fun is_open(): Bool => false
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
-  fun socket_open(): Bool => false
+  fun can_receive(): Bool => false
 
-  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+  fun receive(event: AsioEventID, buffer: Pointer[U8] tag,
     size: USize): (SocketResult, USize)
   =>
     _Unreachable()
@@ -230,9 +219,9 @@ class _ClientConnecting is _ConnectionState
   fun is_open(): Bool => false
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
-  fun socket_open(): Bool => false
+  fun can_receive(): Bool => false
 
-  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+  fun receive(event: AsioEventID, buffer: Pointer[U8] tag,
     size: USize): (SocketResult, USize)
   =>
     _Unreachable()
@@ -319,9 +308,9 @@ class _Open is _ConnectionState
   fun is_open(): Bool => true
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => true
-  fun socket_open(): Bool => true
+  fun can_receive(): Bool => true
 
-  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+  fun receive(event: AsioEventID, buffer: Pointer[U8] tag,
     size: USize): (SocketResult, USize)
   =>
     PonyTCP.receive(event, buffer, size)
@@ -409,9 +398,9 @@ class _Closing is _ConnectionState
   fun is_open(): Bool => false
   fun is_closed(): Bool => true
   fun sends_allowed(): Bool => false
-  fun socket_open(): Bool => true
+  fun can_receive(): Bool => true
 
-  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+  fun receive(event: AsioEventID, buffer: Pointer[U8] tag,
     size: USize): (SocketResult, USize)
   =>
     PonyTCP.receive(event, buffer, size)
@@ -503,9 +492,9 @@ class _UnconnectedClosing is _ConnectionState
   fun is_open(): Bool => false
   fun is_closed(): Bool => true
   fun sends_allowed(): Bool => false
-  fun socket_open(): Bool => false
+  fun can_receive(): Bool => false
 
-  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+  fun receive(event: AsioEventID, buffer: Pointer[U8] tag,
     size: USize): (SocketResult, USize)
   =>
     _Unreachable()
@@ -587,9 +576,9 @@ class _Closed is _ConnectionState
   fun is_open(): Bool => false
   fun is_closed(): Bool => true
   fun sends_allowed(): Bool => false
-  fun socket_open(): Bool => false
+  fun can_receive(): Bool => false
 
-  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+  fun receive(event: AsioEventID, buffer: Pointer[U8] tag,
     size: USize): (SocketResult, USize)
   =>
     _Unreachable()
@@ -688,9 +677,9 @@ class _SSLHandshaking is _ConnectionState
   fun is_open(): Bool => false
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
-  fun socket_open(): Bool => true
+  fun can_receive(): Bool => true
 
-  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+  fun receive(event: AsioEventID, buffer: Pointer[U8] tag,
     size: USize): (SocketResult, USize)
   =>
     PonyTCP.receive(event, buffer, size)
@@ -784,9 +773,9 @@ class _TLSUpgrading is _ConnectionState
   fun is_open(): Bool => true
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
-  fun socket_open(): Bool => true
+  fun can_receive(): Bool => true
 
-  fun read_socket(event: AsioEventID, buffer: Pointer[U8] tag,
+  fun receive(event: AsioEventID, buffer: Pointer[U8] tag,
     size: USize): (SocketResult, USize)
   =>
     PonyTCP.receive(event, buffer, size)

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -18,6 +18,8 @@ actor \nodoc\ Main is TestList
     test(_TestUnmute)
     test(_TestSendToken)
     test(_TestSendAfterClose)
+    test(_TestHardCloseDuringReceive)
+    test(_TestHardCloseAfterFramedReceive)
     test(_TestStartTLSPingPong)
     test(_TestStartTLSPreconditions)
     test(_TestHardCloseWhileConnecting)

--- a/lori/_test_connection.pony
+++ b/lori/_test_connection.pony
@@ -365,3 +365,245 @@ actor \nodoc\ _TestListenerLocalAddressListener is TCPListenerActor
 
   fun ref _listener(): TCPListener =>
     _tcp_listener
+
+class \nodoc\ iso _TestHardCloseDuringReceive is UnitTest
+  """
+  A hard close from inside `_on_received` must break `_read`'s loop, not fall
+  through to another socket read on the fd it just closed.
+
+  The application closing when it has read what it needs is a normal pattern.
+  `mute()` + `close()` in `_on_received` routes to `hard_close()`, which
+  transitions the connection to `_Closed` while `_read` is still on the stack.
+  `_read` must stop on that transition. If it doesn't, it reaches
+  `_state.read_socket()` in `_Closed` — which is `_Unreachable()` — so a
+  regression trips that here; in production it read a closed fd, and under
+  connection churn a reused blocking fd would hang a scheduler thread.
+
+  `_on_closed` completes the test action before the stray read would run, so a
+  regression surfaces as a non-zero process exit from `_Unreachable()`, not a
+  failed assertion. `HardCloseAfterFramedReceive` is the assertion-based
+  companion for the buffered-delivery path.
+  """
+  fun name(): String => "HardCloseDuringReceive"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("server listening")
+    h.expect_action("server closed during receive")
+
+    let s = _TestHardCloseDuringReceiveListener(h)
+    h.dispose_when_done(s)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestHardCloseDuringReceiveListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _client: (_TestHardCloseDuringReceiveClient | None) = None
+  var _server: (_TestHardCloseDuringReceiveServer | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      "7920",
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestHardCloseDuringReceiveServer =>
+    let server = _TestHardCloseDuringReceiveServer(fd, _h)
+    _server = server
+    server
+
+  fun ref _on_closed() =>
+    try (_client as _TestHardCloseDuringReceiveClient).dispose() end
+    try (_server as _TestHardCloseDuringReceiveServer).dispose() end
+
+  fun ref _on_listening() =>
+    _h.complete_action("server listening")
+    _client = _TestHardCloseDuringReceiveClient(_h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestHardCloseDuringReceiveListener")
+
+actor \nodoc\ _TestHardCloseDuringReceiveClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(_h.env.root),
+      "localhost",
+      "7920",
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    // Give the server data so its `_on_received` fires.
+    match _tcp_connection.send("ping")
+    | let _: SendToken => None
+    | let _: SendError =>
+      _h.fail("client send() failed")
+      _h.complete(false)
+    end
+
+actor \nodoc\ _TestHardCloseDuringReceiveServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+  var _closed_in_receive: Bool = false
+
+  new create(fd: U32, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.server(
+      TCPServerAuth(_h.env.root),
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    // Hard close from inside the read callback (see the class docstring).
+    _closed_in_receive = true
+    _tcp_connection.mute()
+    _tcp_connection.close()
+
+  fun ref _on_closed() =>
+    if _closed_in_receive then
+      _h.complete_action("server closed during receive")
+    end
+
+class \nodoc\ iso _TestHardCloseAfterFramedReceive is UnitTest
+  """
+  When two framed messages arrive in one socket read and the application
+  hard_closes after the first, `_read` must not deliver the second.
+
+  With `buffer_until` framing, `_read`'s inner loop hands over one frame at a
+  time from a single buffered read. A `hard_close()` in the first frame's
+  `_on_received` transitions the connection to `_Closed`; the loop must stop
+  rather than deliver the buffered second frame after `_on_closed` fired. The
+  close is unmuted, so `socket_open()` — not `_muted` — is what has to stop it.
+  The delivery count is checked in a self-behavior that runs after `_read`
+  returns, so a regression fails with a clear assertion, not a process exit.
+
+  The two 4-byte frames go out in one `send()`, so on loopback they arrive in a
+  single read. A split (not expected here) would leave the second frame unread
+  after the close, so the test would pass without exercising the path — it can
+  never fail spuriously.
+  """
+  fun name(): String => "HardCloseAfterFramedReceive"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("only first frame delivered")
+
+    let s = _TestHardCloseAfterFramedReceiveListener(h)
+    h.dispose_when_done(s)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestHardCloseAfterFramedReceiveListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _client: (_TestHardCloseAfterFramedReceiveClient | None) = None
+  var _server: (_TestHardCloseAfterFramedReceiveServer | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      "7921",
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestHardCloseAfterFramedReceiveServer =>
+    let server = _TestHardCloseAfterFramedReceiveServer(fd, _h)
+    _server = server
+    server
+
+  fun ref _on_closed() =>
+    try (_client as _TestHardCloseAfterFramedReceiveClient).dispose() end
+    try (_server as _TestHardCloseAfterFramedReceiveServer).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestHardCloseAfterFramedReceiveClient(_h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestHardCloseAfterFramedReceiveListener")
+
+actor \nodoc\ _TestHardCloseAfterFramedReceiveClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.client(
+      TCPConnectAuth(_h.env.root),
+      "localhost",
+      "7921",
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    // Two 4-byte frames in a single send, so both land in one server read.
+    match _tcp_connection.send("AAAABBBB")
+    | let _: SendToken => None
+    | let _: SendError =>
+      _h.fail("client send() failed")
+      _h.complete(false)
+    end
+
+actor \nodoc\ _TestHardCloseAfterFramedReceiveServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+  var _received_count: U8 = 0
+
+  new create(fd: U32, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.server(
+      TCPServerAuth(_h.env.root),
+      fd,
+      this,
+      this)
+    match MakeBufferSize(4)
+    | let b: BufferSize => _tcp_connection.buffer_until(b)
+    end
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    _received_count = _received_count + 1
+    if _received_count == 1 then
+      _h.assert_eq[String]("AAAA", String.from_array(consume data))
+      // Unmuted hard close inside the first frame's callback. The buffered
+      // second frame must not be delivered next. The count is checked below in
+      // a behavior that runs after `_read` returns.
+      _tcp_connection.hard_close()
+      _check_delivery_count()
+    end
+
+  be _check_delivery_count() =>
+    if _received_count == 1 then
+      _h.complete_action("only first frame delivered")
+    else
+      _h.fail("second frame delivered after hard_close()")
+    end

--- a/lori/_test_connection.pony
+++ b/lori/_test_connection.pony
@@ -375,7 +375,7 @@ class \nodoc\ iso _TestHardCloseDuringReceive is UnitTest
   `mute()` + `close()` in `_on_received` routes to `hard_close()`, which
   transitions the connection to `_Closed` while `_read` is still on the stack.
   `_read` must stop on that transition. If it doesn't, it reaches
-  `_state.read_socket()` in `_Closed` — which is `_Unreachable()` — so a
+  `_state.receive()` in `_Closed` — which is `_Unreachable()` — so a
   regression trips that here; in production it read a closed fd, and under
   connection churn a reused blocking fd would hang a scheduler thread.
 
@@ -492,7 +492,7 @@ class \nodoc\ iso _TestHardCloseAfterFramedReceive is UnitTest
   time from a single buffered read. A `hard_close()` in the first frame's
   `_on_received` transitions the connection to `_Closed`; the loop must stop
   rather than deliver the buffered second frame after `_on_closed` fired. The
-  close is unmuted, so `socket_open()` — not `_muted` — is what has to stop it.
+  close is unmuted, so `can_receive()` — not `_muted` — is what has to stop it.
   The delivery count is checked in a self-behavior that runs after `_read`
   returns, so a regression fails with a clear assertion, not a process exit.
 

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -1160,10 +1160,10 @@ class TCPConnection
             return
           end
 
-          // Handle any data already in the read buffer. `_state.socket_open()`
+          // Handle any data already in the read buffer. `_state.can_receive()`
           // stops mid-delivery if an `_on_received` hard_closed us — see the
           // guard after this loop for the rationale.
-          while not _muted and _state.socket_open()
+          while not _muted and _state.can_receive()
             and _there_is_buffered_read_data()
           do
             let bytes_to_consume = match \exhaustive\ _tcp_buffer_until()
@@ -1194,9 +1194,9 @@ class TCPConnection
           // which can hard_close() this connection, transitioning it to
           // `_Closed`. Break the loop on that transition rather than fall
           // through to a socket read on the just-closed fd. Graceful close
-          // (`_Closing`) stays `socket_open()`, so it keeps reading here to
+          // (`_Closing`) stays `can_receive()`, so it keeps reading here to
           // detect the peer FIN. (Mute is handled by the top-of-loop check.)
-          if not _state.socket_open() then
+          if not _state.can_receive() then
             return
           end
 
@@ -1210,7 +1210,7 @@ class TCPConnection
 
           _resize_read_buffer_if_needed()
 
-          match \exhaustive\ _state.read_socket(_event,
+          match \exhaustive\ _state.receive(_event,
             _read_buffer.cpointer(_bytes_in_read_buffer),
             _read_buffer.size() - _bytes_in_read_buffer)
           | (SocketResultOk, let bytes_read: USize) =>

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -1160,8 +1160,12 @@ class TCPConnection
             return
           end
 
-          // Handle any data already in the read buffer
-          while not _muted and _there_is_buffered_read_data() do
+          // Handle any data already in the read buffer. `_state.socket_open()`
+          // stops mid-delivery if an `_on_received` hard_closed us — see the
+          // guard after this loop for the rationale.
+          while not _muted and _state.socket_open()
+            and _there_is_buffered_read_data()
+          do
             let bytes_to_consume = match \exhaustive\ _tcp_buffer_until()
             | let e: BufferSize => e()
             | Streaming => _bytes_in_read_buffer
@@ -1186,6 +1190,16 @@ class TCPConnection
             end
           end
 
+          // `_deliver_received()` above runs the application's `_on_received`,
+          // which can hard_close() this connection, transitioning it to
+          // `_Closed`. Break the loop on that transition rather than fall
+          // through to a socket read on the just-closed fd. Graceful close
+          // (`_Closing`) stays `socket_open()`, so it keeps reading here to
+          // detect the peer FIN. (Mute is handled by the top-of-loop check.)
+          if not _state.socket_open() then
+            return
+          end
+
           // Yield after reading a buffer's worth of data to allow GC and
           // other actors to run. _queue_read() schedules _read_again to
           // resume.
@@ -1196,7 +1210,7 @@ class TCPConnection
 
           _resize_read_buffer_if_needed()
 
-          match \exhaustive\ PonyTCP.receive(_event,
+          match \exhaustive\ _state.read_socket(_event,
             _read_buffer.cpointer(_bytes_in_read_buffer),
             _read_buffer.size() - _bytes_in_read_buffer)
           | (SocketResultOk, let bytes_read: USize) =>


### PR DESCRIPTION
Closing a connection from inside `_on_received` left `_read()` able to run one more socket read on the fd it had just closed. On a plaintext connection the stale read usually returned EBADF and was harmless, but under connection churn the closed fd number gets reused, and if the reused number is a blocking socket the read never returns: a scheduler thread parks in `recv` and the runtime never exits. The swarm stress test failed on close=hard workloads because of this.

The read loop now breaks when a callback transitions the connection to `_Closed`, and the socket read is a state-machine operation (`receive`) that is `_Unreachable()` in a state that can't receive, so a future read-after-close fails loudly instead of reading a dead fd. Graceful close (`_Closing`) keeps its fd open and still reads for the peer FIN.

Two regression tests: a hard close from inside `_on_received` (the reported path), and an unmuted hard close between two framed messages in one read that asserts the second frame is not delivered.

Follow-ups filed while working on this:

- #309 — the SSL `_ssl_poll` deliver-after-close / use-after-dispose. Same shape one layer up; this PR fixes the hang for SSL, but not the record-level delivery and read of the disposed session.
- #308 — the `is_open` predicate is a vague umbrella (surfaced while naming the read-loop predicate `can_receive` here); split it into specific capability predicates.
- ponylang/ponyc#5715 — harden `pony_os_recv`/`pony_os_recvfrom` with `MSG_DONTWAIT` so a stray read on a reused blocking fd can never park a scheduler thread.
