### PR TITLE
Fix graceful close dropping writes queued under backpressure

### DIFF
--- a/.release-notes/fix-graceful-close-dropping-queued-writes.md
+++ b/.release-notes/fix-graceful-close-dropping-queued-writes.md
@@ -1,0 +1,5 @@
+## Fix graceful close dropping writes queued under backpressure
+
+When a connection was under write backpressure — bytes you sent were queued because the socket couldn't take them yet — a graceful `close()` dropped those queued bytes. They never reached the peer, and their sends completed with `_on_send_failed` instead of `_on_sent`, even though you closed the connection cleanly rather than aborting it.
+
+A graceful `close()` now sends what is still queued before shutting the connection down, so the data you handed to an accepted `send()` goes out rather than being dropped, and those sends fire `_on_sent`. `hard_close()` is unchanged: it still drops queued writes and fails their sends with `_on_send_failed`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -217,7 +217,7 @@ _Open → _TLSUpgrading (start_tls) → _Open (ssl_handshake_complete)
 | `_SSLHandshaking` | false | false | false | true | TCP connected, initial SSL handshake in progress. Application not notified yet. `close()` delegates to `hard_close()`. |
 | `_TLSUpgrading` | true | false | false | true | Established connection upgrading to TLS via `start_tls()`. Application already notified. `close()` delegates to `hard_close()`. |
 | `_Open` | true | false | true | true | Connection established, application notified, I/O active. |
-| `_Closing` | false | true | false | true | Graceful shutdown in progress — waiting for peer FIN. Still reads to detect FIN. |
+| `_Closing` | false | true | false | true | Graceful shutdown in progress. Flushes writes still queued under backpressure, then sends FIN once the queue drains, and waits for the peer FIN. Still reads to detect FIN. |
 | `_Closed` | false | true | false | false | Fully closed. Handles straggler event cleanup only. |
 
 State classes dispatch lifecycle-gated operations (`send`, `close`, `hard_close`, `start_tls`, `read_again`, `receive`, `ssl_handshake_complete`, `own_event`, `foreign_event`, `keepalive`, `getsockopt`, `getsockopt_u32`, `setsockopt`, `setsockopt_u32`, `idle_timeout`, `set_timer`) and delegate to TCPConnection methods for the actual work. All I/O, SSL, buffer, and flow control logic remains on TCPConnection.
@@ -331,7 +331,7 @@ Design: Discussion #252.
 
 `send(data: (ByteSeq | ByteSeqIter))` is fallible — it returns `(SendToken | SendError)` instead of silently dropping data:
 
-- `SendToken` — opaque token identifying the send operation. Each accepted `send()` gets exactly one terminal callback: `_on_sent(token)` when its bytes are handed to the OS (kernel send buffer, not peer receipt), or `_on_send_failed(token)` if the connection closes first. Callbacks fire in send order.
+- `SendToken` — opaque token identifying the send operation. Each accepted `send()` gets exactly one terminal callback: `_on_sent(token)` when its bytes are handed to the OS (kernel send buffer, not peer receipt), or `_on_send_failed(token)` if the connection is lost or hard-closed before the bytes are written. A graceful `close()` flushes queued writes first, so sends still pending at a graceful close fire `_on_sent`. Callbacks fire in send order.
 - `SendErrorNotConnected` — connection not open (permanent).
 - `SendErrorNotWriteable` — socket under backpressure (transient, wait for `_on_unthrottled`).
 During SSL handshake (`_SSLHandshaking` or `_TLSUpgrading`), returns `SendErrorNotConnected` directly from the state class without reaching `_do_send()`.

--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -357,6 +357,9 @@ class _Open is _ConnectionState
 class _Closing is _ConnectionState
   fun ref own_event(conn: TCPConnection ref, flags: U32) =>
     conn._dispatch_io_event(flags)
+    // A writeable event may have drained the last queued write; if so, send the
+    // FIN that close() deferred.
+    conn._initiate_shutdown()
 
   fun ref foreign_event(conn: TCPConnection ref, event: AsioEventID,
     flags: U32)

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -104,4 +104,5 @@ actor \nodoc\ Main is TestList
     ifdef posix then test(_TestSendSSLPerTokenCompletion) end
     ifdef posix then test(_TestSendSSLMidFlightDropBoundary) end
     ifdef posix then test(_TestSendGracefulCloseWithPending) end
+    ifdef posix then test(_TestSendSSLGracefulCloseWithPending) end
     ifdef posix then test(_TestReadableEventWriteRecovery) end

--- a/lori/_test_send.pony
+++ b/lori/_test_send.pony
@@ -1460,20 +1460,35 @@ actor \nodoc\ _TestSendSSLMidFlightDropServer
 
 class \nodoc\ iso _TestSendGracefulCloseWithPending is UnitTest
   """
-  A graceful close() with sends still pending resolves every token cleanly.
+  A graceful close() with sends still queued under backpressure flushes those
+  queued writes to the peer before shutting down, rather than dropping them.
 
-  Same backpressure setup as SendMidFlightDropBoundary, but the server calls
-  close() (graceful shutdown) instead of hard_close() after the second large
-  send, leaving tokens 4 and 5 pending. Whichever way close() resolves the
-  pending writes -- draining them to `_on_sent` or failing them via
-  `_on_send_failed` -- the invariant must hold: every returned token fires
-  exactly one terminal callback, and `_on_closed` fires.
+  Same backpressure setup as SendMidFlightDropBoundary: three tiny sends drain
+  to `_on_sent` (tokens 1-3), a 256 KiB send stays queued (token 4), then a
+  second 256 KiB send from `_on_unthrottled` (token 5) leaves data queued when
+  the server calls close(). Because close() is graceful, every queued byte is
+  written before FIN: all five tokens fire `_on_sent` (none fire
+  `_on_send_failed`), the client receives every byte the server sent, and
+  `_on_closed` fires.
+
+  Without the flush, close() shuts the write side immediately, token 5's bytes
+  fail via `_on_send_failed`, and the client never receives them -- the bug in
+  issue #304.
+
+  The three completion signals fire at different times -- the fifth `_on_sent`
+  lands as the queue drains, before the server's `_on_closed` (which waits on
+  the peer's FIN) -- so each is its own expected action rather than one joint
+  check.
 
   POSIX only, for the same reason as `SendPerTokenCompletion`.
   """
   fun name(): String => "SendGracefulCloseWithPending"
 
   fun ref apply(h: TestHelper) =>
+    h.expect_action("server delivered all pending")
+    h.expect_action("server closed")
+    h.expect_action("client received all bytes")
+
     let listener = _TestSendGracefulCloseListener(h)
     h.dispose_when_done(listener)
     h.long_test(30_000_000_000)
@@ -1517,6 +1532,10 @@ actor \nodoc\ _TestSendGracefulCloseClient
   is (TCPConnectionActor & ClientLifecycleEventReceiver)
   var _tcp_connection: TCPConnection = TCPConnection.none()
   let _h: TestHelper
+  // t1+t2+t3 (2+2+2) plus two 256 KiB payloads = every byte the server sends.
+  let _expected: USize = 6 + 256_000 + 256_000
+  var _total_received: USize = 0
+  var _signalled: Bool = false
 
   new create(h: TestHelper) =>
     _h = h
@@ -1543,7 +1562,11 @@ actor \nodoc\ _TestSendGracefulCloseClient
     _tcp_connection.unmute()
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
-    None
+    _total_received = _total_received + data.size()
+    if (not _signalled) and (_total_received >= _expected) then
+      _signalled = true
+      _h.complete_action("client received all bytes")
+    end
     KeepReading
 
 actor \nodoc\ _TestSendGracefulCloseServer
@@ -1555,10 +1578,8 @@ actor \nodoc\ _TestSendGracefulCloseServer
   var _started: Bool = false
   var _unmuted_client: Bool = false
   var _resumed: Bool = false
-  var _closed: Bool = false
   embed _returned: Array[USize] = _returned.create()
   embed _sent_ids: Array[USize] = _sent_ids.create()
-  embed _failed_ids: Array[USize] = _failed_ids.create()
 
   new create(fd: U32, h: TestHelper,
     listener: _TestSendGracefulCloseListener)
@@ -1608,43 +1629,235 @@ actor \nodoc\ _TestSendGracefulCloseServer
   fun ref _on_unthrottled() =>
     if not _resumed then
       _resumed = true
-      // Tokens 4 and 5 are pending; graceful close instead of hard_close.
+      // Token 5's bytes are queued when we close. A graceful close must flush
+      // them, not drop them.
       _record_send(_tcp_connection.send(_large()))
       _tcp_connection.close()
     end
 
   fun ref _on_closed() =>
-    _closed = true
+    _h.complete_action("server closed")
 
   fun ref _on_sent(token: SendToken) =>
     _sent_ids.push(token.id)
-    _maybe_finish()
+    if _sent_ids.size() == _total_sends then
+      // Every returned token fired _on_sent exactly once; none failed.
+      for id in _returned.values() do
+        var count: USize = 0
+        for s in _sent_ids.values() do
+          if s == id then count = count + 1 end
+        end
+        _h.assert_eq[USize](1, count,
+          "each token must fire _on_sent exactly once")
+      end
+      _h.complete_action("server delivered all pending")
+    end
 
   fun ref _on_send_failed(token: SendToken) =>
-    _failed_ids.push(token.id)
-    _maybe_finish()
+    _h.fail("graceful close must flush queued writes, not fail them")
 
-  fun ref _maybe_finish() =>
-    if (_sent_ids.size() + _failed_ids.size()) != _total_sends then
-      return
+class \nodoc\ iso _TestSendSSLGracefulCloseWithPending is UnitTest
+  """
+  The SSL analogue of `SendGracefulCloseWithPending`. A graceful close() on an
+  SSL connection with sends still queued under backpressure flushes those
+  queued writes (ciphertext) to the peer before shutting down.
+
+  Same backpressure setup as `SendSSLMidFlightDropBoundary`: three tiny sends
+  drain to `_on_sent` (tokens 1-3), a 256 KiB send stays queued (token 4), then
+  a second 256 KiB send from `_on_unthrottled` (token 5) leaves ciphertext
+  queued when the server calls close(). Because close() is graceful, every
+  queued byte is written before FIN: all five tokens fire `_on_sent` (none fire
+  `_on_send_failed`), the client decrypts every byte the server sent, and
+  `_on_closed` fires. The SSL path is not a relabel of the plaintext one: the
+  queued bytes are ciphertext, and the `_Closing` drain runs `_ssl_flush_sends`,
+  which can enqueue more ciphertext and re-defer the FIN.
+
+  POSIX only, for the same reason as `SendSSLPerTokenCompletion`.
+  """
+  fun name(): String => "SendSSLGracefulCloseWithPending"
+
+  fun apply(h: TestHelper) ? =>
+    let port = "7916"
+    let file_auth = FileAuth(h.env.root)
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(file_auth, "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(file_auth, "assets/cert.pem"),
+            FilePath(file_auth, "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    h.expect_action("server delivered all pending")
+    h.expect_action("server closed")
+    h.expect_action("client received all bytes")
+
+    let listener = _TestSendSSLGracefulCloseListener(port, consume sslctx, h)
+    h.dispose_when_done(listener)
+
+    h.long_test(30_000_000_000)
+
+actor \nodoc\ _TestSendSSLGracefulCloseListener is TCPListenerActor
+  let _port: String
+  let _sslctx: SSLContext val
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _server: (_TestSendSSLGracefulCloseServer | None) = None
+  var _client: (_TestSendSSLGracefulCloseClient | None) = None
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _port = port
+    _sslctx = sslctx
+    _h = h
+    _tcp_listener = TCPListener(
+      TCPListenAuth(_h.env.root),
+      "localhost",
+      _port,
+      this)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestSendSSLGracefulCloseServer =>
+    let s = _TestSendSSLGracefulCloseServer(_sslctx, fd, _h, this)
+    _server = s
+    s
+
+  fun ref _on_closed() =>
+    try (_client as _TestSendSSLGracefulCloseClient).dispose() end
+    try (_server as _TestSendSSLGracefulCloseServer).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestSendSSLGracefulCloseClient(_port, _sslctx, _h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestSendSSLGracefulCloseListener")
+
+  be unmute_client() =>
+    try (_client as _TestSendSSLGracefulCloseClient).resume_reading() end
+
+actor \nodoc\ _TestSendSSLGracefulCloseClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+  // t1+t2+t3 (2+2+2) plus two 256 KiB payloads = every byte the server sends.
+  let _expected: USize = 6 + 256_000 + 256_000
+  var _total_received: USize = 0
+  var _signalled: Bool = false
+
+  new create(port: String, sslctx: SSLContext val, h: TestHelper) =>
+    _h = h
+    _tcp_connection = TCPConnection.ssl_client(
+      TCPConnectAuth(_h.env.root),
+      sslctx,
+      "localhost",
+      port,
+      "",
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _tcp_connection.set_so_rcvbuf(4096)
+    _tcp_connection.mute()
+    _tcp_connection.send("ready")
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    _h.fail("client connect failed")
+
+  be resume_reading() =>
+    _tcp_connection.unmute()
+
+  fun ref _on_received(data: Array[U8] iso): ReadAction =>
+    _total_received = _total_received + data.size()
+    if (not _signalled) and (_total_received >= _expected) then
+      _signalled = true
+      _h.complete_action("client received all bytes")
+    end
+    KeepReading
+
+actor \nodoc\ _TestSendSSLGracefulCloseServer
+  is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+  let _listener: _TestSendSSLGracefulCloseListener
+  let _total_sends: USize = 5
+  var _started: Bool = false
+  var _unmuted_client: Bool = false
+  var _resumed: Bool = false
+  embed _returned: Array[USize] = _returned.create()
+  embed _sent_ids: Array[USize] = _sent_ids.create()
+
+  new create(sslctx: SSLContext val, fd: U32, h: TestHelper,
+    listener: _TestSendSSLGracefulCloseListener)
+  =>
+    _h = h
+    _listener = listener
+    _tcp_connection = TCPConnection.ssl_server(
+      TCPServerAuth(_h.env.root),
+      sslctx,
+      fd,
+      this,
+      this)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _record_send(r: (SendToken | SendError)) =>
+    match r
+    | let t: SendToken => _returned.push(t.id)
+    | let _: SendError => _h.fail("send() returned an error while flooding")
     end
 
-    _h.log("graceful close: sent=" + _sent_ids.size().string()
-      + " failed=" + _failed_ids.size().string()
-      + " closed=" + _closed.string())
+  fun ref _large(): Array[U8] val =>
+    recover val Array[U8].init('x', 256_000) end
 
-    // Every returned token gets exactly one terminal callback.
-    for id in _returned.values() do
-      var count: USize = 0
-      for s in _sent_ids.values() do
-        if s == id then count = count + 1 end
-      end
-      for f in _failed_ids.values() do
-        if f == id then count = count + 1 end
-      end
-      _h.assert_eq[USize](1, count,
-        "each token must fire exactly one terminal callback")
+  fun ref _on_received(data: Array[U8] iso): ReadAction =>
+    if _started then return KeepReading end
+    _started = true
+    _tcp_connection.set_so_sndbuf(16384)
+    _record_send(_tcp_connection.send("t1"))
+    _record_send(_tcp_connection.send("t2"))
+    _record_send(_tcp_connection.send("t3"))
+    _record_send(_tcp_connection.send(_large()))
+    KeepReading
+
+  fun ref _on_throttled() =>
+    if not _unmuted_client then
+      _unmuted_client = true
+      _listener.unmute_client()
     end
 
-    _h.assert_true(_closed, "_on_closed must fire on graceful close")
-    _h.complete(true)
+  fun ref _on_unthrottled() =>
+    if not _resumed then
+      _resumed = true
+      // Token 5's ciphertext is queued when we close. A graceful close must
+      // flush it, not drop it.
+      _record_send(_tcp_connection.send(_large()))
+      _tcp_connection.close()
+    end
+
+  fun ref _on_closed() =>
+    _h.complete_action("server closed")
+
+  fun ref _on_sent(token: SendToken) =>
+    _sent_ids.push(token.id)
+    if _sent_ids.size() == _total_sends then
+      for id in _returned.values() do
+        var count: USize = 0
+        for s in _sent_ids.values() do
+          if s == id then count = count + 1 end
+        end
+        _h.assert_eq[USize](1, count,
+          "each token must fire _on_sent exactly once")
+      end
+      _h.complete_action("server delivered all pending")
+    end
+
+  fun ref _on_send_failed(token: SendToken) =>
+    _h.fail("graceful close must flush queued writes, not fail them")

--- a/lori/lifecycle_event_receiver.pony
+++ b/lori/lifecycle_event_receiver.pony
@@ -56,12 +56,12 @@ trait ServerLifecycleEventReceiver
   fun ref _on_send_failed(token: SendToken) =>
     """
     Called when the bytes from a successful `send()` could not be handed to
-    the OS before the connection closed. The token matches the one returned
-    by that `send()` call, and this callback fires exactly once for it. Every
-    accepted send whose bytes had not yet been handed to the OS when the
-    connection closes fires this instead, so the split between sends that got
-    `_on_sent` and sends that got `_on_send_failed` marks exactly how far
-    delivery to the OS reached.
+    the OS because the connection was lost or hard-closed first. The token
+    matches the one returned by that `send()` call, and this callback fires
+    exactly once for it. A graceful `close()` sends what's still queued, so only
+    a hard close or a lost connection fires this. On a hard close, the sends
+    that reached the OS fire `_on_sent` and the rest fire this, so the split
+    shows how far your data got.
 
     Always fires in a subsequent behavior turn, never synchronously during
     `hard_close()`. Always arrives after `_on_closed`, which fires
@@ -264,12 +264,12 @@ trait ClientLifecycleEventReceiver
   fun ref _on_send_failed(token: SendToken) =>
     """
     Called when the bytes from a successful `send()` could not be handed to
-    the OS before the connection closed. The token matches the one returned
-    by that `send()` call, and this callback fires exactly once for it. Every
-    accepted send whose bytes had not yet been handed to the OS when the
-    connection closes fires this instead, so the split between sends that got
-    `_on_sent` and sends that got `_on_send_failed` marks exactly how far
-    delivery to the OS reached.
+    the OS because the connection was lost or hard-closed first. The token
+    matches the one returned by that `send()` call, and this callback fires
+    exactly once for it. A graceful `close()` sends what's still queued, so only
+    a hard close or a lost connection fires this. On a hard close, the sends
+    that reached the OS fire `_on_sent` and the rest fire this, so the split
+    shows how far your data got.
 
     Always fires in a subsequent behavior turn, never synchronously during
     `hard_close()`. Always arrives after `_on_closed`, which fires

--- a/lori/send_token.pony
+++ b/lori/send_token.pony
@@ -2,8 +2,9 @@ class val SendToken is Equatable[SendToken]
   """
   Identifies a single `send()`. Returned by `send()` on success, then
   delivered exactly once: to `_on_sent()` when that send's bytes have been
-  handed to the OS, or to `_on_send_failed()` if the connection closes before
-  then.
+  handed to the OS, or to `_on_send_failed()` if the connection is lost or
+  hard-closed first. A graceful `close()` sends what's still queued, so those
+  sends get `_on_sent`.
 
   "Handed to the OS" means written to the kernel send buffer, not received by
   the peer. End-to-end delivery is an application concern -- use your own

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -537,18 +537,15 @@ class TCPConnection
 
   fun ref close() =>
     """
-    Attempt to perform a graceful shutdown. Don't accept new writes.
+    Gracefully close the connection. Data already handed to an accepted
+    `send()` is delivered before the connection closes.
 
-    During the connecting phase (Happy Eyeballs in progress), transitions to
-    `_UnconnectedClosing` to drain inflight connection attempts. Each
-    straggler event is cleaned up as it arrives. Once all inflight connections
-    have drained, `_on_connection_failure` fires.
+    On a muted connection this is a hard close instead: it shuts down at once
+    and drops undelivered data — both held reads and queued writes (the writes
+    fail with `_on_send_failed`).
 
-    If the connection is established and not muted, we won't finish closing
-    until we get a zero length read. If the connection is muted, perform a
-    hard close and shut down immediately. A hard close drops whatever the
-    connection had read but not yet delivered, including anything a `mute` was
-    holding.
+    Closing before the connection is established abandons the attempt and
+    delivers `_on_connection_failure`.
     """
     if _muted then
       hard_close()
@@ -850,7 +847,9 @@ class TCPConnection
     failure. On success the token gets exactly one terminal callback in a
     later behavior turn: `_on_sent(token)` once the data has been handed to
     the OS (written to the kernel send buffer, not received by the peer), or
-    `_on_send_failed(token)` if the connection closes first.
+    `_on_send_failed(token)` if the connection is lost or hard-closed before
+    the bytes are written. A graceful `close()` sends what's still queued, so
+    those sends fire `_on_sent`, not `_on_send_failed`.
     """
     _state.send(this, data)
 
@@ -925,11 +924,16 @@ class TCPConnection
 
   fun ref _initiate_shutdown() =>
     """
-    Send FIN to the peer if not already shutdown and no inflight connections
-    remain. Called when entering _Closing or when inflight connections drain
-    during _Closing.
+    Send FIN to the peer, but only once there is nothing left to send ahead of
+    it: no inflight connection attempts and no queued writes. Idempotent — sends
+    FIN at most once, and no-ops until both have drained — so a graceful close
+    sends the queued writes before the write side is shut. `hard_close()` is the
+    non-graceful path and still drops queued writes.
     """
-    if not _shutdown and (_inflight_connections == 0) then
+    if not _shutdown
+      and (_inflight_connections == 0)
+      and not _has_pending_writes()
+    then
       _shutdown = true
       PonyTCP.shutdown(_fd)
     end
@@ -1624,88 +1628,23 @@ class TCPConnection
       _set_readable()
       _read()
     else
-      // Runs on every write-only event (writeable, no readable flag).
-      // Where one subscription covers the whole fd (Linux EPOLLONESHOT,
-      // Windows ProcessSocketNotifications), any event disarms it, dropping
-      // pending read interest. (macOS kqueue arms read and write as
-      // independent one-shot filters, so a write-only event leaves reads armed
-      // and this re-arm is a harmless no-op there — issue #294 was a Linux
-      // report.) The write branch above already ran _set_writeable(), which
-      // releases backpressure. So on a full drain _apply_backpressure() is
-      // never re-entered, and neither read re-arm path runs (its resubscribe
-      // and _read's EAGAIN resubscribe are both skipped), leaving the
-      // connection permanently read-deaf. Re-arming reads here covers that.
-      // On a partial drain _apply_backpressure() does re-enter,
-      // and because on the whole-fd backends PonyAsio.resubscribe re-arms
-      // whichever directions are not-ready (the read/write names signal
-      // intent, not effect), its write resubscribe also re-arms reads, so the
-      // resubscribe here is redundant but harmless.
-      //
-      // Skip the re-arm unless the socket is still healthy and fully drained,
-      // which `_writeable` captures: `_set_writeable()` above set it true, and
-      // nothing cleared it means no hard_close and no backpressure this turn.
-      // `_send_pending_writes()` above can hard_close() on a write error (peer
-      // RST with data queued), and `_hard_close_cleanup` then unsubscribes the
-      // event and calls `_set_unwriteable()`. Resubscribing after that is wrong:
-      // on POSIX the event is already disposable (the resubscribe would assert
-      // in debug); on Windows the close is DEFERRED — `unsubscribe` only marks
-      // the event `removing`, so `get_disposable` still returns false and the
-      // resubscribe would re-enable a socket whose REMOVE is already in flight,
-      // stranding the deferred-close handshake. `_writeable` is false in both
-      // cases, so it is the load-bearing guard; `get_disposable` is kept as
-      // POSIX defense in depth. `_writeable` is also false after a partial-drain
-      // backpressure, where `_apply_backpressure`'s resubscribe already re-arms
-      // reads, so skipping here is redundant, not harmful.
-      //
-      // `_writeable` (not is_closed()/is_open()) is deliberate: this branch is
-      // shared by _Open, _Closing, _SSLHandshaking, and _TLSUpgrading. During
-      // _Closing the read side is still open and reads must stay armed to detect
-      // the peer FIN, yet is_closed() is true there; during _SSLHandshaking
-      // is_open() is false but reads must stay armed to finish the handshake.
-      // Only _Open is exercised by a test (WriteOnlyEventReadRecovery, POSIX
-      // only); the full-drain can't be triggered deterministically in the other
-      // states, so neither the compiler nor the suite catches a regression here.
-      // Do not weaken this guard. See issues #294 and #296.
+      // A whole-fd one-shot event (Linux epoll, Windows readiness) disarms the
+      // fd, so a write-only event drops read interest. Re-arm reads, guarded by
+      // `_writeable` to skip a closed or backpressured fd. Do not weaken; the
+      // reasoning and the deadlock it prevents are in #294, #296.
       if _writeable and not PonyAsio.get_disposable(_event) then
         PonyAsio.resubscribe_read(_event)
       end
     end
 
-    // Mirror image of the read re-arm above, for the write side. On backends
-    // where one subscription covers the whole fd (Linux EPOLLONESHOT, Windows
-    // ProcessSocketNotifications), any event consumes it, so a readable event
-    // drops the write interest a prior `_apply_backpressure()` armed. The read
-    // path re-arms write as a side effect whenever it reaches its EAGAIN
-    // resubscribe (that resubscribe re-arms every not-ready direction), so most
-    // reads self-heal. The one path that does not is a read that ends in
-    // `mute()` before EAGAIN — exactly what a backpressured echo peer does when
-    // it stashes a chunk it cannot echo. Nothing then re-arms the pending
-    // write: if still throttled, the writeable edge never arrives, backpressure
-    // never releases, `_on_unthrottled` never fires, and the connection wedges.
-    // A lost-wakeup deadlock, seen under sustained backpressure with two or
-    // more scheduler threads (the readable edge has to land between the
-    // `resubscribe_write` and the writeable edge). macOS kqueue arms read and
-    // write as independent one-shot filters, so a readable event leaves write
-    // armed and this re-arm is a harmless no-op there. See issues #294 and #296
-    // for the read-side counterpart.
-    //
-    // Guarded by `is_open()`: `_throttled` alone is not enough because
-    // `_hard_close_cleanup` does not clear it. After a hard_close the event is
-    // gone in both regimes — disposable immediately on POSIX (resubscribe would
-    // assert in debug), and on Windows the REMOVE is only deferred so
-    // `get_disposable` still returns false, where resubscribing would strand
-    // the deferred-close handshake. `is_open()` is true only in
-    // `_Open`/`_TLSUpgrading`, never after a hard_close (which moves to
-    // `_Closed`), so it excludes that case on every platform. Excluding the
-    // other dispatching states is safe: `_SSLHandshaking` delivers no data to
-    // the application, so its read path never mutes and reaches EAGAIN (whose
-    // resubscribe re-arms a throttled write). `_Closing` can mute — an app may
-    // call `mute()` from `_on_received` during graceful shutdown — but a muted
-    // `_Closing` connection is already waiting on the peer's FIN it won't read,
-    // so re-arming write cannot move it forward and its absence is not the
-    // wedge this fixes. `get_disposable` is kept as defense in depth, matching
-    // the read guard.
-    if _throttled and is_open() and not PonyAsio.get_disposable(_event) then
+    // Mirror for the write side: a readable event drops the write interest, and
+    // a read that mutes or yields before EAGAIN never re-arms it, so a
+    // backpressured write wedges. Re-arm it, guarded by `_throttled`.
+    // `is_live()` (was `is_open()`) covers `_Closing`, which now drains queued
+    // writes before it closes. Do not weaken; see #294, #296.
+    if _throttled and _state.is_live()
+      and not PonyAsio.get_disposable(_event)
+    then
       PonyAsio.resubscribe_write(_event)
     end
 


### PR DESCRIPTION
A graceful `close()` sent FIN before draining lori's own write queue, so writes queued under backpressure were lost: they landed on the shut-down write side, which hard-closed the connection and failed those sends with `_on_send_failed` even though the caller closed cleanly. `close()` now defers the FIN until the write queue drains, so an accepted `send()` still queued at a graceful close is delivered rather than dropped and fires `_on_sent`. `hard_close()` is unchanged; it still drops queued writes and fails their sends.

The fix reuses the existing shutdown path rather than adding state. `_initiate_shutdown()` already held the FIN until inflight Happy Eyeballs attempts drained; it now also holds it until the write queue is empty, and `_Closing` re-runs it after each socket event so the writeable event that drains the last byte sends the FIN. Because `_Closing` now holds pending writes for the first time, the write-interest re-arm in `_dispatch_io_event` (the lost-wakeup fix from #294/#296) now guards on `_state.is_live()` instead of `is_open()`, so it covers `_Closing`; otherwise, if the application mutes or yields from `_on_received` during the drain, the connection could lose its write interest and hang.

Divergence worth a look: a graceful close to a peer that has stopped reading now stays in `_Closing` until the queue drains, where before it FIN'd immediately and dropped the data (the bug). That is inherent to flushing before FIN — you can't gracefully deliver to a peer that won't read. The `close()` docstring notes that `hard_close()` ends it regardless.

The `_Closing` write re-arm has no deterministic test, matching the existing note that the non-`_Open` re-arm can't be triggered deterministically; the plaintext and SSL graceful-close tests cover the queue-drain and FIN paths.

Closes #304
