### PR TITLE
Document is_closed() and is_writeable()

### DIFF
--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -752,12 +752,14 @@ class TCPConnection
     _state.is_open()
 
   fun is_closed(): Bool =>
+    """
+    Returns whether the connection is closed or closing.
+    """
     _state.is_closed()
 
   fun is_writeable(): Bool =>
     """
-    Returns whether the connection can currently accept a `send()` call.
-    Checks that the state allows sends and the socket is writeable.
+    Returns whether the socket can currently send.
     """
     _state.sends_allowed() and _writeable
 


### PR DESCRIPTION
`is_closed()` had no docstring. `is_writeable()` had one whose second line restated its own body.

No behavior change, so no release note.