### PR TITLE
Bump actions/upload-artifact to v7.0.1

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -30,7 +30,7 @@ jobs:
             --out rt-stress-out
       - name: Upload failure bundles
         if: ${{ failure() || cancelled() }}
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: tcp-swarm-bundles-linux
           path: rt-stress-out/*.json
@@ -72,7 +72,7 @@ jobs:
             --out rt-stress-out
       - name: Upload failure bundles
         if: ${{ failure() || cancelled() }}
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: tcp-swarm-bundles-macos
           path: rt-stress-out/*.json
@@ -130,7 +130,7 @@ jobs:
             --out rt-stress-out
       - name: Upload failure bundles
         if: ${{ failure() || cancelled() }}
-        uses: actions/upload-artifact@v4.6.2
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: tcp-swarm-bundles-windows
           path: rt-stress-out/*.json


### PR DESCRIPTION
The three stress-test jobs pinned `actions/upload-artifact@v4.6.2`, three majors behind current. This matches the bump made in ponyc (ponylang/ponyc#5751) and ponyup (ponylang/ponyup#456).

v6 moved the action to Node 24 and v7 to ESM. The macOS and Windows jobs run directly on GitHub-hosted runners, so Node 24 is a non-issue there. The Linux job containers on an Alpine image, where the glibc build of Node 24 will not run — but that job already runs `actions/checkout@v6.0.2`, itself a node24 action, in that same container on every scheduled run, so the runner is already supplying a musl Node 24 build. The three inputs these jobs pass — `name`, `path`, `if-no-files-found` — are unchanged in v7, and v7's new `archive` input defaults to the existing zip-on-upload behavior.