### PR TITLE
Require ponyc 0.67.0 to fix a possible write hang under load

### DIFF
--- a/.release-notes/fix-possible-write-hang-under-load.md
+++ b/.release-notes/fix-possible-write-hang-under-load.md
@@ -1,0 +1,5 @@
+## Require ponyc 0.67.0 to fix a possible write hang under load
+
+Under write load, a socket write could hang the whole program. When the send buffer filled on a blocking file descriptor, the write stalled and never returned. Connections use non-blocking descriptors, so this was only reachable once the operating system had reused a closed connection's descriptor number for a blocking socket elsewhere in the process — rare, but possible.
+
+Sends now use a socket call, new in ponyc 0.67.0, that returns when the send buffer is full instead of stalling. Lori therefore requires ponyc 0.67.0 or later. The hang is closed on Linux, FreeBSD, OpenBSD, and DragonFly; macOS and Windows are unchanged.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Designs that were tried, or are tempting, and why lori does not use them — the
 
 ## Platform differences
 
-POSIX and Windows share one readiness-based I/O path: one-shot readiness events (epoll/kqueue; `ProcessSocketNotifications` on Windows), resubscribe, then a synchronous `PonyTCP.receive`/`writev`. Windows needs ponyc 0.66.0 or later, the release that removed IOCP; the floor is Windows 11 / Windows Server 2022. Two rules stay platform-specific — the `writev` batch size (`PonyTCP.writev_max()`) and closing a subscribed fd (`_close_event_fd()`, POSIX-only) — both documented at those functions.
+POSIX and Windows share one readiness-based I/O path: one-shot readiness events (epoll/kqueue; `ProcessSocketNotifications` on Windows), resubscribe, then a synchronous `PonyTCP.receive`/`sendv`. Windows uses this path because ponyc removed IOCP; the floor is Windows 11 / Windows Server 2022. Two rules stay platform-specific — the vectored-send batch size (`PonyTCP.writev_max()`) and closing a subscribed fd (`_close_event_fd()`, POSIX-only) — both documented at those functions.
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please note that if this library encounters a state that the programmers thought
 - `use "lori"` to include this package
 - `corral run -- ponyc` to compile your application
 
-Requires ponyc 0.64.0 or later. On Windows, requires ponyc 0.66.0 or later, the release that switched Windows networking from IOCP to readiness notifications.
+Requires ponyc 0.67.0 or later.
 
 Note: The ssl transitive dependency requires a C SSL library to be installed. Please see the ssl installation instructions for more information.
 

--- a/examples/framed-protocol/framed_protocol.pony
+++ b/examples/framed-protocol/framed_protocol.pony
@@ -1,6 +1,6 @@
 """
 Demonstrates lori's buffer_until() for length-prefixed message framing and
-multi-buffer send() for sending header + payload in a single writev syscall.
+multi-buffer send() for sending header + payload in a single syscall.
 
 A framed client connects to an echo server and exchanges messages using a
 simple protocol: each message is preceded by a 4-byte big-endian length
@@ -89,7 +89,7 @@ actor FramedServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
       let len = payload.size()
       _out.print("Server: echoing \"" + String.from_array(payload) + "\"")
 
-      // Echo back with same framing: header + payload in one writev syscall
+      // Echo back with same framing: header + payload in one syscall
       let header =
         recover val
           Array[U8](4)
@@ -152,7 +152,7 @@ actor FramedClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
   fun ref _send_framed(msg: String) =>
     """
     Send a message with a 4-byte big-endian length prefix, sending both
-    header and payload in a single writev syscall.
+    header and payload in a single syscall.
     """
     let len = msg.size()
     let header =

--- a/lori/_pending_writes.pony
+++ b/lori/_pending_writes.pony
@@ -34,7 +34,7 @@ class _PendingWrites
   fun prefix_total(n: USize): USize =>
     """
     Bytes in the first `n` buffers, counting the offset already sent from the
-    first. `n >= size()` is `total()`. The byte count for a capped writev batch.
+    first. `n >= size()` is `total()`. The byte count for a capped sendv batch.
     """
     if n >= _buffers.size() then return _total end
     var sum: USize = 0
@@ -52,7 +52,7 @@ class _PendingWrites
 
   fun buffers(): this->Array[ByteSeq] =>
     """
-    The buffers, for `PonyTCP.writev`. Read together with `first_offset`.
+    The buffers, for `PonyTCP.sendv`. Read together with `first_offset`.
     """
     _buffers
 

--- a/lori/_test_send.pony
+++ b/lori/_test_send.pony
@@ -2430,7 +2430,7 @@ class \nodoc\ iso _TestSendDeliveredNotFailedOnHardClose is UnitTest
   """
   A hard close from `_on_throttled` must not report a delivered send as failed.
 
-  `_on_throttled` runs inside the write flush, after a partial `writev` has
+  `_on_throttled` runs inside the write flush, after a partial `sendv` has
   accounted its bytes and before the flush reports the sends those bytes
   completed. A `hard_close()` from the callback fails every send still on the
   queue, so a send the flush had just finished gets `_on_send_failed` even
@@ -2447,7 +2447,7 @@ class \nodoc\ iso _TestSendDeliveredNotFailedOnHardClose is UnitTest
 
   A 256,000-byte send opens a backlog deep enough to keep the connection
   throttled, and twenty-five 32,000-byte sends pile up behind it. Against a
-  16 KiB `SO_SNDBUF` a `writev` moves a few tens of kilobytes a pass, so it
+  16 KiB `SO_SNDBUF` a `sendv` moves a few tens of kilobytes a pass, so it
   lands mid-send far more often than on a boundary.
 
   POSIX only, for the same reason as `SendPerTokenCompletion`.

--- a/lori/lori.pony
+++ b/lori/lori.pony
@@ -158,7 +158,7 @@ calling `send()`.
 
 `send()` accepts both a single buffer (`ByteSeq`) and multiple buffers
 (`ByteSeqIter`). When a protocol sends structured data (e.g. a length header
-followed by a payload), passing multiple buffers sends them in a single writev
+followed by a payload), passing multiple buffers sends them in a single
 syscall — avoiding both the per-buffer syscall overhead of calling `send()`
 multiple times and the cost of copying into a contiguous buffer:
 
@@ -166,7 +166,7 @@ multiple times and the cost of copying into a contiguous buffer:
 // Single buffer
 _tcp_connection.send("Hello, world!")
 
-// Multiple buffers — one writev syscall
+// Multiple buffers — one syscall
 let header: Array[U8] val = _encode_header(payload.size())
 _tcp_connection.send(recover val [as ByteSeq: header; payload] end)
 ```

--- a/lori/pony_tcp.pony
+++ b/lori/pony_tcp.pony
@@ -29,13 +29,13 @@ use @pony_os_recv[U8](event: AsioEventID,
   buffer: Pointer[U8] tag,
   size: USize,
   count_out: Pointer[USize])
-use @pony_os_socket_close[None](fd: U32)
-use @pony_os_socket_shutdown[None](fd: U32)
-use @pony_os_sockname[Bool](fd: U32, ip: net.NetAddress ref)
-use @pony_os_writev[U8](ev: AsioEventID,
+use @pony_os_sendv[U8](ev: AsioEventID,
   iov: Pointer[(Pointer[U8] tag, USize)] tag,
   iovcnt: I32,
   count_out: Pointer[USize])
+use @pony_os_socket_close[None](fd: U32)
+use @pony_os_socket_shutdown[None](fd: U32)
+use @pony_os_sockname[Bool](fd: U32, ip: net.NetAddress ref)
 use @pony_os_writev_max[I32]()
 
 use net = "net"
@@ -43,7 +43,7 @@ use net = "net"
 primitive PonyTCP
   """
   Wrappers for the runtime's `pony_os_*` TCP functions -- connect, listen,
-  accept, receive, writev, keepalive, and socket teardown.
+  accept, receive, sendv, keepalive, and socket teardown.
   """
   fun listen(the_actor: AsioEventNotify,
     host: String,
@@ -127,7 +127,7 @@ primitive PonyTCP
   fun sockname(fd: U32, ip: net.NetAddress ref): Bool =>
     @pony_os_sockname(fd, ip)
 
-  fun writev(event: AsioEventID,
+  fun sendv(event: AsioEventID,
     data: Array[ByteSeq] box,
     from: USize,
     count: USize,
@@ -135,7 +135,8 @@ primitive PonyTCP
     : (SocketResult, USize) ?
   =>
     """
-    Send `count` buffers from `data` starting at index `from` via writev.
+    Send `count` buffers from `data` starting at index `from` via
+    `pony_os_sendv`.
     Builds the IOV array of `(pointer, size)` entries internally; the runtime
     turns it into `iovec` (POSIX) or `WSABUF` (Windows) as needed.
 
@@ -161,13 +162,13 @@ primitive PonyTCP
     end
     let result =
       SocketResultDecoder(
-        @pony_os_writev(
+        @pony_os_sendv(
           event, iov.cpointer(), count.i32(), addressof bytes_sent))
     (result, bytes_sent)
 
   fun writev_max(): I32 =>
     """
-    Maximum number of `(pointer, size)` entries a single writev call may
+    Maximum number of `(pointer, size)` entries a single `sendv` call may
     carry. `IOV_MAX` on POSIX, 1 on Windows.
     """
     @pony_os_writev_max()

--- a/lori/socket_result.pony
+++ b/lori/socket_result.pony
@@ -1,7 +1,7 @@
 primitive SocketResultOk
   """
-  The socket operation completed. For send/writev, the runtime accepted some
-  bytes; for recv, bytes were read into the supplied buffer. The accompanying
+  The socket operation completed. For a send, the runtime accepted some
+  bytes; for a recv, bytes were read into the supplied buffer. The accompanying
   count is the number of bytes handled. The operation is synchronous and
   non-blocking on every platform (the Windows backend uses readiness
   notifications, not overlapped IOCP), so the count is always the bytes
@@ -32,9 +32,9 @@ type SocketResult is
 
 primitive SocketResultDecoder
   """
-  Decodes the `U8` returned by the five `pony_os_*` socket runtime functions
-  (`pony_os_writev`, `pony_os_send`, `pony_os_recv`, `pony_os_sendto`,
-  `pony_os_recvfrom`) into a `SocketResult` union.
+  Decodes the `U8` returned by the six `pony_os_*` socket runtime functions
+  (`pony_os_writev`, `pony_os_sendv`, `pony_os_send`, `pony_os_recv`,
+  `pony_os_sendto`, `pony_os_recvfrom`) into a `SocketResult` union.
 
   This is the Pony-side dual of `pony_socket_result_t` defined in
   `src/libponyrt/lang/socket.h` of ponyc. The integer values produced by

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -824,7 +824,7 @@ class TCPConnection
       return StartTLSAlreadyTLS
     end
 
-    // writev is synchronous on every platform now — it returns OK with a
+    // sendv is synchronous on every platform now — it returns OK with a
     // byte count, Retry on EWOULDBLOCK, or Error. Any remaining pending
     // bytes mean the write didn't fully drain, so the TLS upgrade must wait.
     if _muted or (_bytes_in_read_buffer > 0) or _has_pending_writes() then
@@ -855,7 +855,7 @@ class TCPConnection
     """
     Send data on this connection. Accepts a single buffer (`ByteSeq`) or
     multiple buffers (`ByteSeqIter`). When multiple buffers are provided,
-    they are sent in a single writev syscall — avoiding both per-buffer
+    they are sent in a single syscall — avoiding both per-buffer
     syscall overhead and the cost of copying into a contiguous buffer.
 
     Returns a `SendToken` on success, or a `SendError` explaining the
@@ -967,7 +967,7 @@ class TCPConnection
 
   fun ref _send_pending_writes() =>
     """
-    Flush pending write data using writev. Synchronous and non-blocking on
+    Flush pending write data using sendv. Synchronous and non-blocking on
     every platform: a partial write or `SocketResultRetry` (the kernel send
     buffer is full) applies backpressure and leaves the rest queued for the
     next writeable event.
@@ -982,8 +982,8 @@ class TCPConnection
           _pending.size().min(writev_batch_size)
         let bytes_to_send: USize = _pending.prefix_total(num_to_send)
 
-        // writev syscall — three-state result with bytes-sent count
-        match \exhaustive\ PonyTCP.writev(
+        // sendv — three-state result with bytes-sent count
+        match \exhaustive\ PonyTCP.sendv(
           _event, _pending.buffers(), 0, num_to_send, _pending.first_offset())?
         | (SocketResultOk, let len: USize) =>
           if len > 0 then
@@ -1000,7 +1000,7 @@ class TCPConnection
         | (SocketResultError, _) => error
         end
       else
-        // writev error or unreachable Array.apply bounds — non-graceful
+        // sendv error or unreachable Array.apply bounds — non-graceful
         // shutdown. Fire _on_sent for sends whose bytes already reached the
         // OS in an earlier batch of this flush first, so hard_close fails only
         // the rest.
@@ -1380,7 +1380,7 @@ class TCPConnection
   fun ref _reset_idle_timer() =>
     """
     Reset the idle timer to the configured duration. Called on I/O activity:
-    a successful `writev` (an application send or a buffered-write drain) or
+    a successful `sendv` (an application send or a buffered-write drain) or
     data received. Only resets an existing timer — does not create one.
     """
     if not _timer_event.is_null() then
@@ -1621,7 +1621,7 @@ class TCPConnection
     """
     Common I/O dispatch logic for socket events. Shared by all states that
     have a connected socket and need to process I/O notifications. Identical
-    on every platform: readiness edges drive synchronous recv/writev.
+    on every platform: readiness edges drive synchronous recv/sendv.
     """
     if AsioEvent.errored(flags) then
       hard_close()


### PR DESCRIPTION
Under write load, a socket write could hang the whole program. `PonyTCP`'s send path called `@pony_os_writev`, which runs `writev(2)` on POSIX; `writev(2)` takes no flags, so a write to a full send buffer on a blocking file descriptor parks the scheduler thread and never returns. Connection descriptors are non-blocking, so this is only reachable once the OS has reused a closed connection's descriptor number for a blocking socket elsewhere in the process — rare, but possible.

`@pony_os_sendv`, new in ponyc 0.67.0, has the same signature and result but calls `sendmsg` with `MSG_DONTWAIT` on Linux and the BSDs, returning a retry instead of blocking. Switch the send call to it and rename the wrapper `PonyTCP.writev` to `sendv`. The minimum ponyc is therefore now 0.67.0. macOS and Windows are unchanged, and ponyc's stdlib `net` package made the same switch in that release.

Closes #318
