### PR TITLE
Make a TimerFires timeout show which stage stalled

### DIFF
--- a/lori/_test_timer.pony
+++ b/lori/_test_timer.pony
@@ -9,10 +9,17 @@ class \nodoc\ iso _TestTimerFires is UnitTest
   Test that a one-shot timer fires with the correct token. Server sets a
   2-second timer in _on_started and verifies _on_timer delivers the matching
   token.
+
+  Connect, server start, and timer firing are tracked as separate actions so
+  that on a timeout PonyTest prints which stage did not complete.
   """
   fun name(): String => "TimerFires"
 
   fun apply(h: TestHelper) =>
+    h.expect_action("client connected")
+    h.expect_action("server started")
+    h.expect_action("timer fired")
+
     let listener = _TestTimerFiresListener(h)
     h.dispose_when_done(listener)
 
@@ -66,6 +73,9 @@ actor \nodoc\ _TestTimerFiresClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connected() =>
+    _h.complete_action("client connected")
+
 actor \nodoc\ _TestTimerFiresServer
   is (TCPConnectionActor & ServerLifecycleEventReceiver)
   var _tcp_connection: TCPConnection = TCPConnection.none()
@@ -88,7 +98,9 @@ actor \nodoc\ _TestTimerFiresServer
     match \exhaustive\ MakeTimerDuration(2_000)
     | let d: TimerDuration =>
       match \exhaustive\ _tcp_connection.set_timer(d)
-      | let t: TimerToken => _expected_token = t
+      | let t: TimerToken =>
+        _expected_token = t
+        _h.complete_action("server started")
       | let _: SetTimerError =>
         _h.fail("set_timer returned error")
         _h.complete(false)
@@ -102,7 +114,7 @@ actor \nodoc\ _TestTimerFiresServer
     match _expected_token
     | let t: TimerToken =>
       _h.assert_true(t == token, "token should match")
-      _h.complete(true)
+      _h.complete_action("timer fired")
     else
       _h.fail("_on_timer fired without expected token")
       _h.complete(false)


### PR DESCRIPTION
`TimerFires` intermittently times out on macOS CI (#312). The failure is an opaque 15s `long_test` timeout — nothing in the output says whether the connection came up, whether the timer armed, or whether the timer never fired.

This adds three PonyTest action milestones to `TimerFires` — "client connected", "server started", "timer fired" — completed at the matching lifecycle callbacks. On a timeout PonyTest prints `Action never completed: <name>` for whatever stage stalled, so the next macOS failure names where it got stuck. The token-match assertion is unchanged, so this adds signal without changing what the test verifies. It's a diagnostic step for #312, not a fix.

Verified with a counterfactual: dropping the timeout below the timer duration produced exactly `Action never completed: timer fired`, with the connect and server-start milestones already cleared.

Parked for your input:

- Scope. This instruments only `TimerFires`. Every connection+timer test fails the same opaque way — a bare timeout with no stage information — so whichever one flakes next, we're blind again. Worth extending these milestones across the family?
- Separate finding, not touched here: most timer-test listeners create a server connection in `_on_accept` and never store or dispose it — cleanup rides on the client's `hard_close` reaching the server. AGENTS.md warns a missed dispose "hangs CI, macOS especially." Not the cause of this timeout, but a latent macOS-hang risk worth a separate look.
