### PR TITLE
Document that a muted connection won't detect a peer close

### DIFF
--- a/lori/lori.pony
+++ b/lori/lori.pony
@@ -411,6 +411,12 @@ is no way to deliver held data without also resuming reads — an application th
 needs it has to `unmute()` and keep processing until it has caught up, taking
 whatever else arrives in the meantime.
 
+While muted, the connection reads nothing off the socket, so a peer's close is
+not detected until `unmute()` resumes reading. A muted connection also holds a
+live I/O resource, and the Pony runtime does not exit while any actor holds one,
+so a program that mutes a connection and leaves it muted never exits. The
+application must end that state: `unmute()` the connection or `close()` it.
+
 ## Read Yielding
 
 Under sustained inbound traffic, a single connection's read loop can monopolize


### PR DESCRIPTION
Documents, in the package-level Flow Control docs, that a muted connection reads nothing off the socket — so it won't detect a peer close until the application unmutes — and that a connection left muted holds a live I/O resource that keeps the Pony runtime from exiting. The application has to unmute or close to clean up.

Issue #243 decided this is a documentation matter rather than a behavior change.

Closes #243
