### PR TITLE
Shuffle test order

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ test: unit-tests
 ci: unit-tests examples stress-tests
 
 unit-tests: $(tests_binary)
-	$^ --exclude=integration --sequential
+	$^ --exclude=integration --sequential --shuffle
 
 test-one: $(tests_binary)
 	$^ --only="$(t)"

--- a/make.ps1
+++ b/make.ps1
@@ -173,7 +173,7 @@ switch ($Command.ToLower())
   {
     $testFile = (BuildTest)[-1]
     Write-Host "$testFile"
-    $rawOutput = & "$testFile" --sequential 2>&1
+    $rawOutput = & "$testFile" --sequential --shuffle 2>&1
     $exitCode = $LastExitCode
     foreach ($line in $rawOutput) { Write-Host $line }
     if ($exitCode -ne 0)


### PR DESCRIPTION
Add `--shuffle` to the test runs so tests execute in a randomized order, which surfaces hidden dependencies between tests.
