### PR TITLE
Add a compatibility API for moving code from the standard library net package

### DIFF
--- a/.release-notes/add-legacy-net-compatibility-api.md
+++ b/.release-notes/add-legacy-net-compatibility-api.md
@@ -1,0 +1,32 @@
+## Add a compatibility API for moving code from the standard library net package
+
+lori now includes `LegacyTCPClient`, `LegacyTCPListener`, and matching notifier interfaces that recreate the standard library `net` package's API on top of lori. If you have code written against `net.TCPConnection` and `net.TCPListener`, this lets you move it to lori with mechanical changes rather than a rewrite: the application logic stays in notifier objects, the way the standard library does it.
+
+```pony
+use "lori"
+
+actor Main
+  new create(env: Env) =>
+    LegacyTCPListener(TCPListenAuth(env.root), EchoListener, "", "8989")
+
+class EchoListener is LegacyTCPListenNotify
+  fun ref connected(listen: LegacyTCPListener ref)
+    : LegacyTCPConnectionNotify iso^
+  =>
+    EchoConnection
+
+class EchoConnection is LegacyTCPConnectionNotify
+  fun ref received(
+    conn: LegacyTCPConnection ref,
+    data: Array[U8] iso,
+    times: USize)
+    : Bool
+  =>
+    conn.write(consume data)
+    true
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    None
+```
+
+SSL is covered by `LegacySSLConnection`, matching the `ssl/net` package's `SSLConnection` decorator. Moving code over needs a few changes — the notifier's `conn` parameter becomes `LegacyTCPConnection`, and clients are created with `LegacyTCPClient` instead of `TCPConnection` — and a few behaviors differ. The package documentation lists them.

--- a/examples/README.md
+++ b/examples/README.md
@@ -53,6 +53,10 @@ Socket option tuning with dedicated convenience methods (`set_nodelay()`, `set_s
 
 Configurable read buffer sizing with two phases. A server starts with a small 128-byte buffer for a control phase, then switches to an 8192-byte buffer for bulk transfer after receiving a command. Demonstrates `set_read_buffer_minimum()` and `resize_read_buffer()` for tuning buffer allocation at runtime, and the `read_buffer_size` constructor parameter for setting the initial size.
 
+## [legacy-echo-server](legacy-echo-server/)
+
+The echo server written against the Legacy stdlib-net compatibility API (`LegacyTCPListener`, `LegacyTCPListenNotify`, `LegacyTCPConnectionNotify`) instead of lori's native traits. Application logic lives in notifier objects, matching the shape of a Pony standard library `net` package server. Shows the programming model that eases moving existing `net` code onto lori.
+
 ## [net-ssl-echo-server](net-ssl-echo-server/)
 
 SSL version of the echo server. Demonstrates how to set up an `SSLContext` and use `TCPConnection.ssl_server` — the only change from the plain echo server is the constructor call and SSL context setup.

--- a/examples/legacy-echo-server/legacy_echo_server.pony
+++ b/examples/legacy-echo-server/legacy_echo_server.pony
@@ -1,0 +1,77 @@
+"""
+Echo server using the Legacy stdlib-net compatibility API.
+
+This mirrors the shape of a Pony standard library `net` package echo server —
+notifier objects, a listener, and a per-connection notifier — but runs on lori.
+It shows how code written against the old `net.TCPListener` /
+`net.TCPConnection` API moves to lori with small changes: the notifier's `conn`
+parameter becomes `LegacyTCPConnection`, `is TCPConnectionNotify` becomes
+`is LegacyTCPConnectionNotify`, and a client (not shown here) is created with
+`LegacyTCPClient` instead of constructing `TCPConnection` directly.
+
+Unlike lori's native API (see the `echo-server` example), the application logic
+lives in notifier classes rather than in your own actor. That is the point of
+this API: it keeps the old programming model so existing code needs less
+rework.
+
+Connect with any TCP client (e.g. `netcat localhost 7679`) and type to see your
+input echoed back.
+"""
+use "../../lori"
+
+actor Main
+  new create(env: Env) =>
+    LegacyTCPListener(
+      TCPListenAuth(env.root), EchoListener(env.out), "", "7679")
+
+class EchoListener is LegacyTCPListenNotify
+  """
+  Reports listener lifecycle and builds an echo notifier for each connection.
+  """
+  let _out: OutStream
+
+  new iso create(out: OutStream) =>
+    _out = out
+
+  fun ref listening(listen: LegacyTCPListener ref) =>
+    _out.print("Echo server started.")
+
+  fun ref not_listening(listen: LegacyTCPListener ref) =>
+    _out.print("Couldn't start echo server. " +
+      "Perhaps try another network interface?")
+
+  fun ref connected(listen: LegacyTCPListener ref)
+    : LegacyTCPConnectionNotify iso^
+  =>
+    EchoConnection(_out)
+
+  fun ref closed(listen: LegacyTCPListener ref) =>
+    _out.print("Echo server shut down.")
+
+class EchoConnection is LegacyTCPConnectionNotify
+  """
+  Echoes received data back to the client.
+  """
+  let _out: OutStream
+
+  new iso create(out: OutStream) =>
+    _out = out
+
+  fun ref accepted(conn: LegacyTCPConnection ref) =>
+    _out.print("Connection accepted.")
+
+  fun ref received(
+    conn: LegacyTCPConnection ref,
+    data: Array[U8] iso,
+    times: USize)
+    : Bool
+  =>
+    _out.print("Data received. Echoing it back.")
+    conn.write(consume data)
+    true
+
+  fun ref closed(conn: LegacyTCPConnection ref) =>
+    _out.print("Connection closed.")
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    None

--- a/lori/_legacy_connection.pony
+++ b/lori/_legacy_connection.pony
@@ -1,0 +1,155 @@
+use net = "net"
+use "constrained_types"
+
+trait _LegacyConnection is LegacyTCPConnection
+  """
+  Shared implementation of the `LegacyTCPConnection` surface for the client and
+  accepted-connection actors. Each actor supplies the accessors below; this
+  trait turns them into the stdlib-shaped connection methods, delegating the
+  actual I/O to the lori `TCPConnection` the actor owns.
+  """
+  fun ref _connection(): TCPConnection
+  fun ref _notifier(): LegacyTCPConnectionNotify
+  fun ref _set_notifier(notify: LegacyTCPConnectionNotify)
+  fun ref _sending(): Bool
+  fun ref _set_sending(value: Bool)
+  fun ref _read_buffer_size(): USize
+  fun ref _read_state(): _LegacyReadState
+
+  fun ref _deliver_received(data: Array[U8] iso): ReadAction =>
+    """
+    Deliver received data to the notifier and decide whether to yield the read
+    loop. Yields on the notifier returning `false`, after 50 deliveries since
+    the last yield, or once the bytes since the last yield reach
+    `yield_after_reading`. Shared by both connection actors so the yield policy
+    lives in one place.
+    """
+    let rs = _read_state()
+    rs.count = rs.count + 1
+    rs.bytes = rs.bytes + data.size()
+    let keep = _notifier().received(this, consume data, rs.count)
+    if (not keep) or (rs.count >= 50) or (rs.bytes >= rs.yield_after) then
+      rs.count = 0
+      rs.bytes = 0
+      YieldReading
+    else
+      KeepReading
+    end
+
+  be write(data: ByteSeq) =>
+    if _connection().is_open() then
+      _set_sending(true)
+      let out = _notifier().sent(this, data)
+      _set_sending(false)
+      if out.size() > 0 then
+        _connection().send(out)
+      end
+    end
+
+  be writev(data: ByteSeqIter) =>
+    if _connection().is_open() then
+      _set_sending(true)
+      let out = _notifier().sentv(this, data)
+      _set_sending(false)
+      // No empty-swallow guard as in `write`: `ByteSeqIter` has no safe
+      // emptiness check, and lori's `send` already skips empty buffers.
+      _connection().send(out)
+    end
+
+  fun ref write_final(data: ByteSeq) =>
+    if _connection().is_open() then
+      _connection().send(data)
+    end
+
+  be mute() =>
+    _connection().mute()
+
+  be unmute() =>
+    _connection().unmute()
+
+  be set_notify(notify: LegacyTCPConnectionNotify iso) =>
+    _set_notifier(consume notify)
+
+  fun ref close() =>
+    _connection().close()
+
+  fun ref expect(qty: USize = 0) ? =>
+    if qty > _read_buffer_size() then
+      error
+    end
+
+    if not _sending() then
+      let e = _notifier().expect(this, qty)
+      if e == 0 then
+        match \exhaustive\ _connection().buffer_until(Streaming)
+        | BufferUntilSet => None
+        | BufferSizeAboveMinimum => _Unreachable()
+        end
+      else
+        // A notifier can return a frame larger than the read buffer holds
+        // (nested framing changes the quantity). Bound the frame to the read
+        // buffer size -- the same ceiling the `qty` check above enforces --
+        // rather than growing the buffer to an unbounded, possibly
+        // attacker-supplied, value.
+        let frame = e.min(_read_buffer_size())
+        match \exhaustive\ MakeBufferSize(frame)
+        | let b: BufferSize =>
+          match \exhaustive\ _connection().buffer_until(b)
+          | BufferUntilSet => None
+          | BufferSizeAboveMinimum => _Unreachable()
+          end
+        | let _: ValidationFailure =>
+          // frame >= 1 (e > 0 and _read_buffer_size() >= 1), so this can't
+          // fail.
+          _Unreachable()
+        end
+      end
+    end
+
+  fun ref set_nodelay(state: Bool) =>
+    _connection().set_nodelay(state)
+
+  fun ref set_keepalive(secs: U32) =>
+    _connection().keepalive(secs)
+
+  fun ref local_address(): net.NetAddress =>
+    _connection().local_address()
+
+  fun ref remote_address(): net.NetAddress =>
+    _connection().remote_address()
+
+  fun ref getsockopt(level: I32, option_name: I32, option_max_size: USize = 4)
+    : (U32, Array[U8] iso^)
+  =>
+    _connection().getsockopt(level, option_name, option_max_size)
+
+  fun ref getsockopt_u32(level: I32, option_name: I32): (U32, U32) =>
+    _connection().getsockopt_u32(level, option_name)
+
+  fun ref setsockopt(level: I32, option_name: I32, option: Array[U8]): U32 =>
+    _connection().setsockopt(level, option_name, option)
+
+  fun ref setsockopt_u32(level: I32, option_name: I32, option: U32): U32 =>
+    _connection().setsockopt_u32(level, option_name, option)
+
+  fun ref get_so_error(): (U32, U32) =>
+    _connection().getsockopt_u32(OSSockOpt.sol_socket(), OSSockOpt.so_error())
+
+  fun ref get_so_rcvbuf(): (U32, U32) =>
+    _connection().get_so_rcvbuf()
+
+  fun ref get_so_sndbuf(): (U32, U32) =>
+    _connection().get_so_sndbuf()
+
+  fun ref get_tcp_nodelay(): (U32, U32) =>
+    _connection().getsockopt_u32(
+      OSSockOpt.ipproto_tcp(), OSSockOpt.tcp_nodelay())
+
+  fun ref set_so_rcvbuf(bufsize: U32): U32 =>
+    _connection().set_so_rcvbuf(bufsize)
+
+  fun ref set_so_sndbuf(bufsize: U32): U32 =>
+    _connection().set_so_sndbuf(bufsize)
+
+  fun ref set_tcp_nodelay(state: Bool): U32 =>
+    _connection().set_nodelay(state)

--- a/lori/_legacy_max_spawn.pony
+++ b/lori/_legacy_max_spawn.pony
@@ -1,0 +1,19 @@
+use "constrained_types"
+
+primitive _LegacyMaxSpawn
+  fun apply(limit: USize): (MaxSpawn | None) =>
+    """
+    Convert a raw `USize` connection limit (the stdlib API, 0 = unlimited) into
+    lori's `(MaxSpawn | None)`. 0 maps to `None` (no limit). lori's `MaxSpawn`
+    is a `U32`, so a limit above `U32.max_value()` is clamped to it rather than
+    silently truncated.
+    """
+    if limit == 0 then
+      None
+    else
+      let clamped = limit.min(U32.max_value().usize()).u32()
+      match \exhaustive\ MakeMaxSpawn(clamped)
+      | let m: MaxSpawn => m
+      | let _: ValidationFailure => None
+      end
+    end

--- a/lori/_legacy_mode.pony
+++ b/lori/_legacy_mode.pony
@@ -1,0 +1,10 @@
+use "pony_test"
+
+interface val _LegacyMode
+  """
+  A test scenario for the Legacy API integration tests: builds the client to
+  connect and the server-side notifier for the accepted connection. Each
+  integration test is one mode. Used only by `_test_legacy.pony`.
+  """
+  fun make_client(h: TestHelper, port: String): LegacyTCPClient
+  fun make_server(h: TestHelper): LegacyTCPConnectionNotify iso^

--- a/lori/_legacy_read_buffer_size.pony
+++ b/lori/_legacy_read_buffer_size.pony
@@ -1,0 +1,13 @@
+use "constrained_types"
+
+primitive _LegacyReadBufferSize
+  fun apply(size: USize): ReadBufferSize =>
+    """
+    Convert a raw `USize` (the stdlib API's read buffer size) into lori's
+    constrained `ReadBufferSize`. A value lori rejects (0) falls back to the
+    default, since an actor constructor cannot fail.
+    """
+    match \exhaustive\ MakeReadBufferSize(size)
+    | let r: ReadBufferSize => r
+    | let _: ValidationFailure => DefaultReadBufferSize()
+    end

--- a/lori/_legacy_read_state.pony
+++ b/lori/_legacy_read_state.pony
@@ -1,0 +1,13 @@
+class _LegacyReadState
+  """
+  Per-connection read-yield bookkeeping for a Legacy connection: the receive
+  count reported to the notifier as `times`, and the bytes delivered since the
+  last yield. The client and accepted-connection actors each own one and share
+  the yield policy through `_LegacyConnection._deliver_received`.
+  """
+  var count: USize = 0
+  var bytes: USize = 0
+  let yield_after: USize
+
+  new create(yield_after': USize) =>
+    yield_after = yield_after'

--- a/lori/_legacy_server_connection.pony
+++ b/lori/_legacy_server_connection.pony
@@ -1,0 +1,76 @@
+actor _LegacyServerConnection is
+  (TCPConnectionActor & ServerLifecycleEventReceiver & _LegacyConnection)
+  """
+  A server-side accepted connection, created by `LegacyTCPListener`. Not
+  created directly by applications. Presents the `LegacyTCPConnection` surface
+  to the notifier the listener supplied.
+  """
+  var _conn: TCPConnection = TCPConnection.none()
+  var _notify: LegacyTCPConnectionNotify
+  var _in_sent: Bool = false
+  var _rbs: USize
+  embed _read: _LegacyReadState
+
+  new _accept(
+    auth: TCPServerAuth,
+    notify: LegacyTCPConnectionNotify iso,
+    fd: U32,
+    read_buffer_size: USize = 16384,
+    yield_after_reading: USize = 16384)
+  =>
+    """
+    Take ownership of an accepted socket `fd`.
+    """
+    _notify = consume notify
+    _rbs = _LegacyReadBufferSize(read_buffer_size)()
+    _read = _LegacyReadState(yield_after_reading)
+    _conn =
+      TCPConnection.server(
+        auth, fd, this, this, _LegacyReadBufferSize(read_buffer_size))
+
+  fun ref _connection(): TCPConnection =>
+    _conn
+
+  fun ref _notifier(): LegacyTCPConnectionNotify =>
+    _notify
+
+  fun ref _set_notifier(notify: LegacyTCPConnectionNotify) =>
+    _notify = notify
+
+  fun ref _sending(): Bool =>
+    _in_sent
+
+  fun ref _set_sending(value: Bool) =>
+    _in_sent = value
+
+  fun ref _read_buffer_size(): USize =>
+    _rbs
+
+  fun ref _read_state(): _LegacyReadState =>
+    _read
+
+  be dispose() =>
+    """
+    Gracefully close the connection once queued writes are sent, matching the
+    stdlib `net.TCPConnection.dispose`. A muted connection hard closes and drops
+    data instead (see `close`). This overrides lori's own
+    `TCPConnectionActor.dispose`, which hard closes to sidestep the
+    edge-triggered race in issue #229; the Legacy API keeps the stdlib's
+    graceful behavior.
+    """
+    _conn.close()
+
+  fun ref _on_started() =>
+    _notify.accepted(this)
+
+  fun ref _on_received(data: Array[U8] iso): ReadAction =>
+    _deliver_received(consume data)
+
+  fun ref _on_closed() =>
+    _notify.closed(this)
+
+  fun ref _on_throttled() =>
+    _notify.throttled(this)
+
+  fun ref _on_unthrottled() =>
+    _notify.unthrottled(this)

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -114,3 +114,5 @@ actor \nodoc\ Main is TestList
     ifdef posix then test(_TestSendSSLHardCloseFromThrottled) end
     ifdef posix then test(_TestSendDeliveredNotFailedOnHardClose) end
     ifdef posix then test(_TestReadableEventWriteRecovery) end
+
+    _LegacyTests.tests(test)

--- a/lori/_test_legacy.pony
+++ b/lori/_test_legacy.pony
@@ -1,0 +1,609 @@
+use "files"
+use "pony_test"
+use "ssl/net"
+
+// Tests for the Legacy stdlib-net compatibility API (LegacyTCPClient,
+// LegacyTCPListener, and their notifiers) built on top of lori.
+//
+// The integration tests share one listener notifier, `_LegacyTestListenNotify`,
+// parameterized by a `_LegacyMode`. The mode builds the test's client and its
+// server-side connection notifier, so each test's inputs and assertions live in
+// its own mode and notifier classes while the listen/accept plumbing is shared.
+
+primitive \nodoc\ _LegacyTests
+  fun tag tests(test: PonyTest) =>
+    test(_TestLegacyReadBufferSizeZeroDefaults)
+    test(_TestLegacyReadBufferSizePassesThrough)
+    test(_TestLegacyMaxSpawnZeroUnlimited)
+    test(_TestLegacyMaxSpawnPositive)
+    test(_TestLegacyEchoRoundTrip)
+    test(_TestLegacyConnectFailed)
+    test(_TestLegacySentTransforms)
+    test(_TestLegacyWriteFinalBypassesSent)
+    test(_TestLegacyExpectFrames)
+    test(_TestLegacyExpectErrorsAboveBufferSize)
+    test(_TestLegacyExpectInflatingNotifier)
+    test(_TestLegacyReceivedTimes)
+    test(_TestLegacyProxyVia)
+    test(_TestLegacySSLEchoRoundTrip)
+
+// ---------------------------------------------------------------------------
+// Mapping primitives (pure, no I/O)
+// ---------------------------------------------------------------------------
+class \nodoc\ iso _TestLegacyReadBufferSizeZeroDefaults is UnitTest
+  """
+  A read buffer size of 0 (which lori rejects) falls back to the default,
+  since an actor constructor cannot fail.
+  """
+  fun name(): String => "LegacyReadBufferSizeZeroDefaults"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[USize](_LegacyReadBufferSize(0)(), DefaultReadBufferSize()())
+
+class \nodoc\ iso _TestLegacyReadBufferSizePassesThrough is UnitTest
+  """
+  A valid read buffer size is passed through unchanged.
+  """
+  fun name(): String => "LegacyReadBufferSizePassesThrough"
+
+  fun apply(h: TestHelper) =>
+    h.assert_eq[USize](_LegacyReadBufferSize(512)(), 512)
+    h.assert_eq[USize](_LegacyReadBufferSize(1)(), 1)
+
+class \nodoc\ iso _TestLegacyMaxSpawnZeroUnlimited is UnitTest
+  """
+  A connection limit of 0 maps to None (no limit).
+  """
+  fun name(): String => "LegacyMaxSpawnZeroUnlimited"
+
+  fun apply(h: TestHelper) =>
+    h.assert_true(_LegacyMaxSpawn(0) is None)
+
+class \nodoc\ iso _TestLegacyMaxSpawnPositive is UnitTest
+  """
+  A positive connection limit maps to a MaxSpawn carrying that value.
+  """
+  fun name(): String => "LegacyMaxSpawnPositive"
+
+  fun apply(h: TestHelper) =>
+    match \exhaustive\ _LegacyMaxSpawn(5)
+    | let m: MaxSpawn => h.assert_eq[U32](m(), 5)
+    | None => h.fail("expected a MaxSpawn, got None")
+    end
+
+// Shared integration harness. The `_LegacyMode` interface is in
+// `_legacy_mode.pony`.
+class \nodoc\ _LegacyTestListenNotify is LegacyTCPListenNotify
+  let _h: TestHelper
+  let _port: String
+  let _mode: _LegacyMode
+  var _client: (LegacyTCPClient | None) = None
+
+  new iso create(h: TestHelper, port: String, mode: _LegacyMode) =>
+    _h = h
+    _port = port
+    _mode = mode
+
+  fun ref listening(listen: LegacyTCPListener ref) =>
+    _h.complete_action("server listening")
+    _client = _mode.make_client(_h, _port)
+
+  fun ref not_listening(listen: LegacyTCPListener ref) =>
+    _h.fail("listener failed to listen")
+
+  fun ref connected(listen: LegacyTCPListener ref)
+    : LegacyTCPConnectionNotify iso^
+  =>
+    _mode.make_server(_h)
+
+  fun ref closed(listen: LegacyTCPListener ref) =>
+    match _client
+    | let c: LegacyTCPClient => c.dispose()
+    end
+
+class \nodoc\ _LegacyEchoServerNotify is LegacyTCPConnectionNotify
+  """
+  Server side that echoes whatever it receives back to the client.
+  """
+  new iso create() =>
+    None
+
+  fun ref received(
+    conn: LegacyTCPConnection ref,
+    data: Array[U8] iso,
+    times: USize)
+    : Bool
+  =>
+    conn.write(consume data)
+    true
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    None
+
+class \nodoc\ _LegacyDropServerNotify is LegacyTCPConnectionNotify
+  """
+  Server side that accepts and reads but does nothing with the data. Used when
+  the test's assertions all run on the client side.
+  """
+  new iso create() =>
+    None
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    None
+
+// ---------------------------------------------------------------------------
+// Echo round trip: listening, connected, accepted, received, write() through
+// the LegacyTCPConnection interface handle, end to end.
+// ---------------------------------------------------------------------------
+class \nodoc\ iso _TestLegacyEchoRoundTrip is UnitTest
+  fun name(): String => "LegacyEchoRoundTrip"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("server listening")
+    h.expect_action("client connected")
+    h.expect_action("client got echo")
+    _RunLegacy(h, "8790", _ModeEcho)
+
+primitive \nodoc\ _ModeEcho is _LegacyMode
+  fun make_client(h: TestHelper, port: String): LegacyTCPClient =>
+    LegacyTCPClient(
+      TCPConnectAuth(h.env.root), _EchoClient(h), "localhost", port)
+
+  fun make_server(h: TestHelper): LegacyTCPConnectionNotify iso^ =>
+    _LegacyEchoServerNotify
+
+class \nodoc\ _EchoClient is LegacyTCPConnectionNotify
+  let _h: TestHelper
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref connected(conn: LegacyTCPConnection ref) =>
+    _h.complete_action("client connected")
+    conn.write("hello")
+
+  fun ref received(
+    conn: LegacyTCPConnection ref,
+    data: Array[U8] iso,
+    times: USize)
+    : Bool
+  =>
+    _h.assert_eq[String]("hello", String.from_array(consume data))
+    _h.complete_action("client got echo")
+    conn.close()
+    true
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    _h.fail("client failed to connect")
+
+// ---------------------------------------------------------------------------
+// Connect failure: _on_connection_failure translates to connect_failed.
+// ---------------------------------------------------------------------------
+class \nodoc\ iso _TestLegacyConnectFailed is UnitTest
+  fun name(): String => "LegacyConnectFailed"
+
+  fun apply(h: TestHelper) =>
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let client =
+      LegacyTCPClient(
+        TCPConnectAuth(h.env.root), _ConnectFailedClient(h), host, "3457")
+    h.dispose_when_done(client)
+    h.long_test(5_000_000_000)
+
+class \nodoc\ _ConnectFailedClient is LegacyTCPConnectionNotify
+  let _h: TestHelper
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref connected(conn: LegacyTCPConnection ref) =>
+    _h.fail("connected on a connection that should have failed")
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    _h.complete(true)
+
+// ---------------------------------------------------------------------------
+// sent transforms outgoing data: the server receives the transformed bytes.
+// ---------------------------------------------------------------------------
+class \nodoc\ iso _TestLegacySentTransforms is UnitTest
+  fun name(): String => "LegacySentTransforms"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("server listening")
+    h.expect_action("server got transformed")
+    _RunLegacy(h, "8791", _ModeSentTransform)
+
+primitive \nodoc\ _ModeSentTransform is _LegacyMode
+  fun make_client(h: TestHelper, port: String): LegacyTCPClient =>
+    LegacyTCPClient(
+      TCPConnectAuth(h.env.root), _SentTransformClient, "localhost", port)
+
+  fun make_server(h: TestHelper): LegacyTCPConnectionNotify iso^ =>
+    _SentTransformServer(h)
+
+class \nodoc\ _SentTransformClient is LegacyTCPConnectionNotify
+  new iso create() =>
+    None
+
+  fun ref connected(conn: LegacyTCPConnection ref) =>
+    conn.write("ping")
+
+  fun ref sent(conn: LegacyTCPConnection ref, data: ByteSeq): ByteSeq =>
+    "PING"
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    None
+
+class \nodoc\ _SentTransformServer is LegacyTCPConnectionNotify
+  let _h: TestHelper
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref received(
+    conn: LegacyTCPConnection ref,
+    data: Array[U8] iso,
+    times: USize)
+    : Bool
+  =>
+    _h.assert_eq[String]("PING", String.from_array(consume data))
+    _h.complete_action("server got transformed")
+    true
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    None
+
+// ---------------------------------------------------------------------------
+// write_final bypasses the sent notifier: the server receives the raw bytes.
+// ---------------------------------------------------------------------------
+class \nodoc\ iso _TestLegacyWriteFinalBypassesSent is UnitTest
+  fun name(): String => "LegacyWriteFinalBypassesSent"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("server listening")
+    h.expect_action("server got raw")
+    _RunLegacy(h, "8792", _ModeWriteFinal)
+
+primitive \nodoc\ _ModeWriteFinal is _LegacyMode
+  fun make_client(h: TestHelper, port: String): LegacyTCPClient =>
+    LegacyTCPClient(
+      TCPConnectAuth(h.env.root), _WriteFinalClient, "localhost", port)
+
+  fun make_server(h: TestHelper): LegacyTCPConnectionNotify iso^ =>
+    _WriteFinalServer(h)
+
+class \nodoc\ _WriteFinalClient is LegacyTCPConnectionNotify
+  new iso create() =>
+    None
+
+  fun ref connected(conn: LegacyTCPConnection ref) =>
+    // write_final must not run sent, so the server should see "raw", not "XFORM"
+    conn.write_final("raw")
+
+  fun ref sent(conn: LegacyTCPConnection ref, data: ByteSeq): ByteSeq =>
+    "XFORM"
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    None
+
+class \nodoc\ _WriteFinalServer is LegacyTCPConnectionNotify
+  let _h: TestHelper
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref received(
+    conn: LegacyTCPConnection ref,
+    data: Array[U8] iso,
+    times: USize)
+    : Bool
+  =>
+    _h.assert_eq[String]("raw", String.from_array(consume data))
+    _h.complete_action("server got raw")
+    true
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    None
+
+// ---------------------------------------------------------------------------
+// expect(n) frames received data into exactly n-byte chunks.
+// ---------------------------------------------------------------------------
+class \nodoc\ iso _TestLegacyExpectFrames is UnitTest
+  fun name(): String => "LegacyExpectFrames"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("server listening")
+    h.expect_action("frame one")
+    h.expect_action("frame two")
+    _RunLegacy(h, "8793", _ModeExpectFrames)
+
+primitive \nodoc\ _ModeExpectFrames is _LegacyMode
+  fun make_client(h: TestHelper, port: String): LegacyTCPClient =>
+    LegacyTCPClient(
+      TCPConnectAuth(h.env.root), _ExpectFramesClient, "localhost", port)
+
+  fun make_server(h: TestHelper): LegacyTCPConnectionNotify iso^ =>
+    _ExpectFramesServer(h)
+
+class \nodoc\ _ExpectFramesClient is LegacyTCPConnectionNotify
+  new iso create() =>
+    None
+
+  fun ref connected(conn: LegacyTCPConnection ref) =>
+    conn.write("aaaabbbb")
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    None
+
+class \nodoc\ _ExpectFramesServer is LegacyTCPConnectionNotify
+  let _h: TestHelper
+  var _n: USize = 0
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref accepted(conn: LegacyTCPConnection ref) =>
+    try conn.expect(4)? else _h.fail("expect(4) errored") end
+
+  fun ref received(
+    conn: LegacyTCPConnection ref,
+    data: Array[U8] iso,
+    times: USize)
+    : Bool
+  =>
+    let s = String.from_array(consume data)
+    _n = _n + 1
+    if _n == 1 then
+      _h.assert_eq[String]("aaaa", s)
+      _h.complete_action("frame one")
+    else
+      _h.assert_eq[String]("bbbb", s)
+      _h.complete_action("frame two")
+    end
+    true
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    None
+
+// ---------------------------------------------------------------------------
+// expect errors when qty exceeds the read buffer size the connection was
+// created with.
+// ---------------------------------------------------------------------------
+class \nodoc\ iso _TestLegacyExpectErrorsAboveBufferSize is UnitTest
+  fun name(): String => "LegacyExpectErrorsAboveBufferSize"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("server listening")
+    h.expect_action("boundary checked")
+    _RunLegacy(h, "8794", _ModeExpectBoundary)
+
+primitive \nodoc\ _ModeExpectBoundary is _LegacyMode
+  fun make_client(h: TestHelper, port: String): LegacyTCPClient =>
+    LegacyTCPClient(
+      TCPConnectAuth(h.env.root), _ExpectBoundaryClient(h), "localhost", port
+      where read_buffer_size = 64)
+
+  fun make_server(h: TestHelper): LegacyTCPConnectionNotify iso^ =>
+    _LegacyDropServerNotify
+
+class \nodoc\ _ExpectBoundaryClient is LegacyTCPConnectionNotify
+  let _h: TestHelper
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref connected(conn: LegacyTCPConnection ref) =>
+    try conn.expect(64)? else _h.fail("expect(64) should not error") end
+    try
+      conn.expect(65)?
+      _h.fail("expect(65) should have errored")
+    else
+      _h.complete_action("boundary checked")
+    end
+    conn.close()
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    _h.fail("client failed to connect")
+
+// ---------------------------------------------------------------------------
+// A notifier whose expect() returns a quantity above the read buffer size is
+// bounded to the buffer size, not grown to fit, and the connection keeps
+// working.
+// ---------------------------------------------------------------------------
+class \nodoc\ iso _TestLegacyExpectInflatingNotifier is UnitTest
+  fun name(): String => "LegacyExpectInflatingNotifier"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("server listening")
+    h.expect_action("expect survived")
+    _RunLegacy(h, "8795", _ModeExpectInflating)
+
+primitive \nodoc\ _ModeExpectInflating is _LegacyMode
+  fun make_client(h: TestHelper, port: String): LegacyTCPClient =>
+    LegacyTCPClient(
+      TCPConnectAuth(h.env.root), _ExpectInflatingClient(h), "localhost", port
+      where read_buffer_size = 100)
+
+  fun make_server(h: TestHelper): LegacyTCPConnectionNotify iso^ =>
+    _LegacyDropServerNotify
+
+class \nodoc\ _ExpectInflatingClient is LegacyTCPConnectionNotify
+  let _h: TestHelper
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref connected(conn: LegacyTCPConnection ref) =>
+    // qty (50) is within the buffer size, but the notifier inflates it to 200.
+    // Reaching this line without a runtime abort is the assertion.
+    try conn.expect(50)? else _h.fail("expect(50) should not error") end
+    _h.complete_action("expect survived")
+    conn.close()
+
+  fun ref expect(conn: LegacyTCPConnection ref, qty: USize): USize =>
+    200
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    _h.fail("client failed to connect")
+
+// ---------------------------------------------------------------------------
+// received's `times` counts calls since the last yield, starting at 1.
+// ---------------------------------------------------------------------------
+class \nodoc\ iso _TestLegacyReceivedTimes is UnitTest
+  fun name(): String => "LegacyReceivedTimes"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("server listening")
+    h.expect_action("times ok")
+    _RunLegacy(h, "8796", _ModeReceivedTimes)
+
+primitive \nodoc\ _ModeReceivedTimes is _LegacyMode
+  fun make_client(h: TestHelper, port: String): LegacyTCPClient =>
+    LegacyTCPClient(
+      TCPConnectAuth(h.env.root), _ReceivedTimesClient, "localhost", port)
+
+  fun make_server(h: TestHelper): LegacyTCPConnectionNotify iso^ =>
+    _ReceivedTimesServer(h)
+
+class \nodoc\ _ReceivedTimesClient is LegacyTCPConnectionNotify
+  new iso create() =>
+    None
+
+  fun ref connected(conn: LegacyTCPConnection ref) =>
+    conn.write("aaaabbbbcccc")
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    None
+
+class \nodoc\ _ReceivedTimesServer is LegacyTCPConnectionNotify
+  let _h: TestHelper
+  var _expected: USize = 1
+
+  new iso create(h: TestHelper) =>
+    _h = h
+
+  fun ref accepted(conn: LegacyTCPConnection ref) =>
+    try conn.expect(4)? else _h.fail("expect(4) errored") end
+
+  fun ref received(
+    conn: LegacyTCPConnection ref,
+    data: Array[U8] iso,
+    times: USize)
+    : Bool
+  =>
+    _h.assert_eq[USize](_expected, times)
+    _expected = _expected + 1
+    if times == 3 then
+      _h.complete_action("times ok")
+    end
+    true
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    None
+
+// ---------------------------------------------------------------------------
+// proxy_via redirects the connection to the returned host/service.
+// ---------------------------------------------------------------------------
+class \nodoc\ iso _TestLegacyProxyVia is UnitTest
+  fun name(): String => "LegacyProxyVia"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("server listening")
+    h.expect_action("proxied connect")
+    _RunLegacy(h, "8797", _ModeProxyVia)
+
+primitive \nodoc\ _ModeProxyVia is _LegacyMode
+  fun make_client(h: TestHelper, port: String): LegacyTCPClient =>
+    // Dial a dead endpoint; proxy_via redirects to the live listener.
+    let dead = ifdef linux then "127.0.0.2" else "localhost" end
+    LegacyTCPClient(
+      TCPConnectAuth(h.env.root), _ProxyViaClient(h, port), dead, "3458")
+
+  fun make_server(h: TestHelper): LegacyTCPConnectionNotify iso^ =>
+    _LegacyDropServerNotify
+
+class \nodoc\ _ProxyViaClient is LegacyTCPConnectionNotify
+  let _h: TestHelper
+  let _real_port: String
+
+  new iso create(h: TestHelper, real_port: String) =>
+    _h = h
+    _real_port = real_port
+
+  fun ref proxy_via(host: String, service: String): (String, String) =>
+    ("localhost", _real_port)
+
+  fun ref connected(conn: LegacyTCPConnection ref) =>
+    _h.complete_action("proxied connect")
+    conn.close()
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    _h.fail("proxy_via redirect did not connect")
+
+// ---------------------------------------------------------------------------
+// SSL echo round trip: the same echo, but each side wraps its notifier in a
+// LegacySSLConnection, so the handshake and record framing run on top of the
+// plaintext LegacyTCPConnection.
+// ---------------------------------------------------------------------------
+class \nodoc\ iso _TestLegacySSLEchoRoundTrip is UnitTest
+  fun name(): String => "LegacySSLEchoRoundTrip"
+
+  fun apply(h: TestHelper) ? =>
+    h.expect_action("server listening")
+    h.expect_action("client connected")
+    h.expect_action("client got echo")
+
+    let file_auth = FileAuth(h.env.root)
+    let sslctx =
+      recover
+        SSLContext
+          .> set_authority(FilePath(file_auth, "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(file_auth, "assets/cert.pem"),
+            FilePath(file_auth, "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    _RunLegacy(h, "8798", _ModeSSLEcho(consume sslctx))
+
+class \nodoc\ val _ModeSSLEcho is _LegacyMode
+  let _ctx: SSLContext val
+
+  new val create(ctx: SSLContext val) =>
+    _ctx = ctx
+
+  fun make_client(h: TestHelper, port: String): LegacyTCPClient =>
+    try
+      LegacyTCPClient(
+        TCPConnectAuth(h.env.root),
+        LegacySSLConnection(_EchoClient(h), _ctx.client("localhost")?),
+        "localhost",
+        port)
+    else
+      h.fail("could not create client SSL session")
+      LegacyTCPClient(
+        TCPConnectAuth(h.env.root), _EchoClient(h), "localhost", port)
+    end
+
+  fun make_server(h: TestHelper): LegacyTCPConnectionNotify iso^ =>
+    try
+      LegacySSLConnection(_LegacyEchoServerNotify, _ctx.server()?)
+    else
+      h.fail("could not create server SSL session")
+      _LegacyDropServerNotify
+    end
+
+// ---------------------------------------------------------------------------
+// Shared runner: start a listener with the mode and dispose it when done.
+// ---------------------------------------------------------------------------
+primitive \nodoc\ _RunLegacy
+  fun apply(h: TestHelper, port: String, mode: _LegacyMode) =>
+    let listener =
+      LegacyTCPListener(
+        TCPListenAuth(h.env.root),
+        _LegacyTestListenNotify(h, port, mode),
+        "localhost",
+        port)
+    h.dispose_when_done(listener)
+    h.long_test(5_000_000_000)

--- a/lori/legacy_alpn_protocol_notify.pony
+++ b/lori/legacy_alpn_protocol_notify.pony
@@ -1,0 +1,17 @@
+interface LegacyALPNProtocolNotify
+  """
+  A `LegacyTCPConnectionNotify` that also implements this is told the ALPN
+  protocol negotiated, once the handshake is complete.
+
+  This mirrors the `ssl/net` package's `ALPNProtocolNotify`, retyped to
+  `LegacyTCPConnection` (the stdlib version is typed to `net.TCPConnection`,
+  which a `LegacySSLConnection` never handles).
+  """
+  fun ref alpn_negotiated(
+    conn: LegacyTCPConnection ref,
+    protocol: (String | None))
+    : None
+    """
+    The protocol the peers agreed on, or `None` when they agreed on none.
+    Called once, before any application data reaches `received`.
+    """

--- a/lori/legacy_ssl_connection.pony
+++ b/lori/legacy_ssl_connection.pony
@@ -1,0 +1,227 @@
+use "collections"
+use "ssl/net"
+
+class LegacySSLConnection is LegacyTCPConnectionNotify
+  """
+  Wrap another protocol in an SSL connection.
+
+  This mirrors the standard library `ssl/net` package's `SSLConnection`
+  decorator, retyped to `LegacyTCPConnectionNotify`. It wraps a plaintext
+  `LegacyTCPConnection` (created with `LegacyTCPClient` or accepted by
+  `LegacyTCPListener`) and a wrapped notifier, running the TLS handshake and
+  record framing on top. Give the wrapped notifier's `connected`/`accepted` and
+  `received` the decrypted view; the ciphertext goes to the connection via
+  `write_final`, which does not re-run `sent`.
+
+  This is independent of lori's built-in SSL (the `ssl_client`/`ssl_server`
+  `TCPConnection` constructors); it reproduces the old decorator API for code
+  moving from `ssl/net`.
+  """
+  let _notify: LegacyTCPConnectionNotify
+  let _ssl: SSL
+  var _connected: Bool = false
+  var _expect: USize = 0
+  var _closed: Bool = false
+  let _pending: List[ByteSeq] = _pending.create()
+  var _accept_pending: Bool = false
+
+  new iso create(notify: LegacyTCPConnectionNotify iso, ssl: SSL iso) =>
+    """
+    Initialise with a wrapped protocol and an SSL session.
+    """
+    _notify = consume notify
+    _ssl = consume ssl
+
+  fun ref accepted(conn: LegacyTCPConnection ref) =>
+    """
+    Swallow this event until the handshake is complete.
+    """
+    _accept_pending = true
+    _poll(conn)
+
+  fun ref connecting(conn: LegacyTCPConnection ref, count: U32) =>
+    """
+    Forward to the wrapped protocol.
+    """
+    _notify.connecting(conn, count)
+
+  fun ref connected(conn: LegacyTCPConnection ref) =>
+    """
+    Swallow this event until the handshake is complete.
+    """
+    _poll(conn)
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+    """
+    Forward to the wrapped protocol.
+    """
+    _notify.connect_failed(conn)
+
+  fun ref sent(conn: LegacyTCPConnection ref, data: ByteSeq): ByteSeq =>
+    """
+    Pass the data to the SSL session and check for both new application data
+    and new destination data.
+    """
+    let notified = _notify.sent(conn, data)
+    if _connected then
+      try
+        _ssl.write(notified)?
+      else
+        return ""
+      end
+    else
+      _pending.push(notified)
+    end
+
+    _poll(conn)
+    ""
+
+  fun ref sentv(conn: LegacyTCPConnection ref, data: ByteSeqIter): ByteSeqIter
+  =>
+    """
+    Pass each sequence to the SSL session and check for both new application
+    data and new destination data. Returns an empty sequence: what leaves the
+    connection is the ciphertext `_poll` writes, not these bytes.
+    """
+    let ret = recover val Array[ByteSeq] end
+    let data' = _notify.sentv(conn, data)
+    for bytes in data'.values() do
+      if _connected then
+        try
+          _ssl.write(bytes)?
+        else
+          return ret
+        end
+      else
+        _pending.push(bytes)
+      end
+    end
+
+    _poll(conn)
+    ret
+
+  fun ref received(
+    conn: LegacyTCPConnection ref,
+    data: Array[U8] iso,
+    times: USize)
+    : Bool
+  =>
+    """
+    Pass the data to the SSL session and check for both new application data
+    and new destination data.
+    """
+    _ssl.receive(consume data)
+    _poll(conn)
+
+  fun ref expect(conn: LegacyTCPConnection ref, qty: USize): USize =>
+    """
+    Keep track of the expect count for the wrapped protocol. Always tell the
+    connection to read all available data.
+    """
+    _expect = _notify.expect(conn, qty)
+    0
+
+  fun ref closed(conn: LegacyTCPConnection ref) =>
+    """
+    Forward to the wrapped protocol.
+    """
+    _closed = true
+
+    _poll(conn)
+    _ssl.dispose()
+
+    _connected = false
+    _pending.clear()
+    _notify.closed(conn)
+
+  fun ref throttled(conn: LegacyTCPConnection ref) =>
+    """
+    Forward to the wrapped protocol.
+    """
+    _notify.throttled(conn)
+
+  fun ref unthrottled(conn: LegacyTCPConnection ref) =>
+    """
+    Forward to the wrapped protocol.
+    """
+    _notify.unthrottled(conn)
+
+  fun ref _poll(conn: LegacyTCPConnection ref): Bool =>
+    """
+    Check for both new application data and new destination data. Inform the
+    wrapped protocol that it has connected when the handshake is complete.
+    """
+    match _ssl.state()
+    | SSLReady =>
+      if not _connected then
+        _connected = true
+        if _accept_pending then
+          _notify.accepted(conn)
+        else
+          _notify.connected(conn)
+        end
+
+        match _notify
+        | let alpn_notify: LegacyALPNProtocolNotify =>
+          alpn_notify.alpn_negotiated(conn, _ssl.alpn_selected())
+        end
+
+        try
+          while true do
+            let bytes = try _pending.shift()? else break end
+            _ssl.write(bytes)?
+          end
+        end
+      end
+    | SSLAuthFail =>
+      _notify.auth_failed(conn)
+
+      if not _closed then
+        conn.close()
+      end
+
+      return true
+    | SSLError =>
+      if not _closed then
+        conn.close()
+      end
+
+      return true
+    | SSLDisposed =>
+      // `closed` disposes the session after its last `_poll`, so this arm is
+      // not reached while the connection is open. Once the session is gone
+      // there is nothing to read and nothing to send.
+      return false
+    end
+
+    var continue_reading: Bool = true
+
+    try
+      var received_called: USize = 0
+
+      while true do
+        let r = _ssl.read(_expect)
+
+        if r isnt None then
+          received_called = received_called + 1
+          if not _notify.received(
+            conn,
+            (consume r) as Array[U8] iso^,
+            received_called)
+          then
+            continue_reading = false
+            break
+          end
+        else
+          break
+        end
+      end
+    end
+
+    try
+      while _ssl.can_send() do
+        conn.write_final(_ssl.send()?)
+      end
+    end
+
+    continue_reading

--- a/lori/legacy_tcp_client.pony
+++ b/lori/legacy_tcp_client.pony
@@ -1,0 +1,157 @@
+actor LegacyTCPClient is
+  (TCPConnectionActor & ClientLifecycleEventReceiver & _LegacyConnection)
+  """
+  A client-side TCP connection with the standard library `net` package's
+  `TCPConnection` API, built on lori. Create one to connect to a server:
+
+  ```pony
+  LegacyTCPClient(TCPConnectAuth(env.root), MyNotify, "", "8989")
+  ```
+
+  Data arrives at the `received` method of the `LegacyTCPConnectionNotify` you
+  supply. See `LegacyTCPConnection` for the connection methods.
+  """
+  var _conn: TCPConnection = TCPConnection.none()
+  var _notify: LegacyTCPConnectionNotify
+  var _in_sent: Bool = false
+  var _rbs: USize
+  embed _read: _LegacyReadState
+
+  new create(
+    auth: TCPConnectAuth,
+    notify: LegacyTCPConnectionNotify iso,
+    host: String,
+    service: String,
+    from: String = "",
+    read_buffer_size: USize = 16384,
+    yield_after_reading: USize = 16384,
+    yield_after_writing: USize = 16384)
+  =>
+    """
+    Connect via IPv4 or IPv6. If `from` is non-empty, connect from that
+    interface. `yield_after_writing` is accepted for source compatibility but
+    has no effect (see the package documentation).
+    """
+    _notify = consume notify
+    _rbs = _LegacyReadBufferSize(read_buffer_size)()
+    _read = _LegacyReadState(yield_after_reading)
+    (let host', let service') = _notify.proxy_via(host, service)
+    _conn =
+      TCPConnection.client(
+        auth,
+        host',
+        service',
+        from,
+        this,
+        this,
+        _LegacyReadBufferSize(read_buffer_size),
+        DualStack)
+
+  new ip4(
+    auth: TCPConnectAuth,
+    notify: LegacyTCPConnectionNotify iso,
+    host: String,
+    service: String,
+    from: String = "",
+    read_buffer_size: USize = 16384,
+    yield_after_reading: USize = 16384,
+    yield_after_writing: USize = 16384)
+  =>
+    """
+    Connect via IPv4.
+    """
+    _notify = consume notify
+    _rbs = _LegacyReadBufferSize(read_buffer_size)()
+    _read = _LegacyReadState(yield_after_reading)
+    (let host', let service') = _notify.proxy_via(host, service)
+    _conn =
+      TCPConnection.client(
+        auth,
+        host',
+        service',
+        from,
+        this,
+        this,
+        _LegacyReadBufferSize(read_buffer_size),
+        IP4)
+
+  new ip6(
+    auth: TCPConnectAuth,
+    notify: LegacyTCPConnectionNotify iso,
+    host: String,
+    service: String,
+    from: String = "",
+    read_buffer_size: USize = 16384,
+    yield_after_reading: USize = 16384,
+    yield_after_writing: USize = 16384)
+  =>
+    """
+    Connect via IPv6.
+    """
+    _notify = consume notify
+    _rbs = _LegacyReadBufferSize(read_buffer_size)()
+    _read = _LegacyReadState(yield_after_reading)
+    (let host', let service') = _notify.proxy_via(host, service)
+    _conn =
+      TCPConnection.client(
+        auth,
+        host',
+        service',
+        from,
+        this,
+        this,
+        _LegacyReadBufferSize(read_buffer_size),
+        IP6)
+
+  fun ref _connection(): TCPConnection =>
+    _conn
+
+  fun ref _notifier(): LegacyTCPConnectionNotify =>
+    _notify
+
+  fun ref _set_notifier(notify: LegacyTCPConnectionNotify) =>
+    _notify = notify
+
+  fun ref _sending(): Bool =>
+    _in_sent
+
+  fun ref _set_sending(value: Bool) =>
+    _in_sent = value
+
+  fun ref _read_buffer_size(): USize =>
+    _rbs
+
+  fun ref _read_state(): _LegacyReadState =>
+    _read
+
+  be dispose() =>
+    """
+    Gracefully close the connection once queued writes are sent, matching the
+    stdlib `net.TCPConnection.dispose`. A muted connection hard closes and drops
+    data instead (see `close`). This overrides lori's own
+    `TCPConnectionActor.dispose`, which hard closes to sidestep the
+    edge-triggered race in issue #229; the Legacy API keeps the stdlib's
+    graceful behavior.
+    """
+    _conn.close()
+
+  fun ref _on_connecting(inflight_connections: U32) =>
+    _notify.connecting(this, inflight_connections)
+
+  fun ref _on_connected() =>
+    _notify.connected(this)
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    _notify.connect_failed(this)
+
+  fun ref _on_received(data: Array[U8] iso): ReadAction =>
+    _deliver_received(consume data)
+
+  fun ref _on_closed() =>
+    _notify.closed(this)
+
+  fun ref _on_throttled() =>
+    _notify.throttled(this)
+
+  fun ref _on_unthrottled() =>
+    _notify.unthrottled(this)

--- a/lori/legacy_tcp_connection.pony
+++ b/lori/legacy_tcp_connection.pony
@@ -1,0 +1,150 @@
+use net = "net"
+
+interface LegacyTCPConnection
+  """
+  A TCP connection with the shape of the standard library `net` package's
+  `TCPConnection`, built on top of lori.
+
+  This is the type a `LegacyTCPConnectionNotify` receives as its `conn`
+  parameter, and the type an application holds to drive a connection. It is
+  reached two ways: create a client with `LegacyTCPClient`, or accept one with
+  `LegacyTCPListener`.
+
+  From outside the owning actor only the behaviors (`write`, `writev`, `mute`,
+  `unmute`, `set_notify`, `dispose`) can be called. The synchronous methods
+  (`close`, `write_final`, `expect`, `local_address`, `remote_address`, and the
+  socket-option methods) are for use inside notifier callbacks, where `conn` is
+  a `ref`.
+  """
+  be write(data: ByteSeq)
+    """
+    Write a single sequence of bytes. Discarded if the connection is not open.
+    The `sent` notifier runs first and may transform or swallow the data.
+    """
+
+  be writev(data: ByteSeqIter)
+    """
+    Write several sequences of bytes in one syscall. Discarded if the
+    connection is not open. The `sentv` notifier runs first and may transform
+    or swallow the data.
+    """
+
+  be mute()
+    """
+    Suspend reading off this connection until `unmute` is called.
+    """
+
+  be unmute()
+    """
+    Resume reading off this connection after `mute`.
+    """
+
+  be set_notify(notify: LegacyTCPConnectionNotify iso)
+    """
+    Replace the notifier.
+    """
+
+  be dispose()
+    """
+    Gracefully close the connection once queued writes are sent. On a muted
+    connection this is a hard close that drops undelivered data, the same as
+    `close`.
+    """
+
+  fun ref write_final(data: ByteSeq)
+    """
+    Write bytes without running the `sent` notifier. This is the hook a
+    protocol wrapper (e.g. `LegacySSLConnection`) uses to push already-encoded
+    data. Discarded if the connection is not open.
+    """
+
+  fun ref close()
+    """
+    Gracefully close the connection once queued writes are sent. On a muted
+    connection this is a hard close that drops undelivered data.
+    """
+
+  fun ref expect(qty: USize = 0) ?
+    """
+    A `received` call must contain exactly `qty` bytes, or any amount if `qty`
+    is zero. No effect when called from the `sent` notifier. Errors if `qty`
+    exceeds the read buffer size the connection was created with.
+    """
+
+  fun ref set_nodelay(state: Bool)
+    """
+    Turn Nagle's algorithm on or off. Only meaningful on a connected socket.
+    """
+
+  fun ref set_keepalive(secs: U32)
+    """
+    Set the TCP keepalive timeout to approximately `secs` seconds, or disable
+    it with 0. Only meaningful on a connected socket.
+    """
+
+  fun ref local_address(): net.NetAddress
+    """
+    The local IP address. Invalid if the connection is closed.
+    """
+
+  fun ref remote_address(): net.NetAddress
+    """
+    The remote IP address. Invalid if the connection is closed.
+    """
+
+  fun ref getsockopt(level: I32, option_name: I32, option_max_size: USize = 4)
+    : (U32, Array[U8] iso^)
+    """
+    General `getsockopt(2)` wrapper. See `OSSockOpt` for options.
+    """
+
+  fun ref getsockopt_u32(level: I32, option_name: I32): (U32, U32)
+    """
+    `getsockopt(2)` wrapper where the kernel returns a `U32`.
+    """
+
+  fun ref setsockopt(level: I32, option_name: I32, option: Array[U8]): U32
+    """
+    General `setsockopt(2)` wrapper. Returns 0 on success or `errno`.
+    """
+
+  fun ref setsockopt_u32(level: I32, option_name: I32, option: U32): U32
+    """
+    `setsockopt(2)` wrapper where the kernel expects a `U32`. Returns 0 on
+    success or `errno`.
+    """
+
+  fun ref get_so_error(): (U32, U32)
+    """
+    `getsockopt(fd, SOL_SOCKET, SO_ERROR)`.
+    """
+
+  fun ref get_so_rcvbuf(): (U32, U32)
+    """
+    `getsockopt(fd, SOL_SOCKET, SO_RCVBUF)`.
+    """
+
+  fun ref get_so_sndbuf(): (U32, U32)
+    """
+    `getsockopt(fd, SOL_SOCKET, SO_SNDBUF)`.
+    """
+
+  fun ref get_tcp_nodelay(): (U32, U32)
+    """
+    `getsockopt(fd, IPPROTO_TCP, TCP_NODELAY)`.
+    """
+
+  fun ref set_so_rcvbuf(bufsize: U32): U32
+    """
+    `setsockopt(fd, SOL_SOCKET, SO_RCVBUF)`. Returns 0 on success or `errno`.
+    """
+
+  fun ref set_so_sndbuf(bufsize: U32): U32
+    """
+    `setsockopt(fd, SOL_SOCKET, SO_SNDBUF)`. Returns 0 on success or `errno`.
+    """
+
+  fun ref set_tcp_nodelay(state: Bool): U32
+    """
+    `setsockopt(fd, IPPROTO_TCP, TCP_NODELAY)`. Returns 0 on success or `errno`.
+    """

--- a/lori/legacy_tcp_connection_notify.pony
+++ b/lori/legacy_tcp_connection_notify.pony
@@ -1,0 +1,123 @@
+interface LegacyTCPConnectionNotify
+  """
+  Notifications for a `LegacyTCPConnection`.
+
+  This mirrors the standard library `net` package's `TCPConnectionNotify`
+  interface so that code written against the old API can move to lori with
+  small changes. The one required change is the `conn` parameter type: it is
+  `LegacyTCPConnection ref` here, where the stdlib used `TCPConnection ref`.
+
+  For an example of use, see the documentation for `LegacyTCPConnection` and
+  `LegacyTCPListener`.
+  """
+  fun ref accepted(conn: LegacyTCPConnection ref) =>
+    """
+    Called when a connection is accepted by a `LegacyTCPListener`.
+    """
+    None
+
+  fun ref proxy_via(host: String, service: String): (String, String) =>
+    """
+    Called before attempting to connect to the destination server. To connect
+    via a proxy, return the host and service of the proxy server. The default
+    returns the destination unchanged, so no proxy is used.
+    """
+    (host, service)
+
+  fun ref connecting(conn: LegacyTCPConnection ref, count: U32) =>
+    """
+    Called if name resolution succeeded and connection attempts are now in
+    progress. `count` is the number of attempts being tried. Called each time
+    the count changes, until a connection is made or `connect_failed` is
+    called.
+    """
+    None
+
+  fun ref connected(conn: LegacyTCPConnection ref) =>
+    """
+    Called when a connection to the server has succeeded.
+    """
+    None
+
+  fun ref connect_failed(conn: LegacyTCPConnection ref)
+    """
+    Called when every connection attempt has failed. The connection will never
+    be established.
+
+    You must implement error handling. To ignore the failure, provide an empty
+    body:
+
+    ```pony
+    fun ref connect_failed(conn: LegacyTCPConnection ref) =>
+      None
+    ```
+    """
+
+  fun ref auth_failed(conn: LegacyTCPConnection ref) =>
+    """
+    A plaintext connection has no authentication mechanism. When a protocol is
+    wrapped in another (e.g. SSL via `LegacySSLConnection`), this reports an
+    authentication failure in the lower-level protocol.
+    """
+    None
+
+  fun ref sent(conn: LegacyTCPConnection ref, data: ByteSeq): ByteSeq =>
+    """
+    Called when data is sent on the connection via `write`. Return the data to
+    write, or an empty sequence to swallow the send. This is the hook a
+    protocol wrapper (e.g. `LegacySSLConnection`) uses to transform outgoing
+    data.
+    """
+    data
+
+  fun ref sentv(conn: LegacyTCPConnection ref, data: ByteSeqIter): ByteSeqIter
+  =>
+    """
+    Called when several chunks of data are sent in one `writev`. Return the
+    chunks to write, or an empty sequence to swallow the send.
+    """
+    data
+
+  fun ref received(
+    conn: LegacyTCPConnection ref,
+    data: Array[U8] iso,
+    times: USize)
+    : Bool
+  =>
+    """
+    Called when new data arrives on the connection. Return `true` to keep
+    reading, or `false` to yield to other actors now.
+
+    `times` is the number of times `received` has been called since the last
+    yield. It lets the notifier end a run of reads on a regular basis.
+    """
+    true
+
+  fun ref expect(conn: LegacyTCPConnection ref, qty: USize): USize =>
+    """
+    Called when the connection has been told to expect `qty` bytes. A wrapping
+    notifier can change the expected quantity, letting a lower-level protocol
+    handle framing (e.g. SSL).
+    """
+    qty
+
+  fun ref closed(conn: LegacyTCPConnection ref) =>
+    """
+    Called when the connection is closed.
+    """
+    None
+
+  fun ref throttled(conn: LegacyTCPConnection ref) =>
+    """
+    Called when the connection starts experiencing backpressure. Pause calls to
+    `write` and `writev` until `unthrottled` is called. Unlike the standard
+    library, lori does not queue writes made while throttled — they are dropped.
+    """
+    None
+
+  fun ref unthrottled(conn: LegacyTCPConnection ref) =>
+    """
+    Called when backpressure is released. You may resume calling `write` and
+    `writev`.
+    """
+    None

--- a/lori/legacy_tcp_listen_notify.pony
+++ b/lori/legacy_tcp_listen_notify.pony
@@ -1,0 +1,42 @@
+interface LegacyTCPListenNotify
+  """
+  Notifications for a `LegacyTCPListener`.
+
+  This mirrors the standard library `net` package's `TCPListenNotify` interface
+  so that code written against the old API can move to lori with small changes.
+  The parameter types are `LegacyTCPListener` and `LegacyTCPConnectionNotify`
+  where the stdlib used `TCPListener` and `TCPConnectionNotify`.
+
+  For an example of use, see the documentation for `LegacyTCPListener`.
+  """
+  fun ref listening(listen: LegacyTCPListener ref) =>
+    """
+    Called when the listener has been bound to an address.
+    """
+    None
+
+  fun ref not_listening(listen: LegacyTCPListener ref)
+    """
+    Called if the listener could not be bound to an address.
+
+    You must implement error handling. To ignore the failure, provide an empty
+    body:
+
+    ```pony
+    fun ref not_listening(listen: LegacyTCPListener ref) =>
+      None
+    ```
+    """
+
+  fun ref closed(listen: LegacyTCPListener ref) =>
+    """
+    Called when the listener is closed.
+    """
+    None
+
+  fun ref connected(listen: LegacyTCPListener ref)
+    : LegacyTCPConnectionNotify iso^ ?
+    """
+    Create a `LegacyTCPConnectionNotify` for a newly accepted connection. Raise
+    an error to reject the connection.
+    """

--- a/lori/legacy_tcp_listener.pony
+++ b/lori/legacy_tcp_listener.pony
@@ -1,0 +1,111 @@
+use net = "net"
+
+actor LegacyTCPListener is TCPListenerActor
+  """
+  A TCP listener with the shape of the standard library `net` package's
+  `TCPListener`, built on lori. Create one to accept connections:
+
+  ```pony
+  LegacyTCPListener(TCPListenAuth(env.root), MyListenNotify, "", "8989")
+  ```
+
+  For each accepted connection, the `connected` method of the
+  `LegacyTCPListenNotify` you supply returns a `LegacyTCPConnectionNotify` for
+  it. The listener builds the accepted connection and wires the two together.
+  """
+  var _tcp_listener: TCPListener = TCPListener.none()
+  var _notify: LegacyTCPListenNotify
+  let _server_auth: TCPServerAuth
+  let _rbs: USize
+  let _yield_after_reading: USize
+
+  new create(
+    auth: TCPListenAuth,
+    notify: LegacyTCPListenNotify iso,
+    host: String = "",
+    service: String = "0",
+    limit: USize = 0,
+    read_buffer_size: USize = 16384,
+    yield_after_reading: USize = 16384,
+    yield_after_writing: USize = 16384)
+  =>
+    """
+    Listen for both IPv4 and IPv6 connections. `limit` caps concurrent
+    connections; 0 means no limit. `yield_after_writing` is accepted for source
+    compatibility but has no effect (see the package documentation).
+    """
+    _notify = consume notify
+    _server_auth = TCPServerAuth(auth)
+    _rbs = read_buffer_size
+    _yield_after_reading = yield_after_reading
+    _tcp_listener =
+      TCPListener(
+        auth, host, service, this, DualStack, _LegacyMaxSpawn(limit))
+
+  new ip4(
+    auth: TCPListenAuth,
+    notify: LegacyTCPListenNotify iso,
+    host: String = "",
+    service: String = "0",
+    limit: USize = 0,
+    read_buffer_size: USize = 16384,
+    yield_after_reading: USize = 16384,
+    yield_after_writing: USize = 16384)
+  =>
+    """
+    Listen for IPv4 connections.
+    """
+    _notify = consume notify
+    _server_auth = TCPServerAuth(auth)
+    _rbs = read_buffer_size
+    _yield_after_reading = yield_after_reading
+    _tcp_listener =
+      TCPListener(auth, host, service, this, IP4, _LegacyMaxSpawn(limit))
+
+  new ip6(
+    auth: TCPListenAuth,
+    notify: LegacyTCPListenNotify iso,
+    host: String = "",
+    service: String = "0",
+    limit: USize = 0,
+    read_buffer_size: USize = 16384,
+    yield_after_reading: USize = 16384,
+    yield_after_writing: USize = 16384)
+  =>
+    """
+    Listen for IPv6 connections.
+    """
+    _notify = consume notify
+    _server_auth = TCPServerAuth(auth)
+    _rbs = read_buffer_size
+    _yield_after_reading = yield_after_reading
+    _tcp_listener =
+      TCPListener(auth, host, service, this, IP6, _LegacyMaxSpawn(limit))
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  be set_notify(notify: LegacyTCPListenNotify iso) =>
+    """
+    Replace the notifier.
+    """
+    _notify = consume notify
+
+  fun ref local_address(): net.NetAddress =>
+    """
+    The bound local IP address.
+    """
+    _tcp_listener.local_address()
+
+  fun ref _on_accept(fd: U32): TCPConnectionActor ? =>
+    _LegacyServerConnection._accept(
+      _server_auth, _notify.connected(this)?, fd, _rbs, _yield_after_reading)
+
+  fun ref _on_listening() =>
+    _notify.listening(this)
+
+  fun ref _on_listen_failure() =>
+    _notify.not_listening(this)
+
+  fun ref _on_closed() =>
+    _notify.closed(this)

--- a/lori/lori.pony
+++ b/lori/lori.pony
@@ -602,4 +602,55 @@ them to the actors that need them. The echo server example above shows the
 typical pattern: `Main` creates a `TCPListenAuth`, the listener creates a
 `TCPServerAuth` from it, and each accepted connection receives that
 `TCPServerAuth`.
+
+## Legacy stdlib-net API
+
+[`LegacyTCPClient`](/lori/lori-LegacyTCPClient/),
+[`LegacyTCPListener`](/lori/lori-LegacyTCPListener/), and their notifiers
+recreate the standard library `net` package's API on top of lori, to ease
+moving existing `net` code over. The application logic stays in notifier
+objects, as in the stdlib, rather than in your own actor.
+
+```pony
+use "lori"
+
+actor Main
+  new create(env: Env) =>
+    LegacyTCPListener(TCPListenAuth(env.root), MyListenNotify, "", "8989")
+```
+
+`MyListenNotify` implements
+[`LegacyTCPListenNotify`](/lori/lori-LegacyTCPListenNotify/); its `connected`
+returns a [`LegacyTCPConnectionNotify`](/lori/lori-LegacyTCPConnectionNotify/)
+for each accepted connection. A client is a `LegacyTCPClient`. The
+`legacy-echo-server` example shows the full shape.
+
+Moving `net` code over needs a few mechanical changes:
+
+- The notifier's `conn` parameter is `LegacyTCPConnection` (an interface), not
+  `net.TCPConnection`. Change `is TCPConnectionNotify` to
+  `is LegacyTCPConnectionNotify` and the `conn` parameter types with it.
+- Create a client with `LegacyTCPClient(...)` where the stdlib wrote
+  `TCPConnection(...)`.
+- SSL uses [`LegacySSLConnection`](/lori/lori-LegacySSLConnection/), a notifier
+  decorator matching `ssl/net`'s `SSLConnection`; the ALPN hook is
+  [`LegacyALPNProtocolNotify`](/lori/lori-LegacyALPNProtocolNotify/).
+
+A few behaviors differ from the stdlib:
+
+- A `write` or `writev` made while the connection is under backpressure is
+  dropped, not queued. The stdlib buffers such writes and drains them later;
+  lori's `send` does not queue, so a program that writes without waiting for
+  `unthrottled` loses those bytes. Track `throttled`/`unthrottled` and stop
+  writing while throttled.
+- `yield_after_writing` is accepted by the constructors for source
+  compatibility but has no effect. lori's write path has no mid-drain yield for
+  it to drive, and it changes nothing a peer can observe.
+- `received`'s `times` counts calls since the last yield. The stdlib resets it
+  once per read behavior instead.
+- `dispose()` closes gracefully, as the stdlib does. lori's own `dispose` hard
+  closes to avoid the race in issue #229, so the Legacy connections keep the
+  stdlib's graceful close.
+- `read_buffer_size` is a `USize` as in the stdlib, but 0 is replaced by the
+  default rather than producing a zero-length buffer.
 """


### PR DESCRIPTION
In #7 I asked for classes that recreate the standard library net package's API on top of lori, to ease moving code over and to show how lori's pieces compose. This is that, under a Legacy prefix rather than Standalone.

Most of the net API ports cleanly: every notifier callback, write/writev/write_final, mute/unmute, expect and its nested-notifier hook, the socket options, the listener including connected-returns-a-notifier and the connection limit, proxy_via, and SSL through LegacySSLConnection (a retype of ssl/net's SSLConnection decorator).

The one behavior that genuinely can't be reproduced is write buffering under backpressure. net's write queues under backpressure and never drops; lori's send doesn't queue, so code that writes without waiting for unthrottled loses data. The other differences are a mechanical rename (the notifier's conn becomes LegacyTCPConnection, clients are built with LegacyTCPClient), an inert parameter (yield_after_writing), a cosmetic one (where received's times counter resets), and constrained types where net took bare USizes.

The structural cost: net's single TCPConnection actor is the client, the accepted connection, and the notifier's conn type at once. In lori, client and server are two lifecycle traits and a connection matches on which one it holds, so one actor can't fill all three roles. Hence two actors and a LegacyTCPConnection interface for conn.

It builds and is tested, and there's a legacy-echo-server example.

## Open questions

- Backpressure: should Legacy queue writes under backpressure to match net's buffering, or keep the drop (lori's no-queue design) and document it? It drops them now and the docs say so.
- dispose: net's dispose is graceful; lori's own dispose hard-closes on purpose (#230, a missed-FIN hang on POSIX edge-triggered events). Legacy overrides back to graceful to match net. I couldn't reproduce a hang on Linux over ~105 runs; macOS is untested. Keep graceful, or hard-close?

Closes #7
