### PR TITLE
Exit instead of wrapping on an inflight connection count underflow

### DIFF
--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -1706,6 +1706,13 @@ class TCPConnection
     _state = state
 
   fun ref _decrement_inflight(): U32 =>
+    // The count is set to the number of connection attempts started, and one
+    // decrement belongs to each attempt. A decrement at zero is one that
+    // belongs to no attempt.
+    if _inflight_connections == 0 then
+      _Unreachable()
+    end
+
     _inflight_connections = _inflight_connections - 1
     _inflight_connections
 


### PR DESCRIPTION
`_inflight_connections` is a U32 decremented with plain `-`, so a decrement at zero wraps to 4294967295. `_initiate_shutdown` waits for the count to reach zero before sending its FIN, so on a wrapped value a graceful close never sends one and the connection never tears down.

Clamping the decrement at zero would stop the wrap, and would also hide the mismatch between the count and the events that produced it. `_Unreachable()` prints the location and exits the process instead, so if the condition is reachable we find out where.

The condition did not occur on Linux: across the suite the count was never zero at a decrement. The underflow was only reproducible by injecting an event by hand.
