### PR TITLE
TEMP diagnostic: trace the macOS inflight underflow (do not merge)

### DIFF
--- a/lori/_fe_trace.pony
+++ b/lori/_fe_trace.pony
@@ -1,0 +1,38 @@
+primitive _FETrace
+  """
+  Temporary diagnostic. Not for merge.
+  """
+  fun dispatch(state: _ConnectionState box,
+    event: AsioEventID,
+    flags: U32,
+    inflight: U32)
+  =>
+    @fprintf(
+      @pony_os_stderr(),
+      "LORI ev=%p fd=%s flags=%s disposed=%s state=%s inflight=%s\n".cstring(),
+      event,
+      PonyAsio.event_fd(event).string().cstring(),
+      flags.string().cstring(),
+      PonyAsio.get_disposable(event).string().cstring(),
+      name(state).cstring(),
+      inflight.string().cstring())
+
+  fun started(count: U32) =>
+    @fprintf(
+      @pony_os_stderr(),
+      "LORI connect started attempts=%s\n".cstring(),
+      count.string().cstring())
+
+  fun name(state: _ConnectionState box): String =>
+    match state
+    | let _: _ConnectionNone box => "ConnectionNone"
+    | let _: _ClientConnecting box => "ClientConnecting"
+    | let _: _Open box => "Open"
+    | let _: _Closing box => "Closing"
+    | let _: _UnconnectedClosing box => "UnconnectedClosing"
+    | let _: _Closed box => "Closed"
+    | let _: _SSLHandshaking box => "SSLHandshaking"
+    | let _: _TLSUpgrading box => "TLSUpgrading"
+    else
+      "unknown"
+    end

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -1840,6 +1840,7 @@ class TCPConnection
         _event = AsioEvent.none()
       end
     else
+      _FETrace.dispatch(_state, event, flags, _inflight_connections)
       if AsioEvent.disposable(flags) then
         PonyAsio.destroy(event)
       elseif AsioEvent.errored(flags)
@@ -1917,6 +1918,7 @@ class TCPConnection
         PonyTCP.connect(
           e, _host, _port, _from, AsioEvent.read_write_oneshot()
           where ip_version = _ip_version)
+      _FETrace.started(_inflight_connections)
       _had_inflight = _inflight_connections > 0
       if _had_inflight then
         _arm_connect_timer()

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -1706,6 +1706,13 @@ class TCPConnection
     _state = state
 
   fun ref _decrement_inflight(): U32 =>
+    // The count is set to the number of connection attempts started, and one
+    // decrement belongs to each attempt. A decrement at zero is one that
+    // belongs to no attempt.
+    if _inflight_connections == 0 then
+      _Unreachable()
+    end
+
     _inflight_connections = _inflight_connections - 1
     _inflight_connections
 


### PR DESCRIPTION
Diagnostic only — do not merge. Opened to get a macOS CI run.

PR #350 tripped its `_Unreachable()` on macOS in `CloseWhileConnectingWithTimeout`, so `_decrement_inflight` is called more times than there were connection attempts. This branch adds a stderr trace of every non-own event reaching `_event_notify`, logging the event pointer, its fd, the flags, whether the struct is already disposable, the state, and the inflight count — plus the attempt count when the connect is issued.

On Linux the same test logs one readiness message per fd and the count drains 2 to 0 exactly. The macOS log is the comparison.
