### PR TITLE
Fix a file descriptor being closed twice on macOS

### DIFF
--- a/.release-notes/drop-stale-foreign-events.md
+++ b/.release-notes/drop-stale-foreign-events.md
@@ -1,0 +1,7 @@
+## Fix a file descriptor being closed twice on macOS
+
+On macOS, a client connection to a host that resolves to more than one address — `localhost` is one — could close one of its own file descriptors twice while cleaning up the connection attempts it did not use. The operating system can hand that descriptor number to something else in your program in between, and the second close then lands on whatever got it: an unrelated connection or file closes, and nothing reports why.
+
+The same cleanup also miscounted how many connection attempts were still outstanding. That could abandon an attempt that was still running and report the connection as failed, hand `_on_connecting` a count of 4294967295, or leave a connection that was asked to close gracefully never sending its FIN and never finishing.
+
+Linux and Windows were not affected. macOS can deliver two readiness notifications for a single connection attempt where they deliver one, and the second one was being treated as a second attempt.

--- a/.release-notes/drop-stale-foreign-events.md
+++ b/.release-notes/drop-stale-foreign-events.md
@@ -1,7 +1,7 @@
 ## Fix a file descriptor being closed twice on macOS
 
-On macOS, a client connection to a host that resolves to more than one address — `localhost` is one — could close one of its own file descriptors twice while cleaning up the connection attempts it did not use. The operating system can hand that descriptor number to something else in your program in between, and the second close then lands on whatever got it: an unrelated connection or file closes, and nothing reports why.
+On macOS, setting up a client connection could close one of its own file descriptors twice. The operating system can hand that descriptor number to something else in your program in between, and the second close then lands on whatever got it: an unrelated connection or file closes, and nothing reports why. A connection to a host that resolves to more than one address is the likeliest way to hit it — `localhost` is one — but a single-address connection that fails hits it too.
 
-The same cleanup also miscounted how many connection attempts were still outstanding. That could abandon an attempt that was still running and report the connection as failed, hand `_on_connecting` a count of 4294967295, or leave a connection that was asked to close gracefully never sending its FIN and never finishing.
+The same cleanup also miscounted how many connection attempts were still outstanding. That could abandon an attempt that was still running and report the connection as failed, tell `_on_connecting` that fewer attempts were in progress than really were, or leave a connection that was asked to close gracefully never sending its FIN and never finishing.
 
-Linux and Windows were not affected. macOS can deliver two readiness notifications for a single connection attempt where they deliver one, and the second one was being treated as a second attempt.
+Linux and Windows were not affected. macOS can deliver two readiness notifications for a single connection attempt where they deliver one, and the second was being treated as a second attempt.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,11 +81,15 @@ Designs that were tried, or are tempting, and why lori does not use them — the
 
 - **The yield decision is the callback's return value, not a field.** `_on_received` returns `KeepReading` or `YieldReading`, and `_read()` acts on the returned value. An earlier design stored the answer in a `_yield_read` field, which made the one spot where the loop read that field load-bearing. Do not put the decision back in a field.
 
+- **A stale foreign event is dropped once, in `_event_notify`, not in each state.** A readiness message can arrive for an event that has already been unsubscribed, and acting on it decrements the inflight count a second time and closes an fd the OS may have reassigned. The check that drops it belongs at the single point every foreign event passes through. It used to sit in each `foreign_event` instead: eight copies, of which three were dropped because the suite still passed on Linux — where, per Platform differences above, the second message does not exist. That shipped as issue #349, reachable only on macOS.
+
 - **STARTTLS refuses buffered read data (CVE-2021-23222).** `start_tls()` requires the connection open, not already TLS, not muted, no buffered read data, and no pending writes. The no-buffered-data precondition is there for the CVE; do not relax it.
 
 ## Platform differences
 
 POSIX and Windows share one readiness-based I/O path: one-shot readiness events (epoll/kqueue; `ProcessSocketNotifications` on Windows), resubscribe, then a synchronous `PonyTCP.receive`/`sendv`. Windows uses this path because ponyc removed IOCP; the floor is Windows 11 / Windows Server 2022. Two rules stay platform-specific — the vectored-send batch size (`PonyTCP.writev_max()`) and closing a subscribed fd (`_close_event_fd()`, POSIX-only) — both documented at those functions.
+
+How many messages one subscription delivers is platform-specific too, and nothing in lori says so. kqueue arms read and write as separate one-shot filters and sends a message from each, so a single subscribed socket delivers up to two readiness messages; epoll and Windows combine both directions into one. Anything written to run once per subscription runs twice on macOS.
 
 ## Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,8 @@ Windows builds and tests through `make.ps1`, not the Makefile. A build or test c
 
 `TCPConnection` (class) holds all TCP and SSL state and I/O logic and is not an actor. The user writes an actor that implements the `TCPConnectionActor` trait together with one of the two lifecycle-event-receiver traits, `ClientLifecycleEventReceiver` or `ServerLifecycleEventReceiver`, which carry the `_on_*` callbacks. `TCPListener`/`TCPListenerActor` are the same split for the accept side.
 
+A client connect subscribes one socket per resolved address at once (Happy Eyeballs). Whichever connects first becomes the connection's own event; the rest are stragglers, and each has to be unsubscribed and its fd closed when its event arrives. That is why every state handles `own_event` and `foreign_event` separately, and what `_UnconnectedClosing` drains.
+
 ### Connection lifecycle
 
 `TCPConnection` tracks its lifecycle with explicit state objects — the `_ConnectionState` trait and its implementers in `_connection_state.pony` — rather than boolean flags.
@@ -81,7 +83,7 @@ Designs that were tried, or are tempting, and why lori does not use them — the
 
 - **The yield decision is the callback's return value, not a field.** `_on_received` returns `KeepReading` or `YieldReading`, and `_read()` acts on the returned value. An earlier design stored the answer in a `_yield_read` field, which made the one spot where the loop read that field load-bearing. Do not put the decision back in a field.
 
-- **A stale foreign event is dropped once, in `_event_notify`, not in each state.** A readiness message can arrive for an event that has already been unsubscribed, and acting on it decrements the inflight count a second time and closes an fd the OS may have reassigned. The check that drops it belongs at the single point every foreign event passes through. It used to sit in each `foreign_event` instead: eight copies, of which three were dropped because the suite still passed on Linux — where, per Platform differences above, the second message does not exist. That shipped as issue #349, reachable only on macOS.
+- **A stale foreign event is dropped once, in `_event_notify`, not in each state.** The check used to sit in each `foreign_event` instead: eight copies, three of which were removed because the suite still passed on Linux, where the second message does not arrive. That shipped as issue #349, and only macOS reaches it. Do not push the check back down into the states.
 
 - **STARTTLS refuses buffered read data (CVE-2021-23222).** `start_tls()` requires the connection open, not already TLS, not muted, no buffered read data, and no pending writes. The no-buffered-data precondition is there for the CVE; do not relax it.
 
@@ -89,7 +91,7 @@ Designs that were tried, or are tempting, and why lori does not use them — the
 
 POSIX and Windows share one readiness-based I/O path: one-shot readiness events (epoll/kqueue; `ProcessSocketNotifications` on Windows), resubscribe, then a synchronous `PonyTCP.receive`/`sendv`. Windows uses this path because ponyc removed IOCP; the floor is Windows 11 / Windows Server 2022. Two rules stay platform-specific — the vectored-send batch size (`PonyTCP.writev_max()`) and closing a subscribed fd (`_close_event_fd()`, POSIX-only) — both documented at those functions.
 
-How many messages one subscription delivers is platform-specific too, and nothing in lori says so. kqueue arms read and write as separate one-shot filters and sends a message from each, so a single subscribed socket delivers up to two readiness messages; epoll and Windows combine both directions into one. Anything written to run once per subscription runs twice on macOS.
+How many messages one subscription delivers is platform-specific too, and nothing in lori says so. kqueue arms read and write as separate one-shot filters and sends a message from each (ponyc's `kqueue.c`), so a single subscribed socket can deliver two readiness messages; epoll and Windows combine both directions into one (`epoll.c`, `sock_notify.c`). Code written on the assumption of one message per subscription is wrong on macOS.
 
 ## Conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,7 +83,7 @@ Designs that were tried, or are tempting, and why lori does not use them — the
 
 - **The yield decision is the callback's return value, not a field.** `_on_received` returns `KeepReading` or `YieldReading`, and `_read()` acts on the returned value. An earlier design stored the answer in a `_yield_read` field, which made the one spot where the loop read that field load-bearing. Do not put the decision back in a field.
 
-- **A stale foreign event is dropped once, in `_event_notify`, not in each state.** The check used to sit in each `foreign_event` instead: eight copies, three of which were removed because the suite still passed on Linux, where the second message does not arrive. That shipped as issue #349, and only macOS reaches it. Do not push the check back down into the states.
+- **A stale foreign event is dropped once, in `_event_notify`, not in each state.** The check used to sit in each `foreign_event` instead. Three of those copies were removed because the suite still passed on Linux, where the second message does not arrive, and that shipped as issue #349 — reachable only where kqueue is the backend. Do not push the check back down into the states.
 
 - **STARTTLS refuses buffered read data (CVE-2021-23222).** `start_tls()` requires the connection open, not already TLS, not muted, no buffered read data, and no pending writes. The no-buffered-data precondition is there for the CVE; do not relax it.
 
@@ -91,7 +91,7 @@ Designs that were tried, or are tempting, and why lori does not use them — the
 
 POSIX and Windows share one readiness-based I/O path: one-shot readiness events (epoll/kqueue; `ProcessSocketNotifications` on Windows), resubscribe, then a synchronous `PonyTCP.receive`/`sendv`. Windows uses this path because ponyc removed IOCP; the floor is Windows 11 / Windows Server 2022. Two rules stay platform-specific — the vectored-send batch size (`PonyTCP.writev_max()`) and closing a subscribed fd (`_close_event_fd()`, POSIX-only) — both documented at those functions.
 
-How many messages one subscription delivers is platform-specific too, and nothing in lori says so. kqueue arms read and write as separate one-shot filters and sends a message from each (ponyc's `kqueue.c`), so a single subscribed socket can deliver two readiness messages; epoll and Windows combine both directions into one (`epoll.c`, `sock_notify.c`). Code written on the assumption of one message per subscription is wrong on macOS.
+How many messages one subscription delivers is platform-specific too. kqueue arms read and write as separate one-shot filters and sends a message from each (ponyc's `kqueue.c`), so a single subscribed socket can deliver two readiness messages; epoll and Windows combine both directions into one (`epoll.c`, `sock_notify.c`). Code written on the assumption of one message per subscription is wrong wherever kqueue is the backend — macOS is the one CI covers, but the BSDs use it too.
 
 ## Conventions
 

--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -159,10 +159,8 @@ class _ConnectionNone is _ConnectionState
       return
     end
 
-    // The message flags and the event struct's disposable status can
-    // disagree: a stale message may carry writeable/readable flags while
-    // the event struct has already been marked disposable by a prior
-    // unsubscribe. Check the struct before unsubscribing.
+    // `unsubscribe` on an event that is already unsubscribed trips a runtime
+    // assertion, so check before calling it.
     if not PonyAsio.get_disposable(event) then
       PonyAsio.unsubscribe(event)
     end
@@ -388,8 +386,6 @@ class _Open is _ConnectionState
     event: AsioEventID,
     flags: U32)
   =>
-    // Removing this guard causes the test suite to hang.
-    if PonyAsio.get_disposable(event) then return end
     if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags)
       or AsioEvent.readable(flags))
     then
@@ -498,8 +494,6 @@ class _Closing is _ConnectionState
     event: AsioEventID,
     flags: U32)
   =>
-    // Removing this guard causes the test suite to hang.
-    if PonyAsio.get_disposable(event) then return end
     if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags)
       or AsioEvent.readable(flags))
     then
@@ -831,8 +825,6 @@ class _SSLHandshaking is _ConnectionState
     event: AsioEventID,
     flags: U32)
   =>
-    // Removing this guard causes the test suite to hang.
-    if PonyAsio.get_disposable(event) then return end
     if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags)
       or AsioEvent.readable(flags))
     then
@@ -950,8 +942,6 @@ class _TLSUpgrading is _ConnectionState
     event: AsioEventID,
     flags: U32)
   =>
-    // Removing this guard causes the test suite to hang.
-    if PonyAsio.get_disposable(event) then return end
     if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags)
       or AsioEvent.readable(flags))
     then

--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -159,11 +159,7 @@ class _ConnectionNone is _ConnectionState
       return
     end
 
-    // `unsubscribe` on an event that is already unsubscribed trips a runtime
-    // assertion, so check before calling it.
-    if not PonyAsio.get_disposable(event) then
-      PonyAsio.unsubscribe(event)
-    end
+    PonyAsio.unsubscribe(event)
     conn._close_event_fd(PonyAsio.event_fd(event))
 
   fun ref send(conn: TCPConnection ref,

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -109,6 +109,7 @@ actor \nodoc\ Main is TestList
     // POSIX only: these provoke write backpressure with a fixed payload, which
     // Windows loopback won't trigger (it buffers far beyond SO_SNDBUF/RCVBUF).
     // The drain and write-only re-arm logic they cover is platform-neutral.
+    ifdef posix then test(_TestStaleForeignEventDropped) end
     ifdef posix then test(_TestBackpressureDrain) end
     ifdef posix then test(_TestWriteOnlyEventReadRecovery) end
     ifdef posix then test(_TestSendPerTokenCompletion) end

--- a/lori/_test_stale_foreign_event.pony
+++ b/lori/_test_stale_foreign_event.pony
@@ -1,0 +1,93 @@
+use "pony_test"
+
+use @socket[I32](domain: I32, sock_type: I32, protocol: I32)
+
+class \nodoc\ iso _TestStaleForeignEventDropped is UnitTest
+  """
+  A readiness message can arrive for a connection attempt's event after that
+  event has been unsubscribed. Acting on it decrements the inflight count for
+  an attempt already counted, and once that count has gone below zero a
+  graceful close never sends its FIN. Deliver one and check the close still
+  completes.
+  """
+  fun name(): String => "StaleForeignEventDropped"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("closed")
+
+    let listener = _TestStaleForeignEventListener(h)
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestStaleForeignEventClient
+  is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_connection =
+      TCPConnection.client(
+        TCPConnectAuth(_h.env.root),
+        "127.0.0.1",
+        "7931",
+        "",
+        this,
+        this where ip_version = IP4)
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _deliver_stale_event()
+
+  be _deliver_stale_event() =>
+    // One address, so the attempt that connected took the inflight count to
+    // zero on its way in. A second message for it arrives here.
+    //
+    // The socket is one this test owns: a regression cleans the event up a
+    // second time, and the fd it closes should be ours rather than whatever
+    // the runtime has open.
+    let fd = @socket(I32(2), I32(1), I32(0))
+    let event = PonyAsio.create_event(this, fd.u32())
+    PonyAsio.unsubscribe(event)
+
+    _tcp_connection._event_notify(event, AsioEvent.read_write())
+    _tcp_connection.close()
+
+  fun ref _on_closed() =>
+    _h.complete_action("closed")
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    _h.fail("client could not connect")
+    _h.complete(false)
+
+actor \nodoc\ _TestStaleForeignEventListener is TCPListenerActor
+  var _tcp_listener: TCPListener = TCPListener.none()
+  let _h: TestHelper
+  var _client: (_TestStaleForeignEventClient | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_listener =
+      TCPListener(
+        TCPListenAuth(_h.env.root),
+        "127.0.0.1",
+        "7931",
+        this where ip_version = IP4)
+
+  fun ref _listener(): TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestDoNothingServerActor =>
+    _TestDoNothingServerActor(fd, _h)
+
+  fun ref _on_closed() =>
+    try (_client as _TestStaleForeignEventClient).dispose() end
+
+  fun ref _on_listening() =>
+    _client = _TestStaleForeignEventClient(_h)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Unable to open _TestStaleForeignEventListener")

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -1773,15 +1773,11 @@ class TCPConnection
   fun ref _connecting_event_failed(event: AsioEventID, fd: U32) =>
     """
     Called by _ClientConnecting when a Happy Eyeballs connection attempt
-    fails. Closes the fd and fires the connecting callback. Only
-    unsubscribes if the event hasn't already been unsubscribed — on
-    non-Windows systems, a race can cause the event to already be
-    disposable by the time we process it (see stdlib TCPConnection).
+    fails. Unsubscribes the event, closes the fd, and fires the connecting
+    callback.
     """
-    // The message flags and the event struct's disposable status can
-    // disagree: a stale message may carry writeable/readable flags while
-    // the event struct has already been marked disposable by a prior
-    // unsubscribe. Check the struct before unsubscribing.
+    // `unsubscribe` on an event that is already unsubscribed trips a runtime
+    // assertion, so check before calling it.
     if not PonyAsio.get_disposable(event) then
       PonyAsio.unsubscribe(event)
     end
@@ -1791,13 +1787,11 @@ class TCPConnection
   fun ref _straggler_cleanup(event: AsioEventID) =>
     """
     Clean up a Happy Eyeballs straggler event after the winner has been
-    chosen. Unsubscribes (if not already disposable) and closes the fd.
-    Does NOT decrement _inflight_connections — caller handles that.
+    chosen. Unsubscribes the event and closes the fd. Does NOT decrement
+    _inflight_connections — caller handles that.
     """
-    // The message flags and the event struct's disposable status can
-    // disagree: a stale message may carry writeable/readable flags while
-    // the event struct has already been marked disposable by a prior
-    // unsubscribe. Check the struct before unsubscribing.
+    // `unsubscribe` on an event that is already unsubscribed trips a runtime
+    // assertion, so check before calling it.
     if not PonyAsio.get_disposable(event) then
       PonyAsio.unsubscribe(event)
     end
@@ -1805,9 +1799,7 @@ class TCPConnection
 
   fun ref _event_notify(event: AsioEventID, flags: U32) =>
     // Explicit dispatch on event identity. Timer identity checks must come
-    // before `event is _event`. The else branch checks disposable first
-    // (stale timer disposables, straggler disposables), otherwise dispatches
-    // to foreign_event for Happy Eyeballs stragglers.
+    // before `event is _event`.
     if event is _connect_timer_event then
       if AsioEvent.errored(flags) then
         _fire_connect_timer_error()
@@ -1835,15 +1827,16 @@ class TCPConnection
     else
       if AsioEvent.disposable(flags) then
         PonyAsio.destroy(event)
-      elseif AsioEvent.errored(flags)
-        and PonyAsio.get_disposable(event)
-      then
-        // Stale errored event from a cancelled timer. The timer was
-        // unsubscribed (marking the event struct disposable) before
-        // the errored notification was processed. Destroy it here to
-        // prevent it from reaching foreign_event, where it would be
-        // misidentified as a Happy Eyeballs straggler.
-        PonyAsio.destroy(event)
+      elseif PonyAsio.get_disposable(event) then
+        // The message and the event struct disagree: this carries live flags
+        // for an event that has already been unsubscribed. Whatever the
+        // message is for was done when the event was unsubscribed, so there is
+        // nothing left to act on, and acting anyway means a second cleanup of
+        // an fd the OS may have reassigned and a second decrement of the
+        // inflight count. Drop it rather than destroy it -- the unsubscribe
+        // sends a disposable notification of its own, and that one frees the
+        // struct.
+        None
       else
         _state.foreign_event(this, event, flags)
       end

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -1776,11 +1776,7 @@ class TCPConnection
     fails. Unsubscribes the event, closes the fd, and fires the connecting
     callback.
     """
-    // `unsubscribe` on an event that is already unsubscribed trips a runtime
-    // assertion, so check before calling it.
-    if not PonyAsio.get_disposable(event) then
-      PonyAsio.unsubscribe(event)
-    end
+    PonyAsio.unsubscribe(event)
     _close_event_fd(fd)
     _connecting_callback()
 
@@ -1790,11 +1786,7 @@ class TCPConnection
     chosen. Unsubscribes the event and closes the fd. Does NOT decrement
     _inflight_connections — caller handles that.
     """
-    // `unsubscribe` on an event that is already unsubscribed trips a runtime
-    // assertion, so check before calling it.
-    if not PonyAsio.get_disposable(event) then
-      PonyAsio.unsubscribe(event)
-    end
+    PonyAsio.unsubscribe(event)
     _close_event_fd(PonyAsio.event_fd(event))
 
   fun ref _event_notify(event: AsioEventID, flags: U32) =>


### PR DESCRIPTION
On macOS, kqueue arms read and write as separate one-shot filters and sends a message from each, so one connection attempt delivers two readiness messages where epoll and Windows deliver one. The second arrives after the first was handled and its event unsubscribed. Acting on it cleans the straggler up a second time — closing an fd the OS may have reassigned — and decrements the inflight count for an attempt already counted.

The check that drops such a message was written into each `foreign_event`, and three of the eight copies had been removed on the grounds that the suite still passed. It passes on Linux either way, because epoll never delivers a second message. `_event_notify` is the one point every foreign event passes through, so the check covers every state from there and there is one copy to keep right.

It drops rather than destroys: the unsubscribe sends a disposable notification of its own, and that is what frees the struct.

Confirmed on macOS CI, which captured the same event pointer and fd delivering `flags=3` then `flags=1` with the struct already disposable, then the `flags=0` disposal notification last.
