### PR TITLE
Cut what AGENTS.md was repeating from the code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ```
 make ssl=3.0.x                       # build + run unit tests (test is the default target)
-make test-one t=TestName ssl=3.0.x   # run a single test by name
+make test-one t=TestName ssl=3.0.x   # run one test, by its name() string
 make ci ssl=3.0.x                    # unit tests + build examples + build stress tests
 make examples ssl=3.0.x              # build all examples
 make stress-tests ssl=3.0.x          # build stress tests
@@ -50,24 +50,28 @@ A client connect subscribes one socket per resolved address at once (Happy Eyeba
 `TCPConnection` tracks its lifecycle with explicit state objects — the `_ConnectionState` trait and its implementers in `_connection_state.pony` — rather than boolean flags.
 
 ```
-_ConnectionNone → _ClientConnecting → _Open → _Closing → _Closed
-                                    ↘ _Closed (hard_close)
-_ClientConnecting → _SSLHandshaking → _Open (ssl_handshake_complete)
-                                    ↘ _Closed (hard_close / SSL error)
-_ClientConnecting → _UnconnectedClosing → _Closed (close, drain stragglers)
-_ClientConnecting → _Closed (hard_close / all connections failed)
-_ConnectionNone → _Open (server, plaintext) → _Closing → _Closed
-_ConnectionNone → _SSLHandshaking (server, SSL) → _Open (ssl_handshake_complete)
-_ConnectionNone → _Closed (SSL session creation failed)
-_Open → _TLSUpgrading (start_tls) → _Open (ssl_handshake_complete)
-                                   ↘ _Closed (hard_close / TLS error)
+_ConnectionNone     → _ClientConnecting
+                    → _Open              (server, plaintext)
+                    → _SSLHandshaking    (server, SSL)
+                    → _Closed            (SSL session creation failed)
+_ClientConnecting   → _Open              (connected, plaintext)
+                    → _SSLHandshaking    (connected, SSL)
+                    → _UnconnectedClosing (close, drain stragglers)
+                    → _Closed            (hard_close / all attempts failed)
+_SSLHandshaking     → _Open              (ssl_handshake_complete)
+                    → _Closed            (hard_close / SSL error)
+_Open               → _Closing           (close)
+                    → _TLSUpgrading      (start_tls)
+                    → _Closed            (hard_close)
+_TLSUpgrading       → _Open              (ssl_handshake_complete)
+                    → _Closed            (hard_close / TLS error)
+_Closing            → _Closed            (drained, or hard_close)
+_UnconnectedClosing → _Closed            (drained, or hard_close)
 ```
 
 Design: Discussion #219.
 
 ## Traps
-
-Designs that were tried, or are tempting, and why lori does not use them — the one thing the code cannot tell you, because it only records what it does now.
 
 - **One read loop; keep `_on_received` out of `_ssl_poll()`.** An earlier design had `_ssl_poll()` deliver application data from a second loop of its own, so mute and the liveness check had to be written twice. Both shipped as bugs before the second copy existed: the liveness check as a segfault (PR #311), mute as issue #313.
 
@@ -89,10 +93,9 @@ How many messages one subscription delivers is platform-specific too. kqueue arm
 
 ## Conventions
 
-- Follows the [Pony standard library Style Guide](https://github.com/ponylang/ponyc/blob/main/STYLE_GUIDE.md).
 - `_Unreachable()` in a branch the compiler cannot prove impossible, rather than an empty `else`.
-- A test listener must keep a reference to every actor it creates in `_on_accept`/`_on_listening` and dispose each one in `_on_closed`. The runtime will not exit while actors hold live I/O resources, so a missed dispose hangs CI (macOS especially).
-- Each test uses its own hardcoded port.
+- The runtime will not exit while an actor holds a live I/O resource, so a test has to dispose any actor that might still hold one when it ends, or CI hangs (macOS especially). That is the client a listener creates in `_on_listening`: keep a reference and dispose it in `_on_closed`. An actor returned from `_on_accept` releases its fd when its peer closes, so it needs no reference.
+- Each test uses its own hardcoded port. Grep `lori/_test_*.pony` for a free one.
 - `\nodoc\` on test classes.
 - A new test goes in the `_test_*.pony` file for its functional area, registered in `Main.tests()` in `_test.pony`, which holds only the test runner.
 - Each example has a file-level docstring saying what it demonstrates, uses the Listener/Server/Client actor structure, and uses a unique port. Adding one means adding it to `examples/README.md`, which is ordered simplest first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,8 +43,6 @@ Windows builds and tests through `make.ps1`, not the Makefile. A build or test c
 
 ## Architecture
 
-`TCPConnection` (class) holds all TCP and SSL state and I/O logic and is not an actor. The user writes an actor that implements the `TCPConnectionActor` trait together with one of the two lifecycle-event-receiver traits, `ClientLifecycleEventReceiver` or `ServerLifecycleEventReceiver`, which carry the `_on_*` callbacks. `TCPListener`/`TCPListenerActor` are the same split for the accept side.
-
 A client connect subscribes one socket per resolved address at once (Happy Eyeballs). Whichever connects first becomes the connection's own event; the rest are stragglers, and each has to be unsubscribed and its fd closed when its event arrives. That is why every state handles `own_event` and `foreign_event` separately, and what `_UnconnectedClosing` drains.
 
 ### Connection lifecycle
@@ -71,25 +69,21 @@ Design: Discussion #219.
 
 Designs that were tried, or are tempting, and why lori does not use them — the one thing the code cannot tell you, because it only records what it does now.
 
-- **One read loop; keep `_on_received` out of `_ssl_poll()`.** Application data reaches the application from the single `_read()` loop and nowhere else, so mute and liveness are decided in one place. An earlier design had `_ssl_poll()` deliver from a second loop of its own, so each control had to be written twice — and two shipped as bugs before the second copy existed: the liveness check (segfault, PR #311) and mute (issue #313). `_ssl_poll()` flushes protocol output; it does not deliver.
+- **One read loop; keep `_on_received` out of `_ssl_poll()`.** An earlier design had `_ssl_poll()` deliver application data from a second loop of its own, so mute and the liveness check had to be written twice. Both shipped as bugs before the second copy existed: the liveness check as a segfault (PR #311), mute as issue #313.
 
-- **`_ssl` is a `_TLSState`, not `(SSL | None)`.** Its four variants — `_NoTLS`, `_TLS`, `_TLSDisposed`, `_TLSFailed` — separate "is this TLS?" from "may I use the session?", which an `Option` cannot: with the field cleared, `_next_message()` and `_fill()` take their plaintext branches and hand the application ciphertext; with it kept, `match` binds a disposed session behind what looks like a guard. That ambiguity was PR #311's segfault. Dispose only through `_dispose_tls()`, which disposes and moves to `_TLSDisposed` in one step — disposing without moving leaves `_TLS` binding a dead session.
+- **`_ssl` is a `_TLSState`, not `(SSL | None)`.** `(SSL | None)` was the earlier design. It records whether a session exists but not whether one may be used, and that ambiguity was PR #311's segfault.
 
-- **Mint the send token before the flush, and hand it over in the gap.** `_do_send` mints the `SendToken` and queues it before flushing, so every accepted send gets one terminal callback (`_on_sent` or `_on_send_failed`) whatever the flush does — and the flush can close the connection. Minting after the flush loses the callback for a send whose bytes the flush already wrote. `_on_send_accepted` fires in the gap between the mint and the flush, which is what lets `_on_sent` be a direct call: the application holds the token before the flush can deliver it. That is also why `send()` returns `SendAccepted` and not the token. Every error return stays upstream of the mint, so an errored send burns no token id.
+- **Mint the send token before the flush.** The flush can close the connection, so a token minted after it loses the terminal callback for a send whose bytes already went out. It is also why `send()` returns `SendAccepted` rather than the token: `_on_sent` is a direct call, so the application has to be holding the token before the flush runs (PR #346). Keep every error return upstream of the mint, so an errored send burns no token id.
 
-- **`_on_send_failed` is deferred; `_on_sent` is not.** `_on_send_failed` is the one callback the connection queues through a behavior rather than calling directly. A failed send and the close it belongs to are one event, and `_on_closed` has to come first; the behavior hop is how that ordering is achieved. `_on_sent` was deferred for the same-looking reason and it was wrong: a send reaching the OS is its own event, and queueing it let callbacks for later events overtake it (issue #345).
+- **`_on_send_failed` is deferred; `_on_sent` is not.** `_on_sent` was deferred too, for the same-looking reason, and it was wrong: a send reaching the OS is its own event, and queueing it let callbacks for later events overtake it (issue #345).
 
-- **The hard-close reason is the `_HardCloseCause` argument, not a field.** `_hard_close(cause)` carries why the close happened. An earlier design set one of three fields (`_connect_timed_out` and the like) right before an argumentless `hard_close()` and dug it back out after. Do not add a fourth field, and do not push the no-distinguishing-cause case out to a `None` beside the type — `_UnspecifiedCause` is a real variant, so every hard-close path can match the cause in full.
-
-- **The yield decision is the callback's return value, not a field.** `_on_received` returns `KeepReading` or `YieldReading`, and `_read()` acts on the returned value. An earlier design stored the answer in a `_yield_read` field, which made the one spot where the loop read that field load-bearing. Do not put the decision back in a field.
+- **The hard-close reason is the `_HardCloseCause` argument, not a field.** An earlier design set one of three fields (`_connect_timed_out` and the like) right before an argumentless `hard_close()` and dug it back out after. Do not put it back in a field.
 
 - **A stale foreign event is dropped once, in `_event_notify`, not in each state.** The check used to sit in each `foreign_event` instead. Three of those copies were removed because the suite still passed on Linux, where the second message does not arrive, and that shipped as issue #349 — reachable only where kqueue is the backend. Do not push the check back down into the states.
 
-- **STARTTLS refuses buffered read data (CVE-2021-23222).** `start_tls()` requires the connection open, not already TLS, not muted, no buffered read data, and no pending writes. The no-buffered-data precondition is there for the CVE; do not relax it.
-
 ## Platform differences
 
-POSIX and Windows share one readiness-based I/O path: one-shot readiness events (epoll/kqueue; `ProcessSocketNotifications` on Windows), resubscribe, then a synchronous `PonyTCP.receive`/`sendv`. Windows uses this path because ponyc removed IOCP; the floor is Windows 11 / Windows Server 2022. Two rules stay platform-specific — the vectored-send batch size (`PonyTCP.writev_max()`) and closing a subscribed fd (`_close_event_fd()`, POSIX-only) — both documented at those functions.
+POSIX and Windows share one readiness-based I/O path: one-shot readiness events (epoll/kqueue; `ProcessSocketNotifications` on Windows), resubscribe, then a synchronous `PonyTCP.receive`/`sendv`. Windows uses this path because ponyc removed IOCP; the floor is Windows 11 / Windows Server 2022.
 
 How many messages one subscription delivers is platform-specific too. kqueue arms read and write as separate one-shot filters and sends a message from each (ponyc's `kqueue.c`), so a single subscribed socket can deliver two readiness messages; epoll and Windows combine both directions into one (`epoll.c`, `sock_notify.c`). Code written on the assumption of one message per subscription is wrong wherever kqueue is the backend — macOS is the one CI covers, but the BSDs use it too.
 
@@ -101,4 +95,4 @@ How many messages one subscription delivers is platform-specific too. kqueue arm
 - Each test uses its own hardcoded port.
 - `\nodoc\` on test classes.
 - A new test goes in the `_test_*.pony` file for its functional area, registered in `Main.tests()` in `_test.pony`, which holds only the test runner.
-- Each example has a file-level docstring saying what it demonstrates, uses the Listener/Server/Client actor structure, and uses a unique port.
+- Each example has a file-level docstring saying what it demonstrates, uses the Listener/Server/Client actor structure, and uses a unique port. Adding one means adding it to `examples/README.md`, which is ordered simplest first.

--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -134,7 +134,7 @@ trait _ConnectionState
     """
     Has a socket fd it can still do I/O on -- from the handshake through a
     graceful close still draining, but not before the fd exists or after a hard
-    close tears it down. See the state table in AGENTS.md.
+    close tears it down. See the lifecycle diagram in AGENTS.md.
     """
 
   fun receive(event: AsioEventID,


### PR DESCRIPTION
Two cold readers were given the repository and the file and asked, per section, to name the one thing in the code it is about, and whether reading it in AGENTS.md beats reading that thing.

Most of what went was a second copy of prose already sitting at the line an agent changing it would be reading: `_ssl_poll`'s docstring says it does not deliver, `_tls_state.pony` argues the four-variant type, `read_action.pony` owns the yield design, `start_tls`'s docstring lists every precondition and names CVE-2021-23222. Each trap keeps the design that was tried and the bug it shipped as, which nothing in the code records. The yield and STARTTLS bullets went entirely — the first records a preference rather than a bug, the second is its method's docstring verbatim.

Two things were wrong rather than redundant. The lifecycle diagram encoded a branch's source in how far its arrow was indented, and the indentation did not decode: one branch repeated a line further down, and `_Open → _Closed (hard_close)` was missing. And the dispose convention claimed a test must keep and dispose every actor it creates in `_on_accept` and `_on_listening`; most `_on_accept` bodies keep nothing, nothing cascades dispose from the listener, and an accepted actor releases its fd when its peer closes.

The rest is subtractive: the Architecture paragraph restated the opening sentence and listed two traits the package docstring covers; Platform differences closed by naming two functions and saying both were documented at those functions, which was also wrong, since `tcp_listener.pony` closes a subscribed fd inline; the Style Guide line named a file whose whole content is that sentence.

Added where a reader actually fumbled: what a straggler is, that `t=` takes the `name()` string, and to grep for a free port. `is_live()`'s docstring pointed at a state table in AGENTS.md that does not exist.

The `<!-- contributor-only -->` block is untouched.
