### PR TITLE
Assert _ConnectionNone.foreign_event is unreachable

### DIFF
--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -153,14 +153,7 @@ class _ConnectionNone is _ConnectionState
     event: AsioEventID,
     flags: U32)
   =>
-    if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags)
-      or AsioEvent.readable(flags))
-    then
-      return
-    end
-
-    PonyAsio.unsubscribe(event)
-    conn._close_event_fd(PonyAsio.event_fd(event))
+    _Unreachable()
 
   fun ref send(conn: TCPConnection ref,
     data: (ByteSeq | ByteSeqIter)): SendResult


### PR DESCRIPTION
`_ConnectionNone.foreign_event` unsubscribed an event and closed an fd. It cannot run.

For it to run, an ASIO event has to reach the connection while it is still in `_ConnectionNone`, and none exists that early. A client sets `_ClientConnecting` before `PonyTCP.connect` creates any socket. A server does create one first, but that happens inside `_finish_initialization`, and a behavior runs to completion before the actor takes its next message, so there is no gap to deliver into. Nothing anywhere sets the state back to `_ConnectionNone`.

`own_event` in the same class already asserts this, and it is the method such an event would reach, since it would be the connection's own. Every other method in the class is `_Unreachable()` too.

The body was added in a315e6c, replacing an `_Unreachable()`. Neither that commit message nor PR #249 gives a reason.
