### PR TITLE
Update deploy-pages from v4 to v5

### DIFF
--- a/.github/workflows/generate-documentation.yml
+++ b/.github/workflows/generate-documentation.yml
@@ -39,4 +39,4 @@ jobs:
           path: 'build/lori-docs/site/'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
           path: 'build/lori-docs/site/'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   trigger-release-announcement:
     name: Trigger release announcement


### PR DESCRIPTION
deploy-pages v4 uses a Node.js version that is now out of date. v5 updates to a supported Node.js version.