### PR TITLE
Remove is_open() from TCPConnection

### DIFF
--- a/.release-notes/remove-is-open.md
+++ b/.release-notes/remove-is-open.md
@@ -1,0 +1,21 @@
+## Remove is_open() from TCPConnection
+
+`is_open()` has been removed from `TCPConnection`. Code that queried connection state before acting should instead call the operation directly and handle the result.
+
+Before:
+
+```pony
+if _tcp_connection.is_open() then
+  _tcp_connection.send(data)
+end
+```
+
+After:
+
+```pony
+match _tcp_connection.send(data)
+| SendAccepted => // sent
+| SendErrorNotConnected => // not connected or closed
+| SendErrorNotWriteable => // backpressure
+end
+```

--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -108,16 +108,17 @@ trait _ConnectionState
     Set or clear the idle timeout; states differ in whether they arm it.
     """
 
+  fun ref fire_idle_timeout(conn: TCPConnection ref)
+    """
+    The idle timer fired. Dispatch the callback and re-arm if this state
+    should keep the timer running.
+    """
+
   fun ref set_timer(conn: TCPConnection ref,
     duration: TimerDuration)
     : (TimerToken | SetTimerError)
     """
     Start a user timer, or return why it can't be started in this state.
-    """
-
-  fun is_open(): Bool
-    """
-    The connection is open for application I/O (`_Open`/`_TLSUpgrading`).
     """
 
   fun is_closed(): Bool
@@ -128,13 +129,6 @@ trait _ConnectionState
   fun sends_allowed(): Bool
     """
     Sends are accepted in this state.
-    """
-
-  fun is_live(): Bool
-    """
-    Has a socket fd it can still do I/O on -- from the handshake through a
-    graceful close still draining, but not before the fd exists or after a hard
-    close tears it down. See the lifecycle diagram in AGENTS.md.
     """
 
   fun receive(event: AsioEventID,
@@ -230,15 +224,16 @@ class _ConnectionNone is _ConnectionState
   =>
     conn._store_idle_timeout(duration)
 
+  fun ref fire_idle_timeout(conn: TCPConnection ref) =>
+    conn._dispatch_idle_timeout()
+
   fun ref set_timer(conn: TCPConnection ref,
     duration: TimerDuration): (TimerToken | SetTimerError)
   =>
     SetTimerNotOpen
 
-  fun is_open(): Bool => false
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
-  fun is_live(): Bool => false
 
   fun receive(event: AsioEventID,
     buffer: Pointer[U8] tag,
@@ -349,15 +344,16 @@ class _ClientConnecting is _ConnectionState
   =>
     conn._store_idle_timeout(duration)
 
+  fun ref fire_idle_timeout(conn: TCPConnection ref) =>
+    conn._dispatch_idle_timeout()
+
   fun ref set_timer(conn: TCPConnection ref,
     duration: TimerDuration): (TimerToken | SetTimerError)
   =>
     SetTimerNotOpen
 
-  fun is_open(): Bool => false
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
-  fun is_live(): Bool => false
 
   fun receive(event: AsioEventID,
     buffer: Pointer[U8] tag,
@@ -394,6 +390,7 @@ class _Open is _ConnectionState
 
   fun ref close(conn: TCPConnection ref) =>
     conn._set_state(_Closing)
+    conn._cancel_idle_timer()
     conn._mark_close_notify_pending()
     conn._initiate_shutdown()
 
@@ -457,15 +454,17 @@ class _Open is _ConnectionState
   =>
     conn._do_idle_timeout(duration)
 
+  fun ref fire_idle_timeout(conn: TCPConnection ref) =>
+    conn._dispatch_idle_timeout()
+    conn._rearm_idle_timer_if_configured()
+
   fun ref set_timer(conn: TCPConnection ref,
     duration: TimerDuration): (TimerToken | SetTimerError)
   =>
     conn._do_set_timer(duration)
 
-  fun is_open(): Bool => true
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => true
-  fun is_live(): Bool => true
 
   fun receive(event: AsioEventID,
     buffer: Pointer[U8] tag,
@@ -567,15 +566,16 @@ class _Closing is _ConnectionState
   =>
     conn._store_idle_timeout(duration)
 
+  fun ref fire_idle_timeout(conn: TCPConnection ref) =>
+    conn._dispatch_idle_timeout()
+
   fun ref set_timer(conn: TCPConnection ref,
     duration: TimerDuration): (TimerToken | SetTimerError)
   =>
     SetTimerNotOpen
 
-  fun is_open(): Bool => false
   fun is_closed(): Bool => true
   fun sends_allowed(): Bool => false
-  fun is_live(): Bool => true
 
   fun receive(event: AsioEventID,
     buffer: Pointer[U8] tag,
@@ -680,15 +680,16 @@ class _UnconnectedClosing is _ConnectionState
   =>
     conn._store_idle_timeout(duration)
 
+  fun ref fire_idle_timeout(conn: TCPConnection ref) =>
+    conn._dispatch_idle_timeout()
+
   fun ref set_timer(conn: TCPConnection ref,
     duration: TimerDuration): (TimerToken | SetTimerError)
   =>
     SetTimerNotOpen
 
-  fun is_open(): Bool => false
   fun is_closed(): Bool => true
   fun sends_allowed(): Bool => false
-  fun is_live(): Bool => false
 
   fun receive(event: AsioEventID,
     buffer: Pointer[U8] tag,
@@ -784,22 +785,22 @@ class _Closed is _ConnectionState
   =>
     conn._store_idle_timeout(duration)
 
+  fun ref fire_idle_timeout(conn: TCPConnection ref) =>
+    conn._dispatch_idle_timeout()
+
   fun ref set_timer(conn: TCPConnection ref,
     duration: TimerDuration): (TimerToken | SetTimerError)
   =>
     SetTimerNotOpen
 
-  fun is_open(): Bool => false
   fun is_closed(): Bool => true
   fun sends_allowed(): Bool => false
-  fun is_live(): Bool => false
 
   fun receive(event: AsioEventID,
     buffer: Pointer[U8] tag,
     size: USize)
     : (SocketResult, USize)
   =>
-    _Unreachable()
     (SocketResultError, 0)
 
 class _SSLHandshaking is _ConnectionState
@@ -902,15 +903,16 @@ class _SSLHandshaking is _ConnectionState
   =>
     conn._store_idle_timeout(duration)
 
+  fun ref fire_idle_timeout(conn: TCPConnection ref) =>
+    conn._dispatch_idle_timeout()
+
   fun ref set_timer(conn: TCPConnection ref,
     duration: TimerDuration): (TimerToken | SetTimerError)
   =>
     SetTimerNotOpen
 
-  fun is_open(): Bool => false
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
-  fun is_live(): Bool => true
 
   fun receive(event: AsioEventID,
     buffer: Pointer[U8] tag,
@@ -1015,15 +1017,17 @@ class _TLSUpgrading is _ConnectionState
   =>
     conn._do_idle_timeout(duration)
 
+  fun ref fire_idle_timeout(conn: TCPConnection ref) =>
+    conn._dispatch_idle_timeout()
+    conn._rearm_idle_timer_if_configured()
+
   fun ref set_timer(conn: TCPConnection ref,
     duration: TimerDuration): (TimerToken | SetTimerError)
   =>
     conn._do_set_timer(duration)
 
-  fun is_open(): Bool => true
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
-  fun is_live(): Bool => true
 
   fun receive(event: AsioEventID,
     buffer: Pointer[U8] tag,

--- a/lori/_test_connection.pony
+++ b/lori/_test_connection.pony
@@ -513,8 +513,7 @@ class \nodoc\ iso _TestHardCloseAfterFramedReceive is UnitTest
   With `buffer_until` framing, `_read`'s inner loop hands over one frame at a
   time from a single buffered read. A `hard_close()` in the first frame's
   `_on_received` transitions the connection to `_Closed`; the loop must stop
-  rather than deliver the buffered second frame after `_on_closed` fired. The
-  close is unmuted, so `is_live()` — not `_muted` — is what has to stop it.
+  rather than deliver the buffered second frame after `_on_closed` fired.
   The delivery count is checked in a self-behavior that runs after `_read`
   returns, so a regression fails with a clear assertion, not a process exit.
 

--- a/lori/_test_ssl.pony
+++ b/lori/_test_ssl.pony
@@ -566,8 +566,7 @@ actor \nodoc\ _TestSSLHandshakeFailurePlainClient
 
 class \nodoc\ iso _TestSSLHandshakeCompleteTransitionsToOpen is UnitTest
   """
-  Test that after a successful SSL handshake, the connection is in _Open
-  state: is_open() returns true and send() returns SendAccepted.
+  Test that after a successful SSL handshake, the connection accepts sends.
   """
   fun name(): String => "SSLHandshakeCompleteTransitionsToOpen"
 
@@ -586,7 +585,6 @@ class \nodoc\ iso _TestSSLHandshakeCompleteTransitionsToOpen is UnitTest
           .> set_server_verify(false)
       end
 
-    h.expect_action("is_open verified")
     h.expect_action("send accepted")
 
     let listener =
@@ -650,9 +648,6 @@ actor \nodoc\ _TestSSLTransitionToOpenClient
     _tcp_connection
 
   fun ref _on_connected() =>
-    _h.assert_true(_tcp_connection.is_open(), "is_open should be true")
-    _h.complete_action("is_open verified")
-
     match \exhaustive\ _tcp_connection.send("test")
     | SendAccepted =>
       _h.complete_action("send accepted")
@@ -1183,10 +1178,6 @@ class \nodoc\ iso _TestSSLCloseDuringReceive is UnitTest
   keeps delivering. close() moves to `_Closing`, which still receives and
   does not dispose the SSL session, so the rest of the decrypted records from
   the same read are delivered.
-
-  This is the other side of `_TestSSLHardCloseDuringReceive`, and it is what
-  makes `is_live()` the right predicate to bound `_read()`'s loop:
-  `is_open()` and `is_closed()` both stop delivery here, and both are wrong.
   """
   fun name(): String => "SSLCloseDuringReceive"
 

--- a/lori/_test_timer.pony
+++ b/lori/_test_timer.pony
@@ -950,7 +950,7 @@ actor \nodoc\ _TestTimerSetDuringClosingServer
 
   fun ref _on_started() =>
     _tcp_connection.close()
-    // Now in _Closing — is_open() returns false
+    // Now in _Closing
     match \exhaustive\ MakeTimerDuration(1_000)
     | let d: TimerDuration =>
       match \exhaustive\ _tcp_connection.set_timer(d)
@@ -1044,7 +1044,7 @@ actor \nodoc\ _TestSetTimerNotOpenSSLClient
           this
           where connection_timeout = ct)
       // Try to set a timer before _finish_initialization runs.
-      // The state is still _ConnectionNone (is_open() is false).
+      // The state is still _ConnectionNone.
       match \exhaustive\ MakeTimerDuration(1_000)
       | let d: TimerDuration =>
         match \exhaustive\ _tcp_connection.set_timer(d)
@@ -1233,7 +1233,7 @@ actor \nodoc\ _TestSetTimerNotOpenSSLServerConn
         this,
         this)
     // Try to set a timer before _finish_initialization runs.
-    // The state is still _ConnectionNone (is_open() is false).
+    // The state is still _ConnectionNone.
     match \exhaustive\ MakeTimerDuration(1_000)
     | let d: TimerDuration =>
       match \exhaustive\ _tcp_connection.set_timer(d)

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -332,9 +332,7 @@ class TCPConnection
     is `None`, the idle timeout is disabled.
 
     The timer re-arms after each firing while the connection is open.
-    `hard_close()` cancels it. A graceful `close()` does not, so
-    `_on_idle_timeout` can still arrive on a closing connection that is moving
-    bytes.
+    Both `hard_close()` and `close()` cancel it.
 
     Can be called before the connection is established — the value is
     stored and the timer starts when the connection is ready.
@@ -657,6 +655,7 @@ class TCPConnection
     PonyAsio.unsubscribe(_event)
     _set_unreadable()
     _set_unwriteable()
+    _bytes_in_read_buffer = 0
     _throttled = false
     _close_notify_pending = false
 
@@ -816,9 +815,6 @@ class TCPConnection
     end
 
     _spawner_notification()
-
-  fun is_open(): Bool =>
-    _state.is_open()
 
   fun is_closed(): Bool =>
     """
@@ -996,10 +992,6 @@ class TCPConnection
     `_close_notify_then_shutdown()` sends the alert when the write queue
     drains, then calls back into this method for FIN.
     """
-    if not _state.is_live() then
-      return
-    end
-
     if _shutdown
       or (_inflight_connections > 0)
       or _has_pending_writes()
@@ -1022,11 +1014,9 @@ class TCPConnection
     flush are separate steps because `_do_send` records a send's completion
     offset between them; `_send_pending_writes()` is the flush.
 
-    Uses `not is_closed()` rather than `is_open()` because
-    `_ssl_enqueue_sends()` calls `_enqueue()` during `_SSLHandshaking` (where
-    `is_open() = false`) to push handshake protocol data. The wider guard
-    allows handshake data through while still blocking enqueue after the
-    connection closes.
+    `_ssl_enqueue_sends()` calls this during `_SSLHandshaking` to push
+    handshake protocol data, so the guard is `is_closed()` — not
+    `sends_allowed()`, which is false during the handshake.
     """
     if data.size() == 0 then return end
     if not is_closed() then
@@ -1151,8 +1141,8 @@ class TCPConnection
     The next message for the application, or `None` when there isn't one.
 
     Returns a value; it never calls the application. That is what keeps `mute`
-    and `is_live` in `_read()`'s loop and out of here — code that hands over
-    control needs those guards, code that hands back a value does not.
+    in `_read()`'s loop and out of here — code that hands over control needs
+    that guard, code that hands back a value does not.
 
     For an SSL connection the messages come from the SSL session, which frames
     them itself. Otherwise they are chopped off the read buffer.
@@ -1161,9 +1151,6 @@ class TCPConnection
     | let tls: _TLS =>
       tls.session.read(_user_buffer_until())
     | _TLSDisposed | _TLSFailed =>
-      // `_read()`'s loop stops on `is_live()` before it gets here, and a
-      // connection whose session never existed never opened.
-      _Unreachable()
       None
     | _NoTLS =>
       if not _there_is_buffered_read_data() then
@@ -1233,22 +1220,6 @@ class TCPConnection
         var total_bytes_read: USize = 0
 
         while _readable do
-          // `_on_received` can mute us or hard_close us, and either takes
-          // effect before the next message is taken or the socket is touched.
-          // The `_ssl_flush_sends()` below writes protocol output, which
-          // carries no send token, so `_on_throttled` is the callback it can
-          // run. That can do the same, so both controls are re-checked after
-          // it.
-          //
-          // `is_live()` is about the socket: `_fill()` must not read an fd
-          // a `hard_close()` has released. The SSL session guards itself — a
-          // `hard_close()` moves `_ssl` to `_TLSDisposed`, which no match
-          // binds. A graceful `close()` stays live, so reading
-          // continues there to pick up the peer's FIN.
-          if not _state.is_live() then
-            return
-          end
-
           if _muted then
             // Mute stops reading. It does not hold the write side, so protocol
             // output `ssl.read()` queued still goes out; a mute lasts as long
@@ -1274,7 +1245,7 @@ class TCPConnection
               hard_close()
             else
               close()
-              if _state.is_live() then
+              if not PonyAsio.get_disposable(_event) then
                 _set_unreadable()
                 PonyAsio.resubscribe_read(_event)
               end
@@ -1293,10 +1264,7 @@ class TCPConnection
             // peer waiting on the output would otherwise wedge. No-op on a
             // plaintext connection.
             _ssl_flush_sends()
-            if (not _state.is_live()) or _muted then
-              // The flush can hard_close on a write error, and it can raise
-              // backpressure, so `_on_throttled` runs here and the application
-              // can hard_close or mute from it.
+            if _muted then
               return
             end
 
@@ -1519,21 +1487,18 @@ class TCPConnection
     end
 
   fun ref _fire_idle_timeout() =>
-    """
-    Dispatch _on_idle_timeout to the lifecycle event receiver, then re-arm
-    the timer if the connection is still open and the timeout is still
-    configured.
+    _state.fire_idle_timeout(this)
 
-    Not the only thing that arms it: `_reset_idle_timer()` re-arms an
-    already-fired timer on any I/O, in any state.
-    """
+  fun ref _dispatch_idle_timeout() =>
     match \exhaustive\ _lifecycle_event_receiver
     | let s: EitherLifecycleEventReceiver ref =>
       s._on_idle_timeout()
     | None =>
       _Unreachable()
     end
-    if is_open() and (_idle_timeout_nsec > 0) then
+
+  fun ref _rearm_idle_timer_if_configured() =>
+    if _idle_timeout_nsec > 0 then
       _reset_idle_timer()
     end
 
@@ -1762,11 +1727,8 @@ class TCPConnection
     // Mirror for the write side: a readable event drops the write interest, and
     // a read that mutes or yields before EAGAIN never re-arms it, so a
     // backpressured write wedges. Re-arm it, guarded by `_throttled`.
-    // `is_live()` (was `is_open()`) covers `_Closing`, which now drains queued
-    // writes before it closes. Do not weaken; see #294, #296.
-    if _throttled and _state.is_live()
-      and not PonyAsio.get_disposable(_event)
-    then
+    // Do not weaken; see #294, #296.
+    if _throttled and not PonyAsio.get_disposable(_event) then
       PonyAsio.resubscribe_write(_event)
     end
 
@@ -1808,14 +1770,6 @@ class TCPConnection
       | let c: ClientLifecycleEventReceiver ref =>
         c._on_connected()
       end
-    end
-
-    // The flush above can hard_close on a write error, and `_on_connected` can
-    // hard_close from the application. If either did, the fd is gone and there
-    // is nothing to read or drain. A graceful `close()` stays live and falls
-    // through, so its drain and FIN read still happen.
-    if not _state.is_live() then
-      return
     end
 
     _read()
@@ -2011,15 +1965,6 @@ class TCPConnection
         s._on_started()
       end
 
-      // The flush above can hard_close on a write error, and `_on_started` can
-      // hard_close from the application. If either did, the fd is gone. A
-      // graceful `close()` stays live and falls through.
-      if not _state.is_live() then
-        return
-      end
-
-      // Queue up reads as we are now connected
-      // But might have been in a race with ASIO
       _queue_read()
     | None =>
       _Unreachable()


### PR DESCRIPTION
Replace `is_open()` and `is_live()` with state-driven behavior: states decide what to do, callers don't query and branch.

The idle timer is the visible change — `fire_idle_timeout` on the state trait lets `_Open` and `_TLSUpgrading` re-arm while other states don't, instead of a central method checking `is_open()`. `close()` now cancels the idle timer (`hard_close` already did).

Removing `is_live()` required making the operations it guarded safe to call in any state. `_Closed.receive()` returns an error instead of crashing; `_next_message()` returns `None` when the TLS session is disposed; `_hard_close_cleanup()` clears the read buffer so `_dispatch_io_event`'s readable branch can't deliver buffered data after `_on_closed`.

Closes #308
