### PR TITLE
Make TCPConnection and TCPListener generic over TCP operations

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -20,3 +20,25 @@ match _tcp_connection.send(data)
 end
 ```
 
+## Make TCPConnection and TCPListener generic over TCPBackend
+
+`TCPConnection`, `TCPListener`, and the related actor and lifecycle receiver traits now take a type parameter `TCP: TCPBackend val = RuntimeBackend`. The default means existing code compiles unchanged — bare `TCPConnection` and `TCPListener` resolve to the `RuntimeBackend` instantiation without a type argument.
+
+`TCPBackend` is a public trait. A test fake that implements it can drive the connection state machine without real sockets. Pony fully reifies generics, so each instantiation compiles to direct calls with no runtime dispatch overhead.
+
+## Rename PonyTCP to RuntimeBackend
+
+`PonyTCP` has been renamed to `RuntimeBackend`. Code that references `PonyTCP` by name should use `RuntimeBackend` instead.
+
+Before:
+
+```pony
+PonyTCP.writev_max()
+```
+
+After:
+
+```pony
+RuntimeBackend.writev_max()
+```
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,7 @@ Design: Discussion #219.
 
 ## Platform differences
 
-POSIX and Windows share one readiness-based I/O path: one-shot readiness events (epoll/kqueue; `ProcessSocketNotifications` on Windows), resubscribe, then a synchronous `PonyTCP.receive`/`sendv`. Windows uses this path because ponyc removed IOCP; the floor is Windows 11 / Windows Server 2022.
+POSIX and Windows share one readiness-based I/O path: one-shot readiness events (epoll/kqueue; `ProcessSocketNotifications` on Windows), resubscribe, then a synchronous `RuntimeBackend.receive`/`sendv`. Windows uses this path because ponyc removed IOCP; the floor is Windows 11 / Windows Server 2022.
 
 How many messages one subscription delivers is platform-specific too. kqueue arms read and write as separate one-shot filters and sends a message from each (ponyc's `kqueue.c`), so a single subscribed socket can deliver two readiness messages; epoll and Windows combine both directions into one (`epoll.c`, `sock_notify.c`). Code written on the assumption of one message per subscription is wrong wherever kqueue is the backend — macOS is the one CI covers, but the BSDs use it too.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes to this project will be documented in this file. This projec
 ### Changed
 
 - Remove is_open() from TCPConnection ([PR #365](https://github.com/ponylang/lori/pull/365))
+- Make TCPConnection and TCPListener generic over TCPBackend ([PR #366](https://github.com/ponylang/lori/pull/366))
+- Rename PonyTCP to RuntimeBackend ([PR #366](https://github.com/ponylang/lori/pull/366))
 
 ## [0.18.1] - 2026-08-06
 

--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -1,17 +1,17 @@
 use "ssl/net"
 
-trait _ConnectionState
+trait _ConnectionState[TCP: TCPBackend val]
   """
   One state in the connection lifecycle. `TCPConnection._state` holds the
   current one, and lifecycle-gated operations dispatch through it: each state
   answers what happens in it, and delegates the actual work to `TCPConnection`.
   """
-  fun ref own_event(conn: TCPConnection ref, flags: U32)
+  fun ref own_event(conn: TCPConnection[TCP] ref, flags: U32)
     """
     Handle an ASIO event for this connection's own socket event.
     """
 
-  fun ref foreign_event(conn: TCPConnection ref,
+  fun ref foreign_event(conn: TCPConnection[TCP] ref,
     event: AsioEventID,
     flags: U32)
     """
@@ -19,31 +19,31 @@ trait _ConnectionState
     Eyeballs straggler).
     """
 
-  fun ref send(conn: TCPConnection ref,
+  fun ref send(conn: TCPConnection[TCP] ref,
     data: (ByteSeq | ByteSeqIter))
     : SendResult
     """
     Send data, or return why it can't be sent in this state.
     """
 
-  fun ref drained(conn: TCPConnection ref)
+  fun ref drained(conn: TCPConnection[TCP] ref)
     """
     The pending write queue is empty. A state that defers work until then
     does it here, and re-checks anything it depends on: an application
     callback can run between the queue emptying and this call.
     """
 
-  fun ref close(conn: TCPConnection ref)
+  fun ref close(conn: TCPConnection[TCP] ref)
     """
     Graceful close from this state.
     """
 
-  fun ref hard_close(conn: TCPConnection ref, cause: _HardCloseCause)
+  fun ref hard_close(conn: TCPConnection[TCP] ref, cause: _HardCloseCause)
     """
     Non-graceful close from this state, routing `cause` to a failure callback.
     """
 
-  fun ref start_tls(conn: TCPConnection ref,
+  fun ref start_tls(conn: TCPConnection[TCP] ref,
     ssl_ctx: SSLContext val,
     host: String)
     : (None | StartTLSError)
@@ -51,23 +51,23 @@ trait _ConnectionState
     Upgrade to TLS, or return why it can't happen in this state.
     """
 
-  fun ref read_again(conn: TCPConnection ref)
+  fun ref read_again(conn: TCPConnection[TCP] ref)
     """
     Resume reading after a yield, if this state still reads.
     """
 
-  fun ref ssl_handshake_complete(conn: TCPConnection ref,
-    s: EitherLifecycleEventReceiver ref)
+  fun ref ssl_handshake_complete(conn: TCPConnection[TCP] ref,
+    s: EitherLifecycleEventReceiver[TCP] ref)
     """
     The SSL session reached `SSLReady`. Only the handshake states act.
     """
 
-  fun keepalive(conn: TCPConnection box, secs: U32)
+  fun keepalive(conn: TCPConnection[TCP] box, secs: U32)
     """
     Set TCP keepalive, if the socket is open in this state.
     """
 
-  fun getsockopt(conn: TCPConnection box,
+  fun getsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option_max_size: USize)
@@ -76,7 +76,7 @@ trait _ConnectionState
     Raw `getsockopt`, or an error value if not open in this state.
     """
 
-  fun getsockopt_u32(conn: TCPConnection box,
+  fun getsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32)
     : (U32, U32)
@@ -84,7 +84,7 @@ trait _ConnectionState
     `getsockopt` for a U32, or an error value if not open in this state.
     """
 
-  fun setsockopt(conn: TCPConnection box,
+  fun setsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: Array[U8])
@@ -93,7 +93,7 @@ trait _ConnectionState
     Raw `setsockopt`, or an error value if not open in this state.
     """
 
-  fun setsockopt_u32(conn: TCPConnection box,
+  fun setsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: U32)
@@ -102,19 +102,19 @@ trait _ConnectionState
     `setsockopt` for a U32, or an error value if not open in this state.
     """
 
-  fun ref idle_timeout(conn: TCPConnection ref,
+  fun ref idle_timeout(conn: TCPConnection[TCP] ref,
     duration: (IdleTimeout | None))
     """
     Set or clear the idle timeout; states differ in whether they arm it.
     """
 
-  fun ref fire_idle_timeout(conn: TCPConnection ref)
+  fun ref fire_idle_timeout(conn: TCPConnection[TCP] ref)
     """
     The idle timer fired. Dispatch the callback and re-arm if this state
     should keep the timer running.
     """
 
-  fun ref set_timer(conn: TCPConnection ref,
+  fun ref set_timer(conn: TCPConnection[TCP] ref,
     duration: TimerDuration)
     : (TimerToken | SetTimerError)
     """
@@ -131,7 +131,8 @@ trait _ConnectionState
     Sends are accepted in this state.
     """
 
-  fun receive(event: AsioEventID,
+  fun receive(conn: TCPConnection[TCP] box,
+    event: AsioEventID,
     buffer: Pointer[U8] tag,
     size: USize)
     : (SocketResult, USize)
@@ -139,29 +140,29 @@ trait _ConnectionState
     Read from the socket. Only states that can receive perform it.
     """
 
-class _ConnectionNone is _ConnectionState
-  fun ref own_event(conn: TCPConnection ref, flags: U32) =>
+class _ConnectionNone[TCP: TCPBackend val] is _ConnectionState[TCP]
+  fun ref own_event(conn: TCPConnection[TCP] ref, flags: U32) =>
     _Unreachable()
 
-  fun ref foreign_event(conn: TCPConnection ref,
+  fun ref foreign_event(conn: TCPConnection[TCP] ref,
     event: AsioEventID,
     flags: U32)
   =>
     _Unreachable()
 
-  fun ref send(conn: TCPConnection ref,
+  fun ref send(conn: TCPConnection[TCP] ref,
     data: (ByteSeq | ByteSeqIter)): SendResult
   =>
     _Unreachable()
     SendErrorNotConnected
 
-  fun ref drained(conn: TCPConnection ref) =>
+  fun ref drained(conn: TCPConnection[TCP] ref) =>
     _Unreachable()
 
-  fun ref close(conn: TCPConnection ref) =>
+  fun ref close(conn: TCPConnection[TCP] ref) =>
     _Unreachable()
 
-  fun ref hard_close(conn: TCPConnection ref,
+  fun ref hard_close(conn: TCPConnection[TCP] ref,
     cause: _HardCloseCause)
   =>
     // _finish_initialization is a self→self message queued during the
@@ -170,7 +171,7 @@ class _ConnectionNone is _ConnectionState
     // but possible.
     None
 
-  fun ref start_tls(conn: TCPConnection ref,
+  fun ref start_tls(conn: TCPConnection[TCP] ref,
     ssl_ctx: SSLContext val,
     host: String)
     : (None | StartTLSError)
@@ -178,17 +179,17 @@ class _ConnectionNone is _ConnectionState
     _Unreachable()
     StartTLSNotConnected
 
-  fun ref read_again(conn: TCPConnection ref) =>
+  fun ref read_again(conn: TCPConnection[TCP] ref) =>
     _Unreachable()
 
-  fun ref ssl_handshake_complete(conn: TCPConnection ref,
-    s: EitherLifecycleEventReceiver ref)
+  fun ref ssl_handshake_complete(conn: TCPConnection[TCP] ref,
+    s: EitherLifecycleEventReceiver[TCP] ref)
   =>
     _Unreachable()
 
-  fun keepalive(conn: TCPConnection box, secs: U32) => None
+  fun keepalive(conn: TCPConnection[TCP] box, secs: U32) => None
 
-  fun getsockopt(conn: TCPConnection box,
+  fun getsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option_max_size: USize)
@@ -196,14 +197,14 @@ class _ConnectionNone is _ConnectionState
   =>
     (1, recover Array[U8] end)
 
-  fun getsockopt_u32(conn: TCPConnection box,
+  fun getsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32)
     : (U32, U32)
   =>
     (1, 0)
 
-  fun setsockopt(conn: TCPConnection box,
+  fun setsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: Array[U8])
@@ -211,7 +212,7 @@ class _ConnectionNone is _ConnectionState
   =>
     1
 
-  fun setsockopt_u32(conn: TCPConnection box,
+  fun setsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: U32)
@@ -219,15 +220,15 @@ class _ConnectionNone is _ConnectionState
   =>
     1
 
-  fun ref idle_timeout(conn: TCPConnection ref,
+  fun ref idle_timeout(conn: TCPConnection[TCP] ref,
     duration: (IdleTimeout | None))
   =>
     conn._store_idle_timeout(duration)
 
-  fun ref fire_idle_timeout(conn: TCPConnection ref) =>
+  fun ref fire_idle_timeout(conn: TCPConnection[TCP] ref) =>
     conn._dispatch_idle_timeout()
 
-  fun ref set_timer(conn: TCPConnection ref,
+  fun ref set_timer(conn: TCPConnection[TCP] ref,
     duration: TimerDuration): (TimerToken | SetTimerError)
   =>
     SetTimerNotOpen
@@ -235,7 +236,8 @@ class _ConnectionNone is _ConnectionState
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
 
-  fun receive(event: AsioEventID,
+  fun receive(conn: TCPConnection[TCP] box,
+    event: AsioEventID,
     buffer: Pointer[U8] tag,
     size: USize)
     : (SocketResult, USize)
@@ -243,11 +245,11 @@ class _ConnectionNone is _ConnectionState
     _Unreachable()
     (SocketResultError, 0)
 
-class _ClientConnecting is _ConnectionState
-  fun ref own_event(conn: TCPConnection ref, flags: U32) =>
+class _ClientConnecting[TCP: TCPBackend val] is _ConnectionState[TCP]
+  fun ref own_event(conn: TCPConnection[TCP] ref, flags: U32) =>
     _Unreachable()
 
-  fun ref foreign_event(conn: TCPConnection ref,
+  fun ref foreign_event(conn: TCPConnection[TCP] ref,
     event: AsioEventID,
     flags: U32)
   =>
@@ -275,40 +277,40 @@ class _ClientConnecting is _ConnectionState
       conn._connecting_event_failed(event, fd)
     end
 
-  fun ref send(conn: TCPConnection ref,
+  fun ref send(conn: TCPConnection[TCP] ref,
     data: (ByteSeq | ByteSeqIter)): SendResult
   =>
     SendErrorNotConnected
 
-  fun ref drained(conn: TCPConnection ref) =>
+  fun ref drained(conn: TCPConnection[TCP] ref) =>
     _Unreachable()
 
-  fun ref close(conn: TCPConnection ref) =>
-    conn._set_state(_UnconnectedClosing)
+  fun ref close(conn: TCPConnection[TCP] ref) =>
+    conn._set_state(_UnconnectedClosing[TCP])
 
-  fun ref hard_close(conn: TCPConnection ref,
+  fun ref hard_close(conn: TCPConnection[TCP] ref,
     cause: _HardCloseCause)
   =>
     conn._hard_close_connecting(cause)
 
-  fun ref start_tls(conn: TCPConnection ref,
+  fun ref start_tls(conn: TCPConnection[TCP] ref,
     ssl_ctx: SSLContext val,
     host: String)
     : (None | StartTLSError)
   =>
     StartTLSNotConnected
 
-  fun ref read_again(conn: TCPConnection ref) =>
+  fun ref read_again(conn: TCPConnection[TCP] ref) =>
     None
 
-  fun ref ssl_handshake_complete(conn: TCPConnection ref,
-    s: EitherLifecycleEventReceiver ref)
+  fun ref ssl_handshake_complete(conn: TCPConnection[TCP] ref,
+    s: EitherLifecycleEventReceiver[TCP] ref)
   =>
     _Unreachable()
 
-  fun keepalive(conn: TCPConnection box, secs: U32) => None
+  fun keepalive(conn: TCPConnection[TCP] box, secs: U32) => None
 
-  fun getsockopt(conn: TCPConnection box,
+  fun getsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option_max_size: USize)
@@ -316,14 +318,14 @@ class _ClientConnecting is _ConnectionState
   =>
     (1, recover Array[U8] end)
 
-  fun getsockopt_u32(conn: TCPConnection box,
+  fun getsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32)
     : (U32, U32)
   =>
     (1, 0)
 
-  fun setsockopt(conn: TCPConnection box,
+  fun setsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: Array[U8])
@@ -331,7 +333,7 @@ class _ClientConnecting is _ConnectionState
   =>
     1
 
-  fun setsockopt_u32(conn: TCPConnection box,
+  fun setsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: U32)
@@ -339,15 +341,15 @@ class _ClientConnecting is _ConnectionState
   =>
     1
 
-  fun ref idle_timeout(conn: TCPConnection ref,
+  fun ref idle_timeout(conn: TCPConnection[TCP] ref,
     duration: (IdleTimeout | None))
   =>
     conn._store_idle_timeout(duration)
 
-  fun ref fire_idle_timeout(conn: TCPConnection ref) =>
+  fun ref fire_idle_timeout(conn: TCPConnection[TCP] ref) =>
     conn._dispatch_idle_timeout()
 
-  fun ref set_timer(conn: TCPConnection ref,
+  fun ref set_timer(conn: TCPConnection[TCP] ref,
     duration: TimerDuration): (TimerToken | SetTimerError)
   =>
     SetTimerNotOpen
@@ -355,7 +357,8 @@ class _ClientConnecting is _ConnectionState
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
 
-  fun receive(event: AsioEventID,
+  fun receive(conn: TCPConnection[TCP] box,
+    event: AsioEventID,
     buffer: Pointer[U8] tag,
     size: USize)
     : (SocketResult, USize)
@@ -363,11 +366,11 @@ class _ClientConnecting is _ConnectionState
     _Unreachable()
     (SocketResultError, 0)
 
-class _Open is _ConnectionState
-  fun ref own_event(conn: TCPConnection ref, flags: U32) =>
+class _Open[TCP: TCPBackend val] is _ConnectionState[TCP]
+  fun ref own_event(conn: TCPConnection[TCP] ref, flags: U32) =>
     conn._dispatch_io_event(flags)
 
-  fun ref foreign_event(conn: TCPConnection ref,
+  fun ref foreign_event(conn: TCPConnection[TCP] ref,
     event: AsioEventID,
     flags: U32)
   =>
@@ -381,44 +384,44 @@ class _Open is _ConnectionState
     conn._decrement_inflight()
     conn._straggler_cleanup(event)
 
-  fun ref send(conn: TCPConnection ref,
+  fun ref send(conn: TCPConnection[TCP] ref,
     data: (ByteSeq | ByteSeqIter)): SendResult
   =>
     conn._do_send(data)
 
-  fun ref drained(conn: TCPConnection ref) => None
+  fun ref drained(conn: TCPConnection[TCP] ref) => None
 
-  fun ref close(conn: TCPConnection ref) =>
-    conn._set_state(_Closing)
+  fun ref close(conn: TCPConnection[TCP] ref) =>
+    conn._set_state(_Closing[TCP])
     conn._cancel_idle_timer()
     conn._mark_close_notify_pending()
     conn._initiate_shutdown()
 
-  fun ref hard_close(conn: TCPConnection ref,
+  fun ref hard_close(conn: TCPConnection[TCP] ref,
     cause: _HardCloseCause)
   =>
     conn._hard_close_connected()
 
-  fun ref start_tls(conn: TCPConnection ref,
+  fun ref start_tls(conn: TCPConnection[TCP] ref,
     ssl_ctx: SSLContext val,
     host: String)
     : (None | StartTLSError)
   =>
     conn._do_start_tls(ssl_ctx, host)
 
-  fun ref read_again(conn: TCPConnection ref) =>
+  fun ref read_again(conn: TCPConnection[TCP] ref) =>
     conn._do_read_again()
 
-  fun ref ssl_handshake_complete(conn: TCPConnection ref,
-    s: EitherLifecycleEventReceiver ref)
+  fun ref ssl_handshake_complete(conn: TCPConnection[TCP] ref,
+    s: EitherLifecycleEventReceiver[TCP] ref)
   =>
     // Already open: the handshake completed on the way in.
     None
 
-  fun keepalive(conn: TCPConnection box, secs: U32) =>
+  fun keepalive(conn: TCPConnection[TCP] box, secs: U32) =>
     conn._do_keepalive(secs)
 
-  fun getsockopt(conn: TCPConnection box,
+  fun getsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option_max_size: USize)
@@ -426,14 +429,14 @@ class _Open is _ConnectionState
   =>
     conn._do_getsockopt(level, option_name, option_max_size)
 
-  fun getsockopt_u32(conn: TCPConnection box,
+  fun getsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32)
     : (U32, U32)
   =>
     conn._do_getsockopt_u32(level, option_name)
 
-  fun setsockopt(conn: TCPConnection box,
+  fun setsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: Array[U8])
@@ -441,7 +444,7 @@ class _Open is _ConnectionState
   =>
     conn._do_setsockopt(level, option_name, option)
 
-  fun setsockopt_u32(conn: TCPConnection box,
+  fun setsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: U32)
@@ -449,16 +452,16 @@ class _Open is _ConnectionState
   =>
     conn._do_setsockopt_u32(level, option_name, option)
 
-  fun ref idle_timeout(conn: TCPConnection ref,
+  fun ref idle_timeout(conn: TCPConnection[TCP] ref,
     duration: (IdleTimeout | None))
   =>
     conn._do_idle_timeout(duration)
 
-  fun ref fire_idle_timeout(conn: TCPConnection ref) =>
+  fun ref fire_idle_timeout(conn: TCPConnection[TCP] ref) =>
     conn._dispatch_idle_timeout()
     conn._rearm_idle_timer_if_configured()
 
-  fun ref set_timer(conn: TCPConnection ref,
+  fun ref set_timer(conn: TCPConnection[TCP] ref,
     duration: TimerDuration): (TimerToken | SetTimerError)
   =>
     conn._do_set_timer(duration)
@@ -466,20 +469,21 @@ class _Open is _ConnectionState
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => true
 
-  fun receive(event: AsioEventID,
+  fun receive(conn: TCPConnection[TCP] box,
+    event: AsioEventID,
     buffer: Pointer[U8] tag,
     size: USize)
     : (SocketResult, USize)
   =>
-    PonyTCP.receive(event, buffer, size)
+    conn._tcp_ops().receive(event, buffer, size)
 
-class _Closing is _ConnectionState
-  fun ref own_event(conn: TCPConnection ref, flags: U32) =>
+class _Closing[TCP: TCPBackend val] is _ConnectionState[TCP]
+  fun ref own_event(conn: TCPConnection[TCP] ref, flags: U32) =>
     // No trailing `_initiate_shutdown()`: the FIN waits on the write queue
     // emptying, and `drained` is where that becomes true.
     conn._dispatch_io_event(flags)
 
-  fun ref foreign_event(conn: TCPConnection ref,
+  fun ref foreign_event(conn: TCPConnection[TCP] ref,
     event: AsioEventID,
     flags: U32)
   =>
@@ -496,41 +500,41 @@ class _Closing is _ConnectionState
     // Inflight drained — try to advance the shutdown sequence
     conn._initiate_shutdown()
 
-  fun ref send(conn: TCPConnection ref,
+  fun ref send(conn: TCPConnection[TCP] ref,
     data: (ByteSeq | ByteSeqIter)): SendResult
   =>
     SendErrorNotConnected
 
-  fun ref drained(conn: TCPConnection ref) =>
+  fun ref drained(conn: TCPConnection[TCP] ref) =>
     conn._close_notify_then_shutdown()
 
-  fun ref close(conn: TCPConnection ref) =>
+  fun ref close(conn: TCPConnection[TCP] ref) =>
     None
 
-  fun ref hard_close(conn: TCPConnection ref,
+  fun ref hard_close(conn: TCPConnection[TCP] ref,
     cause: _HardCloseCause)
   =>
     conn._hard_close_connected()
 
-  fun ref start_tls(conn: TCPConnection ref,
+  fun ref start_tls(conn: TCPConnection[TCP] ref,
     ssl_ctx: SSLContext val,
     host: String)
     : (None | StartTLSError)
   =>
     StartTLSNotConnected
 
-  fun ref read_again(conn: TCPConnection ref) =>
+  fun ref read_again(conn: TCPConnection[TCP] ref) =>
     conn._do_read_again()
 
-  fun ref ssl_handshake_complete(conn: TCPConnection ref,
-    s: EitherLifecycleEventReceiver ref)
+  fun ref ssl_handshake_complete(conn: TCPConnection[TCP] ref,
+    s: EitherLifecycleEventReceiver[TCP] ref)
   =>
     // Already open: the handshake completed on the way in.
     None
 
-  fun keepalive(conn: TCPConnection box, secs: U32) => None
+  fun keepalive(conn: TCPConnection[TCP] box, secs: U32) => None
 
-  fun getsockopt(conn: TCPConnection box,
+  fun getsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option_max_size: USize)
@@ -538,14 +542,14 @@ class _Closing is _ConnectionState
   =>
     (1, recover Array[U8] end)
 
-  fun getsockopt_u32(conn: TCPConnection box,
+  fun getsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32)
     : (U32, U32)
   =>
     (1, 0)
 
-  fun setsockopt(conn: TCPConnection box,
+  fun setsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: Array[U8])
@@ -553,7 +557,7 @@ class _Closing is _ConnectionState
   =>
     1
 
-  fun setsockopt_u32(conn: TCPConnection box,
+  fun setsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: U32)
@@ -561,15 +565,15 @@ class _Closing is _ConnectionState
   =>
     1
 
-  fun ref idle_timeout(conn: TCPConnection ref,
+  fun ref idle_timeout(conn: TCPConnection[TCP] ref,
     duration: (IdleTimeout | None))
   =>
     conn._store_idle_timeout(duration)
 
-  fun ref fire_idle_timeout(conn: TCPConnection ref) =>
+  fun ref fire_idle_timeout(conn: TCPConnection[TCP] ref) =>
     conn._dispatch_idle_timeout()
 
-  fun ref set_timer(conn: TCPConnection ref,
+  fun ref set_timer(conn: TCPConnection[TCP] ref,
     duration: TimerDuration): (TimerToken | SetTimerError)
   =>
     SetTimerNotOpen
@@ -577,24 +581,25 @@ class _Closing is _ConnectionState
   fun is_closed(): Bool => true
   fun sends_allowed(): Bool => false
 
-  fun receive(event: AsioEventID,
+  fun receive(conn: TCPConnection[TCP] box,
+    event: AsioEventID,
     buffer: Pointer[U8] tag,
     size: USize)
     : (SocketResult, USize)
   =>
-    PonyTCP.receive(event, buffer, size)
+    conn._tcp_ops().receive(event, buffer, size)
 
-class _UnconnectedClosing is _ConnectionState
+class _UnconnectedClosing[TCP: TCPBackend val] is _ConnectionState[TCP]
   """
   Draining inflight Happy Eyeballs connections after close() during the
   connecting phase. The failure callback is deferred until all inflight
   connections drain. hard_close() can interrupt this drain (e.g., connection
   timeout fires during drain), transitioning to _Closed immediately.
   """
-  fun ref own_event(conn: TCPConnection ref, flags: U32) =>
+  fun ref own_event(conn: TCPConnection[TCP] ref, flags: U32) =>
     _Unreachable()
 
-  fun ref foreign_event(conn: TCPConnection ref,
+  fun ref foreign_event(conn: TCPConnection[TCP] ref,
     event: AsioEventID,
     flags: U32)
   =>
@@ -611,40 +616,40 @@ class _UnconnectedClosing is _ConnectionState
         conn._hard_close_connecting(_UnspecifiedCause)
     end
 
-  fun ref send(conn: TCPConnection ref,
+  fun ref send(conn: TCPConnection[TCP] ref,
     data: (ByteSeq | ByteSeqIter)): SendResult
   =>
     SendErrorNotConnected
 
-  fun ref drained(conn: TCPConnection ref) =>
+  fun ref drained(conn: TCPConnection[TCP] ref) =>
     _Unreachable()
 
-  fun ref close(conn: TCPConnection ref) =>
+  fun ref close(conn: TCPConnection[TCP] ref) =>
     None
 
-  fun ref hard_close(conn: TCPConnection ref,
+  fun ref hard_close(conn: TCPConnection[TCP] ref,
     cause: _HardCloseCause)
   =>
     conn._hard_close_connecting(cause)
 
-  fun ref start_tls(conn: TCPConnection ref,
+  fun ref start_tls(conn: TCPConnection[TCP] ref,
     ssl_ctx: SSLContext val,
     host: String)
     : (None | StartTLSError)
   =>
     StartTLSNotConnected
 
-  fun ref read_again(conn: TCPConnection ref) =>
+  fun ref read_again(conn: TCPConnection[TCP] ref) =>
     None
 
-  fun ref ssl_handshake_complete(conn: TCPConnection ref,
-    s: EitherLifecycleEventReceiver ref)
+  fun ref ssl_handshake_complete(conn: TCPConnection[TCP] ref,
+    s: EitherLifecycleEventReceiver[TCP] ref)
   =>
     _Unreachable()
 
-  fun keepalive(conn: TCPConnection box, secs: U32) => None
+  fun keepalive(conn: TCPConnection[TCP] box, secs: U32) => None
 
-  fun getsockopt(conn: TCPConnection box,
+  fun getsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option_max_size: USize)
@@ -652,14 +657,14 @@ class _UnconnectedClosing is _ConnectionState
   =>
     (1, recover Array[U8] end)
 
-  fun getsockopt_u32(conn: TCPConnection box,
+  fun getsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32)
     : (U32, U32)
   =>
     (1, 0)
 
-  fun setsockopt(conn: TCPConnection box,
+  fun setsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: Array[U8])
@@ -667,7 +672,7 @@ class _UnconnectedClosing is _ConnectionState
   =>
     1
 
-  fun setsockopt_u32(conn: TCPConnection box,
+  fun setsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: U32)
@@ -675,15 +680,15 @@ class _UnconnectedClosing is _ConnectionState
   =>
     1
 
-  fun ref idle_timeout(conn: TCPConnection ref,
+  fun ref idle_timeout(conn: TCPConnection[TCP] ref,
     duration: (IdleTimeout | None))
   =>
     conn._store_idle_timeout(duration)
 
-  fun ref fire_idle_timeout(conn: TCPConnection ref) =>
+  fun ref fire_idle_timeout(conn: TCPConnection[TCP] ref) =>
     conn._dispatch_idle_timeout()
 
-  fun ref set_timer(conn: TCPConnection ref,
+  fun ref set_timer(conn: TCPConnection[TCP] ref,
     duration: TimerDuration): (TimerToken | SetTimerError)
   =>
     SetTimerNotOpen
@@ -691,7 +696,8 @@ class _UnconnectedClosing is _ConnectionState
   fun is_closed(): Bool => true
   fun sends_allowed(): Bool => false
 
-  fun receive(event: AsioEventID,
+  fun receive(conn: TCPConnection[TCP] box,
+    event: AsioEventID,
     buffer: Pointer[U8] tag,
     size: USize)
     : (SocketResult, USize)
@@ -699,11 +705,11 @@ class _UnconnectedClosing is _ConnectionState
     _Unreachable()
     (SocketResultError, 0)
 
-class _Closed is _ConnectionState
-  fun ref own_event(conn: TCPConnection ref, flags: U32) =>
+class _Closed[TCP: TCPBackend val] is _ConnectionState[TCP]
+  fun ref own_event(conn: TCPConnection[TCP] ref, flags: U32) =>
     None
 
-  fun ref foreign_event(conn: TCPConnection ref,
+  fun ref foreign_event(conn: TCPConnection[TCP] ref,
     event: AsioEventID,
     flags: U32)
   =>
@@ -717,39 +723,39 @@ class _Closed is _ConnectionState
     conn._decrement_inflight()
     conn._straggler_cleanup(event)
 
-  fun ref send(conn: TCPConnection ref,
+  fun ref send(conn: TCPConnection[TCP] ref,
     data: (ByteSeq | ByteSeqIter)): SendResult
   =>
     SendErrorNotConnected
 
-  fun ref drained(conn: TCPConnection ref) => None
+  fun ref drained(conn: TCPConnection[TCP] ref) => None
 
-  fun ref close(conn: TCPConnection ref) =>
+  fun ref close(conn: TCPConnection[TCP] ref) =>
     None
 
-  fun ref hard_close(conn: TCPConnection ref,
+  fun ref hard_close(conn: TCPConnection[TCP] ref,
     cause: _HardCloseCause)
   =>
     None
 
-  fun ref start_tls(conn: TCPConnection ref,
+  fun ref start_tls(conn: TCPConnection[TCP] ref,
     ssl_ctx: SSLContext val,
     host: String)
     : (None | StartTLSError)
   =>
     StartTLSNotConnected
 
-  fun ref read_again(conn: TCPConnection ref) =>
+  fun ref read_again(conn: TCPConnection[TCP] ref) =>
     None
 
-  fun ref ssl_handshake_complete(conn: TCPConnection ref,
-    s: EitherLifecycleEventReceiver ref)
+  fun ref ssl_handshake_complete(conn: TCPConnection[TCP] ref,
+    s: EitherLifecycleEventReceiver[TCP] ref)
   =>
     _Unreachable()
 
-  fun keepalive(conn: TCPConnection box, secs: U32) => None
+  fun keepalive(conn: TCPConnection[TCP] box, secs: U32) => None
 
-  fun getsockopt(conn: TCPConnection box,
+  fun getsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option_max_size: USize)
@@ -757,14 +763,14 @@ class _Closed is _ConnectionState
   =>
     (1, recover Array[U8] end)
 
-  fun getsockopt_u32(conn: TCPConnection box,
+  fun getsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32)
     : (U32, U32)
   =>
     (1, 0)
 
-  fun setsockopt(conn: TCPConnection box,
+  fun setsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: Array[U8])
@@ -772,7 +778,7 @@ class _Closed is _ConnectionState
   =>
     1
 
-  fun setsockopt_u32(conn: TCPConnection box,
+  fun setsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: U32)
@@ -780,15 +786,15 @@ class _Closed is _ConnectionState
   =>
     1
 
-  fun ref idle_timeout(conn: TCPConnection ref,
+  fun ref idle_timeout(conn: TCPConnection[TCP] ref,
     duration: (IdleTimeout | None))
   =>
     conn._store_idle_timeout(duration)
 
-  fun ref fire_idle_timeout(conn: TCPConnection ref) =>
+  fun ref fire_idle_timeout(conn: TCPConnection[TCP] ref) =>
     conn._dispatch_idle_timeout()
 
-  fun ref set_timer(conn: TCPConnection ref,
+  fun ref set_timer(conn: TCPConnection[TCP] ref,
     duration: TimerDuration): (TimerToken | SetTimerError)
   =>
     SetTimerNotOpen
@@ -796,23 +802,24 @@ class _Closed is _ConnectionState
   fun is_closed(): Bool => true
   fun sends_allowed(): Bool => false
 
-  fun receive(event: AsioEventID,
+  fun receive(conn: TCPConnection[TCP] box,
+    event: AsioEventID,
     buffer: Pointer[U8] tag,
     size: USize)
     : (SocketResult, USize)
   =>
     (SocketResultError, 0)
 
-class _SSLHandshaking is _ConnectionState
+class _SSLHandshaking[TCP: TCPBackend val] is _ConnectionState[TCP]
   """
   TCP connected, initial SSL handshake in progress. The application has not
   been notified yet — `_on_connected`/`_on_started` fires only after the
   handshake completes.
   """
-  fun ref own_event(conn: TCPConnection ref, flags: U32) =>
+  fun ref own_event(conn: TCPConnection[TCP] ref, flags: U32) =>
     conn._dispatch_io_event(flags)
 
-  fun ref foreign_event(conn: TCPConnection ref,
+  fun ref foreign_event(conn: TCPConnection[TCP] ref,
     event: AsioEventID,
     flags: U32)
   =>
@@ -826,48 +833,48 @@ class _SSLHandshaking is _ConnectionState
     conn._decrement_inflight()
     conn._straggler_cleanup(event)
 
-  fun ref send(conn: TCPConnection ref,
+  fun ref send(conn: TCPConnection[TCP] ref,
     data: (ByteSeq | ByteSeqIter)): SendResult
   =>
     SendErrorNotConnected
 
-  fun ref drained(conn: TCPConnection ref) => None
+  fun ref drained(conn: TCPConnection[TCP] ref) => None
 
-  fun ref close(conn: TCPConnection ref) =>
+  fun ref close(conn: TCPConnection[TCP] ref) =>
     // Can't drain gracefully during handshake — nothing to FIN.
     conn.hard_close()
 
-  fun ref hard_close(conn: TCPConnection ref,
+  fun ref hard_close(conn: TCPConnection[TCP] ref,
     cause: _HardCloseCause)
   =>
     conn._hard_close_ssl_handshaking(cause)
 
-  fun ref start_tls(conn: TCPConnection ref,
+  fun ref start_tls(conn: TCPConnection[TCP] ref,
     ssl_ctx: SSLContext val,
     host: String)
     : (None | StartTLSError)
   =>
     StartTLSNotConnected
 
-  fun ref read_again(conn: TCPConnection ref) =>
+  fun ref read_again(conn: TCPConnection[TCP] ref) =>
     conn._do_read_again()
 
-  fun ref ssl_handshake_complete(conn: TCPConnection ref,
-    s: EitherLifecycleEventReceiver ref)
+  fun ref ssl_handshake_complete(conn: TCPConnection[TCP] ref,
+    s: EitherLifecycleEventReceiver[TCP] ref)
   =>
-    conn._set_state(_Open)
+    conn._set_state(_Open[TCP])
     conn._cancel_connect_timer()
     conn._arm_idle_timer()
     match \exhaustive\ s
-    | let c: ClientLifecycleEventReceiver ref =>
+    | let c: ClientLifecycleEventReceiver[TCP] ref =>
       c._on_connected()
-    | let srv: ServerLifecycleEventReceiver ref =>
+    | let srv: ServerLifecycleEventReceiver[TCP] ref =>
       srv._on_started()
     end
 
-  fun keepalive(conn: TCPConnection box, secs: U32) => None
+  fun keepalive(conn: TCPConnection[TCP] box, secs: U32) => None
 
-  fun getsockopt(conn: TCPConnection box,
+  fun getsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option_max_size: USize)
@@ -875,14 +882,14 @@ class _SSLHandshaking is _ConnectionState
   =>
     (1, recover Array[U8] end)
 
-  fun getsockopt_u32(conn: TCPConnection box,
+  fun getsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32)
     : (U32, U32)
   =>
     (1, 0)
 
-  fun setsockopt(conn: TCPConnection box,
+  fun setsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: Array[U8])
@@ -890,7 +897,7 @@ class _SSLHandshaking is _ConnectionState
   =>
     1
 
-  fun setsockopt_u32(conn: TCPConnection box,
+  fun setsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: U32)
@@ -898,15 +905,15 @@ class _SSLHandshaking is _ConnectionState
   =>
     1
 
-  fun ref idle_timeout(conn: TCPConnection ref,
+  fun ref idle_timeout(conn: TCPConnection[TCP] ref,
     duration: (IdleTimeout | None))
   =>
     conn._store_idle_timeout(duration)
 
-  fun ref fire_idle_timeout(conn: TCPConnection ref) =>
+  fun ref fire_idle_timeout(conn: TCPConnection[TCP] ref) =>
     conn._dispatch_idle_timeout()
 
-  fun ref set_timer(conn: TCPConnection ref,
+  fun ref set_timer(conn: TCPConnection[TCP] ref,
     duration: TimerDuration): (TimerToken | SetTimerError)
   =>
     SetTimerNotOpen
@@ -914,23 +921,24 @@ class _SSLHandshaking is _ConnectionState
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
 
-  fun receive(event: AsioEventID,
+  fun receive(conn: TCPConnection[TCP] box,
+    event: AsioEventID,
     buffer: Pointer[U8] tag,
     size: USize)
     : (SocketResult, USize)
   =>
-    PonyTCP.receive(event, buffer, size)
+    conn._tcp_ops().receive(event, buffer, size)
 
-class _TLSUpgrading is _ConnectionState
+class _TLSUpgrading[TCP: TCPBackend val] is _ConnectionState[TCP]
   """
   Established connection upgrading to TLS via `start_tls()`. The application
   has already been notified of the plaintext connection — `_on_tls_ready`
   fires when the handshake completes.
   """
-  fun ref own_event(conn: TCPConnection ref, flags: U32) =>
+  fun ref own_event(conn: TCPConnection[TCP] ref, flags: U32) =>
     conn._dispatch_io_event(flags)
 
-  fun ref foreign_event(conn: TCPConnection ref,
+  fun ref foreign_event(conn: TCPConnection[TCP] ref,
     event: AsioEventID,
     flags: U32)
   =>
@@ -944,44 +952,44 @@ class _TLSUpgrading is _ConnectionState
     conn._decrement_inflight()
     conn._straggler_cleanup(event)
 
-  fun ref send(conn: TCPConnection ref,
+  fun ref send(conn: TCPConnection[TCP] ref,
     data: (ByteSeq | ByteSeqIter)): SendResult
   =>
     SendErrorNotConnected
 
-  fun ref drained(conn: TCPConnection ref) => None
+  fun ref drained(conn: TCPConnection[TCP] ref) => None
 
-  fun ref close(conn: TCPConnection ref) =>
+  fun ref close(conn: TCPConnection[TCP] ref) =>
     // Can't send FIN during TLS handshake.
     conn.hard_close()
 
-  fun ref hard_close(conn: TCPConnection ref,
+  fun ref hard_close(conn: TCPConnection[TCP] ref,
     cause: _HardCloseCause)
   =>
     conn._hard_close_tls_upgrading(cause)
 
-  fun ref start_tls(conn: TCPConnection ref,
+  fun ref start_tls(conn: TCPConnection[TCP] ref,
     ssl_ctx: SSLContext val,
     host: String)
     : (None | StartTLSError)
   =>
     StartTLSAlreadyTLS
 
-  fun ref read_again(conn: TCPConnection ref) =>
+  fun ref read_again(conn: TCPConnection[TCP] ref) =>
     conn._do_read_again()
 
-  fun ref ssl_handshake_complete(conn: TCPConnection ref,
-    s: EitherLifecycleEventReceiver ref)
+  fun ref ssl_handshake_complete(conn: TCPConnection[TCP] ref,
+    s: EitherLifecycleEventReceiver[TCP] ref)
   =>
     // TLS upgrade handshake complete — no timer arm needed (timer is
     // already running from the plaintext phase).
-    conn._set_state(_Open)
+    conn._set_state(_Open[TCP])
     s._on_tls_ready()
 
-  fun keepalive(conn: TCPConnection box, secs: U32) =>
+  fun keepalive(conn: TCPConnection[TCP] box, secs: U32) =>
     conn._do_keepalive(secs)
 
-  fun getsockopt(conn: TCPConnection box,
+  fun getsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option_max_size: USize)
@@ -989,14 +997,14 @@ class _TLSUpgrading is _ConnectionState
   =>
     conn._do_getsockopt(level, option_name, option_max_size)
 
-  fun getsockopt_u32(conn: TCPConnection box,
+  fun getsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32)
     : (U32, U32)
   =>
     conn._do_getsockopt_u32(level, option_name)
 
-  fun setsockopt(conn: TCPConnection box,
+  fun setsockopt(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: Array[U8])
@@ -1004,7 +1012,7 @@ class _TLSUpgrading is _ConnectionState
   =>
     conn._do_setsockopt(level, option_name, option)
 
-  fun setsockopt_u32(conn: TCPConnection box,
+  fun setsockopt_u32(conn: TCPConnection[TCP] box,
     level: I32,
     option_name: I32,
     option: U32)
@@ -1012,16 +1020,16 @@ class _TLSUpgrading is _ConnectionState
   =>
     conn._do_setsockopt_u32(level, option_name, option)
 
-  fun ref idle_timeout(conn: TCPConnection ref,
+  fun ref idle_timeout(conn: TCPConnection[TCP] ref,
     duration: (IdleTimeout | None))
   =>
     conn._do_idle_timeout(duration)
 
-  fun ref fire_idle_timeout(conn: TCPConnection ref) =>
+  fun ref fire_idle_timeout(conn: TCPConnection[TCP] ref) =>
     conn._dispatch_idle_timeout()
     conn._rearm_idle_timer_if_configured()
 
-  fun ref set_timer(conn: TCPConnection ref,
+  fun ref set_timer(conn: TCPConnection[TCP] ref,
     duration: TimerDuration): (TimerToken | SetTimerError)
   =>
     conn._do_set_timer(duration)
@@ -1029,9 +1037,10 @@ class _TLSUpgrading is _ConnectionState
   fun is_closed(): Bool => false
   fun sends_allowed(): Bool => false
 
-  fun receive(event: AsioEventID,
+  fun receive(conn: TCPConnection[TCP] box,
+    event: AsioEventID,
     buffer: Pointer[U8] tag,
     size: USize)
     : (SocketResult, USize)
   =>
-    PonyTCP.receive(event, buffer, size)
+    conn._tcp_ops().receive(event, buffer, size)

--- a/lori/_pending_writes.pony
+++ b/lori/_pending_writes.pony
@@ -52,7 +52,7 @@ class _PendingWrites
 
   fun buffers(): this->Array[ByteSeq] =>
     """
-    The buffers, for `PonyTCP.sendv`. Read together with `first_offset`.
+    The buffers, for `RuntimeBackend.sendv`. Read together with `first_offset`.
     """
     _buffers
 

--- a/lori/client_lifecycle_event_receiver.pony
+++ b/lori/client_lifecycle_event_receiver.pony
@@ -1,9 +1,9 @@
-trait ClientLifecycleEventReceiver
+trait ClientLifecycleEventReceiver[TCP: TCPBackend val = RuntimeBackend]
   """
   Application-level callbacks for client-side TCP connections.
   One receiver per connection, no chaining.
   """
-  fun ref _connection(): TCPConnection
+  fun ref _connection(): TCPConnection[TCP]
 
   fun ref _on_connecting(inflight_connections: U32) =>
     """
@@ -230,5 +230,5 @@ trait ClientLifecycleEventReceiver
     """
     None
 
-type EitherLifecycleEventReceiver is
-  (ServerLifecycleEventReceiver | ClientLifecycleEventReceiver)
+type EitherLifecycleEventReceiver[TCP: TCPBackend val = RuntimeBackend] is
+  (ServerLifecycleEventReceiver[TCP] | ClientLifecycleEventReceiver[TCP])

--- a/lori/lori.pony
+++ b/lori/lori.pony
@@ -337,7 +337,7 @@ with the same range as `IdleTimeout` (1 to 18,446,744,073,709 milliseconds).
 The timer is a one-shot: it either fires and fails the connection, or is
 cancelled when the connection becomes ready.
 
-The timer is armed after `PonyTCP.connect` returns, so it does not cover DNS
+The timer is armed after connect returns, so it does not cover DNS
 resolution time. If DNS itself blocks (common with unresponsive nameservers),
 the total wait will exceed the configured timeout by the DNS resolution time.
 

--- a/lori/runtime_backend.pony
+++ b/lori/runtime_backend.pony
@@ -40,7 +40,7 @@ use @pony_os_writev_max[I32]()
 
 use net = "net"
 
-primitive PonyTCP
+primitive RuntimeBackend is TCPBackend
   """
   Wrappers for the runtime's `pony_os_*` TCP functions -- connect, listen,
   accept, receive, sendv, keepalive, and socket teardown.

--- a/lori/server_lifecycle_event_receiver.pony
+++ b/lori/server_lifecycle_event_receiver.pony
@@ -1,9 +1,9 @@
-trait ServerLifecycleEventReceiver
+trait ServerLifecycleEventReceiver[TCP: TCPBackend val = RuntimeBackend]
   """
   Application-level callbacks for server-side TCP connections.
   One receiver per connection, no chaining.
   """
-  fun ref _connection(): TCPConnection
+  fun ref _connection(): TCPConnection[TCP]
 
   fun ref _on_started() =>
     """

--- a/lori/tcp_backend.pony
+++ b/lori/tcp_backend.pony
@@ -1,0 +1,97 @@
+use net = "net"
+
+trait val TCPBackend
+  """
+  The TCP operations a connection and listener need from the runtime.
+  `RuntimeBackend` is the production implementation; test code can
+  substitute a fake to drive the connection state machine without
+  real sockets.
+  """
+  new val create()
+
+  fun listen(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    ip_version: IPVersion = DualStack)
+    : AsioEventID
+    """
+    Open a listening socket bound to `host`:`port` and subscribe
+    `the_actor` for accept-readiness events. Returns the ASIO event,
+    or a null event on failure.
+    """
+
+  fun accept(event: AsioEventID): I32
+    """
+    Accept one pending connection on the listening socket behind
+    `event`. Returns the fd (> 0), 0 if none is ready, or -1 on
+    error.
+    """
+
+  fun close(fd: U32)
+    """
+    Close the socket.
+    """
+
+  fun connect(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    from: String,
+    asio_flags: U32,
+    ip_version: IPVersion = DualStack)
+    : U32
+    """
+    Start non-blocking TCP connection attempts to `host`:`port`.
+    Returns the number of attempts started (one per resolved
+    address). Zero means every attempt failed immediately.
+    """
+
+  fun keepalive(fd: U32, secs: U32)
+    """
+    Enable TCP keepalive on `fd` with an interval of `secs` seconds.
+    """
+
+  fun peername(fd: U32, ip: net.NetAddress ref): Bool
+    """
+    Fill `ip` with the remote address of `fd`. Returns true on
+    success.
+    """
+
+  fun receive(event: AsioEventID,
+    buffer: Pointer[U8] tag,
+    size: USize)
+    : (SocketResult, USize)
+    """
+    Receive up to `size` bytes into `buffer`. The call is synchronous
+    and non-blocking: `SocketResultRetry` means no data was
+    available, `SocketResultError` means an unrecoverable error or
+    peer close.
+    """
+
+  fun shutdown(fd: U32)
+    """
+    Shut down the write side of `fd`.
+    """
+
+  fun sockname(fd: U32, ip: net.NetAddress ref): Bool
+    """
+    Fill `ip` with the local address of `fd`. Returns true on
+    success.
+    """
+
+  fun sendv(event: AsioEventID,
+    data: Array[ByteSeq] box,
+    from: USize,
+    count: USize,
+    first_buffer_byte_offset: USize = 0)
+    : (SocketResult, USize) ?
+    """
+    Send `count` buffers from `data` starting at index `from`.
+    Returns the tri-state socket result plus the number of bytes
+    sent on `SocketResultOk`. The call is synchronous and
+    non-blocking.
+    """
+
+  fun writev_max(): I32
+    """
+    Maximum number of buffers a single `sendv` call may carry.
+    """

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -2,7 +2,7 @@ use net = "net"
 use "collections"
 use "ssl/net"
 
-class TCPConnection
+class TCPConnection[TCP: TCPBackend val = RuntimeBackend]
   """
   The TCP connection: all connection state and I/O, including SSL. A
   `TCPConnectionActor` owns one and delegates to it.
@@ -12,7 +12,8 @@ class TCPConnection
   initializer before that. An open plaintext connection can be upgraded to TLS
   with `start_tls`. See the package documentation for the full lifecycle.
   """
-  var _state: _ConnectionState ref = _ConnectionNone
+  let _tcp: TCP = TCP
+  var _state: _ConnectionState[TCP] ref = _ConnectionNone[TCP]
   var _shutdown: Bool = false
   var _throttled: Bool = false
   var _readable: Bool = false
@@ -22,10 +23,12 @@ class TCPConnection
   var _inflight_connections: U32 = 0
   var _fd: U32 = -1
   var _event: AsioEventID = AsioEvent.none()
-  var _spawned_by: (TCPListenerActor | None) = None
+  var _spawned_by: (TCPListenerActor[TCP] | None) = None
   let _lifecycle_event_receiver:
-    (ClientLifecycleEventReceiver ref | ServerLifecycleEventReceiver ref | None)
-  let _enclosing: (TCPConnectionActor ref | None)
+    (ClientLifecycleEventReceiver[TCP] ref
+    | ServerLifecycleEventReceiver[TCP] ref
+    | None)
+  let _enclosing: (TCPConnectionActor[TCP] ref | None)
   embed _pending: _PendingWrites = _PendingWrites
   var _read_buffer: Array[U8] iso = recover Array[U8] end
   var _bytes_in_read_buffer: USize = 0
@@ -45,7 +48,7 @@ class TCPConnection
   // Built-in SSL support
   var _ssl: _TLSState = _NoTLS
   var _close_notify_pending: Bool = false
-  // Set when PonyTCP.connect returned > 0, meaning at least one TCP
+  // Set when connect returned > 0, meaning at least one TCP
   // connection attempt was made. Used by the failure callback to distinguish
   // DNS failure (no attempts) from TCP failure (all attempts failed).
   var _had_inflight: Bool = false
@@ -65,12 +68,19 @@ class TCPConnection
   var _from: String = ""
   var _ip_version: IPVersion = DualStack
 
+  fun _tcp_ops(): TCP =>
+    """
+    The TCP operations backend for this connection, used by state classes
+    that need to call receive.
+    """
+    _tcp
+
   new client(auth: TCPConnectAuth,
     host: String,
     port: String,
     from: String,
-    enclosing: TCPConnectionActor ref,
-    ler: ClientLifecycleEventReceiver ref,
+    enclosing: TCPConnectionActor[TCP] ref,
+    ler: ClientLifecycleEventReceiver[TCP] ref,
     read_buffer_size: ReadBufferSize = DefaultReadBufferSize(),
     ip_version: IPVersion = DualStack,
     connection_timeout: (ConnectionTimeout | None) = None)
@@ -98,8 +108,8 @@ class TCPConnection
 
   new server(auth: TCPServerAuth,
     fd': U32,
-    enclosing: TCPConnectionActor ref,
-    ler: ServerLifecycleEventReceiver ref,
+    enclosing: TCPConnectionActor[TCP] ref,
+    ler: ServerLifecycleEventReceiver[TCP] ref,
     read_buffer_size: ReadBufferSize = DefaultReadBufferSize())
   =>
     """
@@ -120,8 +130,8 @@ class TCPConnection
     host: String,
     port: String,
     from: String,
-    enclosing: TCPConnectionActor ref,
-    ler: ClientLifecycleEventReceiver ref,
+    enclosing: TCPConnectionActor[TCP] ref,
+    ler: ClientLifecycleEventReceiver[TCP] ref,
     read_buffer_size: ReadBufferSize = DefaultReadBufferSize(),
     ip_version: IPVersion = DualStack,
     connection_timeout: (ConnectionTimeout | None) = None)
@@ -155,8 +165,8 @@ class TCPConnection
   new ssl_server(auth: TCPServerAuth,
     ssl_ctx: SSLContext val,
     fd': U32,
-    enclosing: TCPConnectionActor ref,
-    ler: ServerLifecycleEventReceiver ref,
+    enclosing: TCPConnectionActor[TCP] ref,
+    ler: ServerLifecycleEventReceiver[TCP] ref,
     read_buffer_size: ReadBufferSize = DefaultReadBufferSize())
   =>
     """
@@ -468,7 +478,7 @@ class TCPConnection
     """
     recover
       let ip: net.NetAddress ref = net.NetAddress
-      PonyTCP.sockname(_fd, ip)
+      _tcp.sockname(_fd, ip)
       ip
     end
 
@@ -479,7 +489,7 @@ class TCPConnection
     """
     recover
       let ip: net.NetAddress ref = net.NetAddress
-      PonyTCP.peername(_fd, ip)
+      _tcp.peername(_fd, ip)
       ip
     end
 
@@ -538,7 +548,7 @@ class TCPConnection
     end
 
     match \exhaustive\ _lifecycle_event_receiver
-    | let _: EitherLifecycleEventReceiver =>
+    | let _: EitherLifecycleEventReceiver[TCP] =>
       _buffer_until = qty
     | None =>
       _Unreachable()
@@ -584,10 +594,10 @@ class TCPConnection
     appropriate failure callback, and cancels the idle, connect, and user
     timers.
     """
-    _state = _Closed
+    _state = _Closed[TCP]
     _dispose_tls()
     match _lifecycle_event_receiver
-    | let c: ClientLifecycleEventReceiver ref =>
+    | let c: ClientLifecycleEventReceiver[TCP] ref =>
       // `_had_inflight` is state, not a cause: it records whether any TCP
       // attempt ever started, which is what separates a DNS failure from a
       // TCP one. No caller knows it.
@@ -629,7 +639,7 @@ class TCPConnection
     // `_on_sent` stays a direct call so it still precedes `_on_closed`, which
     // the `_hard_close_*` methods fire after this returns.
     match _enclosing
-    | let e: TCPConnectionActor ref =>
+    | let e: TCPConnectionActor[TCP] ref =>
       try
         while _pending_tokens.size() > 0 do
           (let offset, let token) = _pending_tokens.shift()?
@@ -731,9 +741,9 @@ class TCPConnection
     closed. For client connections, this is a no-op.
     """
     match _lifecycle_event_receiver
-    | let e: ServerLifecycleEventReceiver ref =>
+    | let e: ServerLifecycleEventReceiver[TCP] ref =>
       match \exhaustive\ _spawned_by
-      | let spawner: TCPListenerActor =>
+      | let spawner: TCPListenerActor[TCP] =>
         spawner._connection_closed()
         _spawned_by = None
       | None =>
@@ -750,11 +760,11 @@ class TCPConnection
     reachable from `_Open` and `_Closing` — handshake states have their own
     hard-close methods. Fires `_on_closed` and notifies the spawner.
     """
-    _state = _Closed
+    _state = _Closed[TCP]
     _hard_close_cleanup()
 
     match \exhaustive\ _lifecycle_event_receiver
-    | let s: EitherLifecycleEventReceiver ref =>
+    | let s: EitherLifecycleEventReceiver[TCP] ref =>
       s._on_closed()
     | None =>
       _Unreachable()
@@ -768,13 +778,13 @@ class TCPConnection
     The application has not been notified — fires `_on_connection_failure`
     (client) or `_on_start_failure` (server).
     """
-    _state = _Closed
+    _state = _Closed[TCP]
     _hard_close_cleanup()
 
     match \exhaustive\ _lifecycle_event_receiver
-    | let s: EitherLifecycleEventReceiver ref =>
+    | let s: EitherLifecycleEventReceiver[TCP] ref =>
       match \exhaustive\ s
-      | let c: ClientLifecycleEventReceiver ref =>
+      | let c: ClientLifecycleEventReceiver[TCP] ref =>
         let reason =
           match cause
           | _ConnectTimerFailed => ConnectionFailedTimerError
@@ -782,7 +792,7 @@ class TCPConnection
           else ConnectionFailedSSL
           end
         c._on_connection_failure(reason)
-      | let srv: ServerLifecycleEventReceiver ref =>
+      | let srv: ServerLifecycleEventReceiver[TCP] ref =>
         srv._on_start_failure(StartFailedSSL)
       end
     | None =>
@@ -797,7 +807,7 @@ class TCPConnection
     The application was already notified of the plaintext connection, so
     `_on_tls_failure` fires followed by `_on_closed`.
     """
-    _state = _Closed
+    _state = _Closed[TCP]
     _hard_close_cleanup()
 
     let reason =
@@ -807,7 +817,7 @@ class TCPConnection
       end
 
     match \exhaustive\ _lifecycle_event_receiver
-    | let s: EitherLifecycleEventReceiver ref =>
+    | let s: EitherLifecycleEventReceiver[TCP] ref =>
       s._on_tls_failure(reason)
       s._on_closed()
     | None =>
@@ -852,7 +862,7 @@ class TCPConnection
     _state.start_tls(this, ssl_ctx, host)
 
   fun _do_keepalive(secs: U32) =>
-    PonyTCP.keepalive(_fd, secs)
+    _tcp.keepalive(_fd, secs)
 
   fun _do_getsockopt(level: I32,
     option_name: I32,
@@ -889,9 +899,9 @@ class TCPConnection
     let ssl =
       try
         match \exhaustive\ _lifecycle_event_receiver
-        | let _: ClientLifecycleEventReceiver ref =>
+        | let _: ClientLifecycleEventReceiver[TCP] ref =>
           ssl_ctx.client(host)?
-        | let _: ServerLifecycleEventReceiver ref =>
+        | let _: ServerLifecycleEventReceiver[TCP] ref =>
           ssl_ctx.server()?
         | None =>
           _Unreachable()
@@ -902,7 +912,7 @@ class TCPConnection
       end
 
     _ssl = _TLS(consume ssl)
-    _state = _TLSUpgrading
+    _state = _TLSUpgrading[TCP]
     _ssl_flush_sends()
     None
 
@@ -1006,7 +1016,7 @@ class TCPConnection
     end
 
     _shutdown = true
-    PonyTCP.shutdown(_fd)
+    _tcp.shutdown(_fd)
 
   fun ref _enqueue(data: ByteSeq) =>
     """
@@ -1044,7 +1054,7 @@ class TCPConnection
     `_on_throttled` when it applies backpressure. Either can close the
     connection under the caller.
     """
-    let writev_batch_size: USize = PonyTCP.writev_max().usize()
+    let writev_batch_size: USize = _tcp.writev_max().usize()
     var wrote_bytes: Bool = false
 
     while _writeable and (_pending.total() > 0) do
@@ -1055,7 +1065,7 @@ class TCPConnection
         let bytes_to_send: USize = _pending.prefix_total(num_to_send)
 
         // sendv — three-state result with bytes-sent count
-        match \exhaustive\ PonyTCP.sendv(
+        match \exhaustive\ _tcp.sendv(
           _event, _pending.buffers(), 0, num_to_send, _pending.first_offset())?
         | (SocketResultOk, let len: USize) =>
           if len > 0 then
@@ -1169,7 +1179,7 @@ class TCPConnection
       consume data'
     end
 
-  fun ref _fill(s: EitherLifecycleEventReceiver ref): (USize | None) ? =>
+  fun ref _fill(s: EitherLifecycleEventReceiver[TCP] ref): (USize | None) ? =>
     """
     Get more bytes off the socket. Returns the number read, or `None` when the
     socket has nothing more to give (read interest is re-armed first). Raises
@@ -1188,6 +1198,7 @@ class TCPConnection
 
     let bytes_read =
       match \exhaustive\ _state.receive(
+        this,
         _event,
         _read_buffer.cpointer(_bytes_in_read_buffer),
         _read_buffer.size() - _bytes_in_read_buffer)
@@ -1215,7 +1226,7 @@ class TCPConnection
   fun ref _read() =>
     _reset_idle_timer()
     match \exhaustive\ _lifecycle_event_receiver
-    | let s: EitherLifecycleEventReceiver ref =>
+    | let s: EitherLifecycleEventReceiver[TCP] ref =>
       try
         var total_bytes_read: USize = 0
 
@@ -1331,7 +1342,7 @@ class TCPConnection
     unmuting.
     """
     match \exhaustive\ _enclosing
-    | let e: TCPConnectionActor ref =>
+    | let e: TCPConnectionActor[TCP] ref =>
       e._read_again()
     | None =>
       _Unreachable()
@@ -1339,7 +1350,7 @@ class TCPConnection
 
   fun ref _apply_backpressure() =>
     match \exhaustive\ _lifecycle_event_receiver
-    | let s: EitherLifecycleEventReceiver =>
+    | let s: EitherLifecycleEventReceiver[TCP] =>
       if not _throttled then
         _throttled = true
         // throttled means we are also unwriteable
@@ -1362,7 +1373,7 @@ class TCPConnection
 
   fun ref _release_backpressure() =>
     match \exhaustive\ _lifecycle_event_receiver
-    | let s: EitherLifecycleEventReceiver =>
+    | let s: EitherLifecycleEventReceiver[TCP] =>
       if _throttled then
         _throttled = false
         s._on_unthrottled()
@@ -1378,7 +1389,7 @@ class TCPConnection
     Dispatch _on_send_accepted to the lifecycle event receiver.
     """
     match \exhaustive\ _lifecycle_event_receiver
-    | let s: EitherLifecycleEventReceiver ref =>
+    | let s: EitherLifecycleEventReceiver[TCP] ref =>
       s._on_send_accepted(token, data)
     | None =>
       _Unreachable()
@@ -1389,7 +1400,7 @@ class TCPConnection
     Dispatch _on_sent to the lifecycle event receiver.
     """
     match \exhaustive\ _lifecycle_event_receiver
-    | let s: EitherLifecycleEventReceiver ref =>
+    | let s: EitherLifecycleEventReceiver[TCP] ref =>
       s._on_sent(token)
     | None =>
       _Unreachable()
@@ -1401,7 +1412,7 @@ class TCPConnection
     _notify_send_failed behavior on TCPConnectionActor.
     """
     match \exhaustive\ _lifecycle_event_receiver
-    | let s: EitherLifecycleEventReceiver ref =>
+    | let s: EitherLifecycleEventReceiver[TCP] ref =>
       s._on_send_failed(token)
     | None =>
       _Unreachable()
@@ -1436,7 +1447,7 @@ class TCPConnection
 
     let nsec = duration() * 1_000_000
     match \exhaustive\ _enclosing
-    | let e: TCPConnectionActor ref =>
+    | let e: TCPConnectionActor[TCP] ref =>
       _user_timer_event = PonyAsio.create_timer_event(e, nsec)
     | None =>
       _Unreachable()
@@ -1457,7 +1468,7 @@ class TCPConnection
     if _idle_timeout_nsec == 0 then return end
     if not _timer_event.is_null() then return end
     match \exhaustive\ _enclosing
-    | let e: TCPConnectionActor ref =>
+    | let e: TCPConnectionActor[TCP] ref =>
       _timer_event = PonyAsio.create_timer_event(e, _idle_timeout_nsec)
     | None =>
       _Unreachable()
@@ -1491,7 +1502,7 @@ class TCPConnection
 
   fun ref _dispatch_idle_timeout() =>
     match \exhaustive\ _lifecycle_event_receiver
-    | let s: EitherLifecycleEventReceiver ref =>
+    | let s: EitherLifecycleEventReceiver[TCP] ref =>
       s._on_idle_timeout()
     | None =>
       _Unreachable()
@@ -1512,7 +1523,7 @@ class TCPConnection
     """
     _cancel_idle_timer()
     match \exhaustive\ _lifecycle_event_receiver
-    | let s: EitherLifecycleEventReceiver ref =>
+    | let s: EitherLifecycleEventReceiver[TCP] ref =>
       s._on_idle_timer_failure()
     | None =>
       _Unreachable()
@@ -1521,12 +1532,12 @@ class TCPConnection
   fun ref _arm_connect_timer() =>
     """
     Create the ASIO timer event for the connect timeout. Called after
-    `PonyTCP.connect` succeeds (at least one connection attempt is inflight).
+    connect succeeds (at least one connection attempt is inflight).
     No-op when `_connect_timeout_nsec == 0` (no timeout configured).
     """
     if _connect_timeout_nsec == 0 then return end
     match \exhaustive\ _enclosing
-    | let e: TCPConnectionActor ref =>
+    | let e: TCPConnectionActor[TCP] ref =>
       _connect_timer_event =
         PonyAsio.create_timer_event(e, _connect_timeout_nsec)
     | None =>
@@ -1579,7 +1590,7 @@ class TCPConnection
     PonyAsio.unsubscribe(_user_timer_event)
     _user_timer_event = AsioEvent.none()
     match \exhaustive\ (token, _lifecycle_event_receiver)
-    | (let t: TimerToken, let s: EitherLifecycleEventReceiver ref) =>
+    | (let t: TimerToken, let s: EitherLifecycleEventReceiver[TCP] ref) =>
       s._on_timer(t)
     | (None, _) =>
       _Unreachable()
@@ -1610,7 +1621,7 @@ class TCPConnection
     """
     _cancel_user_timer()
     match \exhaustive\ _lifecycle_event_receiver
-    | let s: EitherLifecycleEventReceiver ref =>
+    | let s: EitherLifecycleEventReceiver[TCP] ref =>
       s._on_timer_failure()
     | None =>
       _Unreachable()
@@ -1658,7 +1669,7 @@ class TCPConnection
     end
 
   fun ref _ssl_poll(
-    s: EitherLifecycleEventReceiver ref,
+    s: EitherLifecycleEventReceiver[TCP] ref,
     result: SSLReceiveResult)
   =>
     """
@@ -1735,7 +1746,7 @@ class TCPConnection
   fun ref _do_read_again() =>
     _read()
 
-  fun ref _set_state(state: _ConnectionState ref) =>
+  fun ref _set_state(state: _ConnectionState[TCP] ref) =>
     _state = state
 
   fun ref _decrement_inflight(): U32 =>
@@ -1755,7 +1766,7 @@ class TCPConnection
 
     match \exhaustive\ _ssl
     | let _: _TLS =>
-      _state = _SSLHandshaking
+      _state = _SSLHandshaking[TCP]
       // Flush ClientHello to initiate SSL handshake.
       // _on_connected() and _arm_idle_timer() deferred until
       // ssl_handshake_complete.
@@ -1763,11 +1774,11 @@ class TCPConnection
     | _TLSDisposed | _TLSFailed =>
       _Unreachable()
     | _NoTLS =>
-      _state = _Open
+      _state = _Open[TCP]
       _arm_idle_timer()
       _cancel_connect_timer()
       match _lifecycle_event_receiver
-      | let c: ClientLifecycleEventReceiver ref =>
+      | let c: ClientLifecycleEventReceiver[TCP] ref =>
         c._on_connected()
       end
     end
@@ -1789,10 +1800,10 @@ class TCPConnection
     Use this for every fd whose event was created via
     `pony_asio_event_create`. Raw, never-subscribed fds (e.g. an accepted fd
     rejected before an event is created) are closed directly with
-    `PonyTCP.close` on both platforms.
+    `close` on both platforms.
     """
     ifdef not windows then
-      PonyTCP.close(fd)
+      _tcp.close(fd)
     end
 
   fun ref _connecting_event_failed(event: AsioEventID, fd: U32) =>
@@ -1861,13 +1872,13 @@ class TCPConnection
 
   fun ref _connecting_callback() =>
     match \exhaustive\ _lifecycle_event_receiver
-    | let c: ClientLifecycleEventReceiver ref =>
+    | let c: ClientLifecycleEventReceiver[TCP] ref =>
       if _inflight_connections > 0 then
         c._on_connecting(_inflight_connections)
       else
         hard_close()
       end
-    | let s: ServerLifecycleEventReceiver ref =>
+    | let s: ServerLifecycleEventReceiver[TCP] ref =>
       _Unreachable()
     | None =>
       _Unreachable()
@@ -1877,7 +1888,7 @@ class TCPConnection
     (let errno: U32, let value: U32) = _OSSocket.get_so_error(fd)
     (errno == 0) and (value == 0)
 
-  fun ref _register_spawner(listener: TCPListenerActor) =>
+  fun ref _register_spawner(listener: TCPListenerActor[TCP]) =>
     if _spawned_by is None then
       if not _state.is_closed() then
         // We were connected by the time the spawner was registered,
@@ -1895,29 +1906,29 @@ class TCPConnection
 
   fun ref _finish_initialization() =>
     match \exhaustive\ _lifecycle_event_receiver
-    | let s: ServerLifecycleEventReceiver ref =>
+    | let s: ServerLifecycleEventReceiver[TCP] ref =>
       _complete_server_initialization(s)
-    | let c: ClientLifecycleEventReceiver ref =>
+    | let c: ClientLifecycleEventReceiver[TCP] ref =>
       _complete_client_initialization(c)
     | None =>
       _Unreachable()
     end
 
   fun ref _complete_client_initialization(
-    s: ClientLifecycleEventReceiver ref)
+    s: ClientLifecycleEventReceiver[TCP] ref)
   =>
     if _ssl is _TLSFailed then
-      _state = _Closed
+      _state = _Closed[TCP]
       s._on_connection_failure(ConnectionFailedSSL)
       return
     end
 
     match \exhaustive\ _enclosing
-    | let e: TCPConnectionActor ref =>
-      _state = _ClientConnecting
+    | let e: TCPConnectionActor[TCP] ref =>
+      _state = _ClientConnecting[TCP]
 
       _inflight_connections =
-        PonyTCP.connect(
+        _tcp.connect(
           e, _host, _port, _from, AsioEvent.read_write_oneshot()
           where ip_version = _ip_version)
       _had_inflight = _inflight_connections > 0
@@ -1930,29 +1941,29 @@ class TCPConnection
     end
 
   fun ref _complete_server_initialization(
-    s: ServerLifecycleEventReceiver ref)
+    s: ServerLifecycleEventReceiver[TCP] ref)
   =>
     if _ssl is _TLSFailed then
       // Raw fd: no ASIO event has been created for it yet (that happens below,
       // after this early return), so close it directly on every platform. Do
       // NOT route this through `_close_event_fd` — that defers to the readiness
       // backend on Windows, which would never close this never-subscribed fd.
-      PonyTCP.close(_fd)
+      _tcp.close(_fd)
       _fd = -1
-      _state = _Closed
+      _state = _Closed[TCP]
       s._on_start_failure(StartFailedSSL)
       return
     end
 
     match \exhaustive\ _enclosing
-    | let e: TCPConnectionActor ref =>
+    | let e: TCPConnectionActor[TCP] ref =>
       _event = PonyAsio.create_event(e, _fd)
       _set_readable()
       _set_writeable()
 
       match \exhaustive\ _ssl
       | let _: _TLS =>
-        _state = _SSLHandshaking
+        _state = _SSLHandshaking[TCP]
         // Flush any initial SSL data (usually no-op for servers).
         // _on_started() and _arm_idle_timer() deferred until
         // ssl_handshake_complete.
@@ -1960,7 +1971,7 @@ class TCPConnection
       | _TLSDisposed | _TLSFailed =>
         _Unreachable()
       | _NoTLS =>
-        _state = _Open
+        _state = _Open[TCP]
         _arm_idle_timer()
         s._on_started()
       end

--- a/lori/tcp_connection_actor.pony
+++ b/lori/tcp_connection_actor.pony
@@ -1,4 +1,5 @@
-trait tag TCPConnectionActor is AsioEventNotify
+trait tag TCPConnectionActor[TCP: TCPBackend val = RuntimeBackend]
+  is AsioEventNotify
   """
   The actor trait a connection actor implements. Provide `_connection()`
   returning the `TCPConnection` the actor owns; the behaviors here deliver ASIO
@@ -6,7 +7,7 @@ trait tag TCPConnectionActor is AsioEventNotify
   together with a `ClientLifecycleEventReceiver` or
   `ServerLifecycleEventReceiver` for the connection callbacks.
   """
-  fun ref _connection(): TCPConnection
+  fun ref _connection(): TCPConnection[TCP]
 
   be dispose() =>
     """
@@ -28,7 +29,7 @@ trait tag TCPConnectionActor is AsioEventNotify
     """
     _connection().read_again()
 
-  be _register_spawner(listener: TCPListenerActor) =>
+  be _register_spawner(listener: TCPListenerActor[TCP]) =>
     """
     Register the listener as the spawner of this connection
     """

--- a/lori/tcp_listener.pony
+++ b/lori/tcp_listener.pony
@@ -1,13 +1,14 @@
 use "collections"
 use net = "net"
 
-class TCPListener
+class TCPListener[TCP: TCPBackend val = RuntimeBackend]
   """
   The TCP listener: opens a listening socket, runs the accept loop, and
   enforces the connection limit. A `TCPListenerActor` owns one and delegates to
   it. Create it with `TCPListener(auth, host, port, this)`, using
   `TCPListener.none()` as the field initializer before that.
   """
+  let _tcp: TCP = TCP
   let _host: String
   let _port: String
   let _limit: (MaxSpawn | None)
@@ -17,12 +18,12 @@ class TCPListener
   var _event: AsioEventID = AsioEvent.none()
   var _fd: U32 = -1
   var _listening: Bool = false
-  var _enclosing: (TCPListenerActor ref | None)
+  var _enclosing: (TCPListenerActor[TCP] ref | None)
 
   new create(auth: TCPListenAuth,
     host: String,
     port: String,
-    enclosing: TCPListenerActor ref,
+    enclosing: TCPListenerActor[TCP] ref,
     ip_version: IPVersion = DualStack,
     limit: (MaxSpawn | None) = DefaultMaxSpawn())
   =>
@@ -46,7 +47,7 @@ class TCPListener
 
   fun ref close() =>
     match \exhaustive\ _enclosing
-    | let e: TCPListenerActor ref =>
+    | let e: TCPListenerActor[TCP] ref =>
       // TODO: when in debug mode we should blow up if listener is closed
       if _listening then
         _listening = false
@@ -60,7 +61,7 @@ class TCPListener
           // accepted/rejected fds in _accept are raw (never subscribed), so
           // those closes stay cross-platform.
           ifdef not windows then
-            PonyTCP.close(_fd)
+            _tcp.close(_fd)
           end
           _fd = -1
           e._on_closed()
@@ -77,7 +78,7 @@ class TCPListener
     """
     recover
       let ip: net.NetAddress ref = net.NetAddress
-      PonyTCP.sockname(_fd, ip)
+      _tcp.sockname(_fd, ip)
       ip
     end
 
@@ -103,10 +104,10 @@ class TCPListener
 
   fun ref _accept() =>
     match \exhaustive\ _enclosing
-    | let e: TCPListenerActor ref =>
+    | let e: TCPListenerActor[TCP] ref =>
       if _listening then
         while not _at_connection_limit() do
-          var fd = PonyTCP.accept(_event)
+          var fd = _tcp.accept(_event)
 
           // 0: would block, -1: error
           if fd <= 0 then
@@ -120,7 +121,7 @@ class TCPListener
           else
             // Rejected before an event was created — raw fd, close on both
             // platforms.
-            PonyTCP.close(fd.u32())
+            _tcp.close(fd.u32())
           end
         end
 
@@ -149,8 +150,8 @@ class TCPListener
 
   fun ref _finish_initialization() =>
     match \exhaustive\ _enclosing
-    | let e: TCPListenerActor ref =>
-      _event = PonyTCP.listen(e, _host, _port where ip_version = _ip_version)
+    | let e: TCPListenerActor[TCP] ref =>
+      _event = _tcp.listen(e, _host, _port where ip_version = _ip_version)
       if not _event.is_null() then
         _fd = PonyAsio.event_fd(_event)
         _listening = true

--- a/lori/tcp_listener_actor.pony
+++ b/lori/tcp_listener_actor.pony
@@ -1,4 +1,5 @@
-trait tag TCPListenerActor is AsioEventNotify
+trait tag TCPListenerActor[TCP: TCPBackend val = RuntimeBackend]
+  is AsioEventNotify
   """
   The actor trait a listener actor implements. Provide `_listener()` returning
   the `TCPListener` the actor owns; the behaviors here deliver ASIO events to
@@ -6,9 +7,9 @@ trait tag TCPListenerActor is AsioEventNotify
   socket, and the listen lifecycle callbacks (`_on_listening`,
   `_on_listen_failure`, `_on_closed`) as needed.
   """
-  fun ref _listener(): TCPListener
+  fun ref _listener(): TCPListener[TCP]
 
-  fun ref _on_accept(fd: U32): TCPConnectionActor ?
+  fun ref _on_accept(fd: U32): TCPConnectionActor[TCP] ?
     """
     Called when a connection is accepted
     """

--- a/stress-tests/tcp-swarm/README.md
+++ b/stress-tests/tcp-swarm/README.md
@@ -20,7 +20,7 @@ oracle on top. Each flag is tied to a distinct code path in `tcp_connection.pony
 - `--write-shape` (`write` | `writev`) — a single-buffer `send(ByteSeq)` vs a
   vectored `send(ByteSeqIter)`.
 - `--writev-chunks` (`N`, writev only) — how many buffers one vectored `send`
-  splits its payload into. Above `PonyTCP.writev_max()` (IOV_MAX on POSIX, 1 on
+  splits its payload into. Above `RuntimeBackend.writev_max()` (IOV_MAX on POSIX, 1 on
   Windows) a single `send` queues more buffers than one `writev` syscall can carry,
   so `_send_pending_writes()` takes its multi-batch path — one `writev_max`-sized
   batch per pass.

--- a/stress-tests/tcp-swarm/tcp_swarm.pony
+++ b/stress-tests/tcp-swarm/tcp_swarm.pony
@@ -16,7 +16,7 @@ Each swarm dimension is tied to a distinct code path in lori's
 * `--write-shape` (`write` | `writev`) -- a single-buffer `send(ByteSeq)` vs a
   vectored `send(ByteSeqIter)`.
 * `--writev-chunks` (N, writev only) -- how many buffers a single vectored
-  `send` splits its payload into. Above `PonyTCP.writev_max()` (IOV_MAX on
+  `send` splits its payload into. Above `writev_max()` (IOV_MAX on
   POSIX, 1 on Windows) lori's `_send_pending_writes()` takes its multi-batch
   path, sending one `writev_max`-sized batch per pass.
 * `--expect` (0 = off, N = frame size) -- fixed-size framed reads via


### PR DESCRIPTION
The TCP I/O calls that were hardcoded to PonyTCP now go through a type parameter `TCP: TCPBackend val = RuntimeBackend`. Test code can substitute a fake implementation to drive the connection state machine without real sockets.

Pony fully reifies generics, so every concrete instantiation compiles to direct calls — zero runtime dispatch overhead. The default type parameter means existing code compiles unchanged: bare `TCPConnection`, `TCPListener`, and the actor/receiver traits all resolve to the RuntimeBackend instantiation without a type argument.

PonyTCP is renamed to RuntimeBackend. `TCPBackend` is public so downstream users can implement test fakes for their own actors.

**Scope**: Only the TCP operations called via RuntimeBackend are abstracted (11 methods). PonyAsio calls (~33 sites) stay direct — a test fake substitutes sockets, not the event loop.

Closes #34
