### PR TITLE
Fix resource leak when disposing a server connection during initialization

### DIFF
--- a/.release-notes/fix-dispose-during-init.md
+++ b/.release-notes/fix-dispose-during-init.md
@@ -1,0 +1,3 @@
+## Fix resource leak when disposing a server connection during initialization
+
+Disposing a server-side `TCPConnection` before it finished initializing leaked an ASIO event. The leaked event was noisy, so the runtime would not exit. This could happen when a listener disposed an accepted connection immediately — the dispose could arrive before the connection's deferred initialization, since the two messages come from different actors.

--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -168,8 +168,12 @@ class _ConnectionNone[TCP: TCPBackend val] is _ConnectionState[TCP]
     // _finish_initialization is a self→self message queued during the
     // constructor. dispose() comes from an external actor. Different senders
     // have no ordering guarantee, so dispose() can arrive first — unlikely
-    // but possible.
-    None
+    // but possible. Transition to _Closed so _finish_initialization (which
+    // will still run) sees it and skips ASIO event creation. No ASIO event
+    // exists yet, so close the raw fd directly and dispose TLS.
+    conn._set_state(_Closed[TCP])
+    conn._close_raw_fd()
+    conn._dispose_tls()
 
   fun ref start_tls(conn: TCPConnection[TCP] ref,
     ssl_ctx: SSLContext val,

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -109,6 +109,29 @@ actor \nodoc\ Main is TestList
     // POSIX only: these provoke write backpressure with a fixed payload, which
     // Windows loopback won't trigger (it buffers far beyond SO_SNDBUF/RCVBUF).
     // The drain and write-only re-arm logic they cover is platform-neutral.
+
+    // Fake-backend tests (no real sockets for I/O)
+    test(_TestFakeSendOk)
+    test(_TestFakeSendMultipleTokenOrder)
+    test(_TestFakeSendOnClosed)
+    test(_TestFakeSendError)
+    test(_TestFakeSendFailedAfterClosed)
+    test(_TestFakeRecvError)
+    test(_TestFakeRecvRetry)
+    test(_TestFakeRecvData)
+    test(_TestFakeRecvFramed)
+    test(_TestFakeMute)
+    test(_TestFakeYieldReading)
+    test(_TestFakeGracefulClose)
+    test(_TestFakeConnectDNSFailure)
+    test(_TestFakeConnectInflight)
+    test(_TestFakeSendWhileConnecting)
+    test(_TestFakeSendWhileUnconnectedClosing)
+    test(_TestFakeUnconnectedClosingDrain)
+    test(_TestFakeHardCloseDuringUnconnectedClosing)
+    test(_TestFakeListenFailure)
+    test(_TestFakeAccept)
+    test(_TestFakeConnectionLimit)
     ifdef posix then test(_TestStaleForeignEventDropped) end
     ifdef posix then test(_TestBackpressureDrain) end
     ifdef posix then test(_TestWriteOnlyEventReadRecovery) end

--- a/lori/_test_connection.pony
+++ b/lori/_test_connection.pony
@@ -632,3 +632,848 @@ actor \nodoc\ _TestHardCloseAfterFramedReceiveServer
     else
       _h.fail("second frame delivered after hard_close()")
     end
+
+// ===========================================================================
+// Fake-backend receive tests (no real sockets for I/O)
+// ===========================================================================
+class \nodoc\ iso _TestFakeRecvError is UnitTest
+  """
+  receive returns error. Verify: _on_closed fires (hard close from receive
+  error). _on_received does not fire.
+  """
+  fun name(): String => "FakeRecvError"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("on_closed")
+
+    let a = _TestFakeRecvErrorActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeRecvErrorActor
+  is (TCPConnectionActor[_FBSendOkRecvError]
+    & ServerLifecycleEventReceiver[_FBSendOkRecvError])
+  var _tcp_connection: TCPConnection[_FBSendOkRecvError] =
+    TCPConnection[_FBSendOkRecvError].none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    try
+      let fd = _FakeServerFd()?
+      _tcp_connection =
+        TCPConnection[_FBSendOkRecvError].server(
+          TCPServerAuth(_h.env.root),
+          fd,
+          this,
+          this)
+    else
+      _h.fail("could not allocate socket")
+      _h.complete(false)
+    end
+
+  fun ref _connection(): TCPConnection[_FBSendOkRecvError] =>
+    _tcp_connection
+
+  fun ref _on_received(data: Array[U8] iso): ReadAction =>
+    _h.fail("_on_received should not fire when receive errors")
+    _h.complete(false)
+    KeepReading
+
+  fun ref _on_closed() =>
+    _h.complete_action("on_closed")
+
+  be dispose() =>
+    _tcp_connection.hard_close()
+
+class \nodoc\ iso _TestFakeRecvRetry is UnitTest
+  """
+  receive returns retry. Verify: _on_received does not fire. The connection
+  waits for the next readable event.
+  """
+  fun name(): String => "FakeRecvRetry"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("started")
+
+    let a = _TestFakeRecvRetryActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeRecvRetryActor
+  is (TCPConnectionActor[_FBSendOkRecvRetry]
+    & ServerLifecycleEventReceiver[_FBSendOkRecvRetry])
+  var _tcp_connection: TCPConnection[_FBSendOkRecvRetry] =
+    TCPConnection[_FBSendOkRecvRetry].none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    try
+      let fd = _FakeServerFd()?
+      _tcp_connection =
+        TCPConnection[_FBSendOkRecvRetry].server(
+          TCPServerAuth(_h.env.root),
+          fd,
+          this,
+          this)
+    else
+      _h.fail("could not allocate socket")
+      _h.complete(false)
+    end
+
+  fun ref _connection(): TCPConnection[_FBSendOkRecvRetry] =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    _tcp_connection.mute()
+    _h.complete_action("started")
+
+  fun ref _on_received(data: Array[U8] iso): ReadAction =>
+    _h.fail("_on_received should not fire when receive retries")
+    _h.complete(false)
+    KeepReading
+
+  be dispose() =>
+    _tcp_connection.hard_close()
+
+class \nodoc\ iso _TestFakeRecvData is UnitTest
+  """
+  receive delivers "hello" on the first call, then retries. Verify:
+  _on_received fires with "hello".
+  """
+  fun name(): String => "FakeRecvData"
+
+  fun apply(h: TestHelper) =>
+    @lori_test_set_recv_hello_step(0)
+
+    h.expect_action("received_hello")
+
+    let a = _TestFakeRecvDataActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeRecvDataActor
+  is (TCPConnectionActor[_FBSendOkRecvHello]
+    & ServerLifecycleEventReceiver[_FBSendOkRecvHello])
+  var _tcp_connection: TCPConnection[_FBSendOkRecvHello] =
+    TCPConnection[_FBSendOkRecvHello].none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    try
+      let fd = _FakeServerFd()?
+      _tcp_connection =
+        TCPConnection[_FBSendOkRecvHello].server(
+          TCPServerAuth(_h.env.root),
+          fd,
+          this,
+          this)
+    else
+      _h.fail("could not allocate socket")
+      _h.complete(false)
+    end
+
+  fun ref _connection(): TCPConnection[_FBSendOkRecvHello] =>
+    _tcp_connection
+
+  fun ref _on_received(data: Array[U8] iso): ReadAction =>
+    let s = String.from_iso_array(consume data)
+    if s == "hello" then
+      _tcp_connection.mute()
+      _h.complete_action("received_hello")
+    else
+      _h.fail("expected 'hello', got '" + consume s + "'")
+      _h.complete(false)
+    end
+    KeepReading
+
+  be dispose() =>
+    _tcp_connection.hard_close()
+
+class \nodoc\ iso _TestFakeRecvFramed is UnitTest
+  """
+  receive delivers 10 bytes, buffer_until(4). Verify: _on_received fires
+  twice with 4 bytes each.
+  """
+  fun name(): String => "FakeRecvFramed"
+
+  fun apply(h: TestHelper) =>
+    @lori_test_set_recv_10_step(0)
+
+    h.expect_action("received_two_frames")
+
+    let a = _TestFakeRecvFramedActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeRecvFramedActor
+  is (TCPConnectionActor[_FBSendOkRecv10]
+    & ServerLifecycleEventReceiver[_FBSendOkRecv10])
+  var _tcp_connection: TCPConnection[_FBSendOkRecv10] =
+    TCPConnection[_FBSendOkRecv10].none()
+  let _h: TestHelper
+  var _received_count: USize = 0
+
+  new create(h: TestHelper) =>
+    _h = h
+    try
+      let fd = _FakeServerFd()?
+      _tcp_connection =
+        TCPConnection[_FBSendOkRecv10].server(
+          TCPServerAuth(_h.env.root),
+          fd,
+          this,
+          this)
+      match MakeBufferSize(4)
+      | let b: BufferSize => _tcp_connection.buffer_until(b)
+      else _Unreachable()
+      end
+    else
+      _h.fail("could not allocate socket")
+      _h.complete(false)
+    end
+
+  fun ref _connection(): TCPConnection[_FBSendOkRecv10] =>
+    _tcp_connection
+
+  fun ref _on_received(data: Array[U8] iso): ReadAction =>
+    _received_count = _received_count + 1
+    _h.assert_eq[USize](
+      4,
+      data.size(),
+      "frame " + _received_count.string() + " should be 4 bytes")
+    if _received_count == 2 then
+      _tcp_connection.mute()
+      _h.complete_action("received_two_frames")
+    end
+    KeepReading
+
+  be dispose() =>
+    _tcp_connection.hard_close()
+
+class \nodoc\ iso _TestFakeMute is UnitTest
+  """
+  mute() before read loop runs prevents _on_received from firing. unmute()
+  resumes delivery via _read_again.
+  """
+  fun name(): String => "FakeMute"
+
+  fun apply(h: TestHelper) =>
+    @lori_test_set_recv_mute_step(0)
+
+    h.expect_action("received_after_unmute")
+
+    let a = _TestFakeMuteActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeMuteActor
+  is (TCPConnectionActor[_FBSendOkRecvHelloMute]
+    & ServerLifecycleEventReceiver[_FBSendOkRecvHelloMute])
+  var _tcp_connection: TCPConnection[_FBSendOkRecvHelloMute] =
+    TCPConnection[_FBSendOkRecvHelloMute].none()
+  let _h: TestHelper
+  var _unmuted: Bool = false
+
+  new create(h: TestHelper) =>
+    _h = h
+    try
+      let fd = _FakeServerFd()?
+      _tcp_connection =
+        TCPConnection[_FBSendOkRecvHelloMute].server(
+          TCPServerAuth(_h.env.root),
+          fd,
+          this,
+          this)
+    else
+      _h.fail("could not allocate socket")
+      _h.complete(false)
+    end
+
+  fun ref _connection(): TCPConnection[_FBSendOkRecvHelloMute] =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    _tcp_connection.mute()
+    _check_muted()
+
+  be _check_muted() =>
+    _unmuted = true
+    _tcp_connection.unmute()
+
+  fun ref _on_received(data: Array[U8] iso): ReadAction =>
+    if not _unmuted then
+      _h.fail("_on_received fired while muted")
+      _h.complete(false)
+    else
+      _tcp_connection.mute()
+      _h.complete_action("received_after_unmute")
+    end
+    KeepReading
+
+  be dispose() =>
+    _tcp_connection.hard_close()
+
+class \nodoc\ iso _TestFakeYieldReading is UnitTest
+  """
+  _on_received returns YieldReading. Verify: no further delivery until
+  _read_again runs in a subsequent behavior turn.
+  """
+  fun name(): String => "FakeYieldReading"
+
+  fun apply(h: TestHelper) =>
+    @lori_test_set_recv_yield_step(0)
+
+    h.expect_action("yielded_then_resumed")
+
+    let a = _TestFakeYieldReadingActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeYieldReadingActor
+  is (TCPConnectionActor[_FBSendOkRecv10Yield]
+    & ServerLifecycleEventReceiver[_FBSendOkRecv10Yield])
+  var _tcp_connection: TCPConnection[_FBSendOkRecv10Yield] =
+    TCPConnection[_FBSendOkRecv10Yield].none()
+  let _h: TestHelper
+  var _received_count: USize = 0
+  var _yielded: Bool = false
+
+  new create(h: TestHelper) =>
+    _h = h
+    try
+      let fd = _FakeServerFd()?
+      _tcp_connection =
+        TCPConnection[_FBSendOkRecv10Yield].server(
+          TCPServerAuth(_h.env.root),
+          fd,
+          this,
+          this)
+      match MakeBufferSize(5)
+      | let b: BufferSize => _tcp_connection.buffer_until(b)
+      else _Unreachable()
+      end
+    else
+      _h.fail("could not allocate socket")
+      _h.complete(false)
+    end
+
+  fun ref _connection(): TCPConnection[_FBSendOkRecv10Yield] =>
+    _tcp_connection
+
+  fun ref _on_received(data: Array[U8] iso): ReadAction =>
+    _received_count = _received_count + 1
+    if _received_count == 1 then
+      _yielded = true
+      YieldReading
+    else
+      if _yielded then
+        _tcp_connection.mute()
+        _h.complete_action("yielded_then_resumed")
+      else
+        _h.fail("second delivery without yielding first")
+        _h.complete(false)
+      end
+      KeepReading
+    end
+
+  be dispose() =>
+    _tcp_connection.hard_close()
+
+// ---------------------------------------------------------------------------
+// Client connection fake-backend tests
+// ---------------------------------------------------------------------------
+class \nodoc\ iso _TestFakeConnectDNSFailure is UnitTest
+  """
+  connect returns 0 (no addresses resolved). _on_connection_failure fires
+  with ConnectionFailedDNS.
+  """
+  fun name(): String => "FakeConnectDNSFailure"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("connection_failed_dns")
+
+    let a = _TestFakeConnectDNSFailureActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeConnectDNSFailureActor
+  is (TCPConnectionActor[_FBConnect0]
+    & ClientLifecycleEventReceiver[_FBConnect0])
+  var _tcp_connection: TCPConnection[_FBConnect0] =
+    TCPConnection[_FBConnect0].none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_connection =
+      TCPConnection[_FBConnect0].client(
+        TCPConnectAuth(_h.env.root),
+        "fake-host",
+        "12345",
+        "",
+        this,
+        this)
+
+  fun ref _connection(): TCPConnection[_FBConnect0] =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _h.fail("_on_connected should not fire for DNS failure")
+    _h.complete(false)
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    match reason
+    | ConnectionFailedDNS =>
+      _h.complete_action("connection_failed_dns")
+    else
+      _h.fail("expected ConnectionFailedDNS")
+      _h.complete(false)
+    end
+
+class \nodoc\ iso _TestFakeConnectInflight is UnitTest
+  """
+  connect returns 3 (three inflight attempts). _on_connecting fires with
+  count 3.
+  """
+  fun name(): String => "FakeConnectInflight"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("on_connecting_3")
+
+    let a = _TestFakeConnectInflightActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeConnectInflightActor
+  is (TCPConnectionActor[_FBConnect3]
+    & ClientLifecycleEventReceiver[_FBConnect3])
+  var _tcp_connection: TCPConnection[_FBConnect3] =
+    TCPConnection[_FBConnect3].none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_connection =
+      TCPConnection[_FBConnect3].client(
+        TCPConnectAuth(_h.env.root),
+        "fake-host",
+        "12345",
+        "",
+        this,
+        this)
+
+  fun ref _connection(): TCPConnection[_FBConnect3] =>
+    _tcp_connection
+
+  fun ref _on_connecting(inflight_connections: U32) =>
+    if inflight_connections == 3 then
+      _h.complete_action("on_connecting_3")
+    else
+      _h.fail("expected inflight_connections == 3, got " +
+        inflight_connections.string())
+      _h.complete(false)
+    end
+
+// ---------------------------------------------------------------------------
+// State machine fake-backend tests
+// ---------------------------------------------------------------------------
+class \nodoc\ iso _TestFakeSendWhileConnecting is UnitTest
+  """
+  send() in _ClientConnecting returns SendErrorNotConnected.
+  """
+  fun name(): String => "FakeSendWhileConnecting"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("send_rejected")
+
+    let a = _TestFakeSendWhileConnectingActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeSendWhileConnectingActor
+  is (TCPConnectionActor[_FBConnect1]
+    & ClientLifecycleEventReceiver[_FBConnect1])
+  var _tcp_connection: TCPConnection[_FBConnect1] =
+    TCPConnection[_FBConnect1].none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_connection =
+      TCPConnection[_FBConnect1].client(
+        TCPConnectAuth(_h.env.root),
+        "fake-host",
+        "12345",
+        "",
+        this,
+        this)
+
+  fun ref _connection(): TCPConnection[_FBConnect1] =>
+    _tcp_connection
+
+  fun ref _on_connecting(inflight_connections: U32) =>
+    match \exhaustive\ _tcp_connection.send("aaa")
+    | SendAccepted =>
+      _h.fail("send should not succeed while connecting")
+      _h.complete(false)
+    | SendErrorNotConnected =>
+      _h.complete_action("send_rejected")
+    | SendErrorNotWriteable =>
+      _h.fail("send returned SendErrorNotWriteable")
+      _h.complete(false)
+    end
+
+class \nodoc\ iso _TestFakeSendWhileUnconnectedClosing is UnitTest
+  """
+  send() in _UnconnectedClosing returns SendErrorNotConnected.
+  """
+  fun name(): String => "FakeSendWhileUnconnectedClosing"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("send_rejected")
+
+    let a = _TestFakeSendWhileUnconnectedClosingActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeSendWhileUnconnectedClosingActor
+  is (TCPConnectionActor[_FBConnect1]
+    & ClientLifecycleEventReceiver[_FBConnect1])
+  var _tcp_connection: TCPConnection[_FBConnect1] =
+    TCPConnection[_FBConnect1].none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_connection =
+      TCPConnection[_FBConnect1].client(
+        TCPConnectAuth(_h.env.root),
+        "fake-host",
+        "12345",
+        "",
+        this,
+        this)
+
+  fun ref _connection(): TCPConnection[_FBConnect1] =>
+    _tcp_connection
+
+  fun ref _on_connecting(inflight_connections: U32) =>
+    _tcp_connection.close()
+    match \exhaustive\ _tcp_connection.send("aaa")
+    | SendAccepted =>
+      _h.fail("send should not succeed in _UnconnectedClosing")
+      _h.complete(false)
+    | SendErrorNotConnected =>
+      _h.complete_action("send_rejected")
+    | SendErrorNotWriteable =>
+      _h.fail("send returned SendErrorNotWriteable")
+      _h.complete(false)
+    end
+
+class \nodoc\ iso _TestFakeUnconnectedClosingDrain is UnitTest
+  """
+  close() during connecting enters _UnconnectedClosing. Two foreign events
+  drain the inflight count to 0, triggering _on_connection_failure.
+  """
+  fun name(): String => "FakeUnconnectedClosingDrain"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("connection_failed")
+
+    let a = _TestFakeUnconnectedClosingDrainActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeUnconnectedClosingDrainActor
+  is (TCPConnectionActor[_FBConnect2]
+    & ClientLifecycleEventReceiver[_FBConnect2])
+  var _tcp_connection: TCPConnection[_FBConnect2] =
+    TCPConnection[_FBConnect2].none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_connection =
+      TCPConnection[_FBConnect2].client(
+        TCPConnectAuth(_h.env.root),
+        "fake-host",
+        "12345",
+        "",
+        this,
+        this)
+
+  fun ref _connection(): TCPConnection[_FBConnect2] =>
+    _tcp_connection
+
+  fun ref _on_connecting(inflight_connections: U32) =>
+    _tcp_connection.close()
+    _deliver_stragglers()
+
+  be _deliver_stragglers() =>
+    try
+      let fd1 = @socket(I32(2), I32(1), I32(0))
+      if fd1 < 0 then error end
+      let ev1 = PonyAsio.create_event(this, fd1.u32())
+      _tcp_connection._event_notify(ev1, AsioEvent.read_write())
+
+      let fd2 = @socket(I32(2), I32(1), I32(0))
+      if fd2 < 0 then error end
+      let ev2 = PonyAsio.create_event(this, fd2.u32())
+      _tcp_connection._event_notify(ev2, AsioEvent.read_write())
+    else
+      _h.fail("could not allocate straggler sockets")
+      _h.complete(false)
+    end
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    _h.complete_action("connection_failed")
+
+class \nodoc\ iso _TestFakeHardCloseDuringUnconnectedClosing is UnitTest
+  """
+  hard_close() during _UnconnectedClosing fires _on_connection_failure
+  without waiting for stragglers.
+  """
+  fun name(): String => "FakeHardCloseDuringUnconnectedClosing"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("connection_failed")
+
+    let a = _TestFakeHardCloseDuringUnconnectedClosingActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeHardCloseDuringUnconnectedClosingActor
+  is (TCPConnectionActor[_FBConnect2]
+    & ClientLifecycleEventReceiver[_FBConnect2])
+  var _tcp_connection: TCPConnection[_FBConnect2] =
+    TCPConnection[_FBConnect2].none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_connection =
+      TCPConnection[_FBConnect2].client(
+        TCPConnectAuth(_h.env.root),
+        "fake-host",
+        "12345",
+        "",
+        this,
+        this)
+
+  fun ref _connection(): TCPConnection[_FBConnect2] =>
+    _tcp_connection
+
+  fun ref _on_connecting(inflight_connections: U32) =>
+    _tcp_connection.close()
+    _tcp_connection.hard_close()
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    _h.complete_action("connection_failed")
+
+// ---------------------------------------------------------------------------
+// Listener fake-backend tests
+// ---------------------------------------------------------------------------
+actor \nodoc\ _TestFakeServerStub[TCP: TCPBackend val]
+  is (TCPConnectionActor[TCP] & ServerLifecycleEventReceiver[TCP])
+  """
+  Minimal server connection for listener accept tests. Closes the fd via
+  the fake backend on dispose.
+  """
+  var _tcp_connection: TCPConnection[TCP] = TCPConnection[TCP].none()
+
+  new create(fd: U32, h: TestHelper) =>
+    _tcp_connection =
+      TCPConnection[TCP].server(
+        TCPServerAuth(h.env.root),
+        fd,
+        this,
+        this)
+
+  fun ref _connection(): TCPConnection[TCP] =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    _tcp_connection.mute()
+
+class \nodoc\ iso _TestFakeListenFailure is UnitTest
+  """
+  listen returns a null event. _on_listen_failure fires.
+  """
+  fun name(): String => "FakeListenFailure"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("listen_failed")
+
+    let a = _TestFakeListenFailureActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeListenFailureActor is TCPListenerActor[_FBListenFail]
+  var _tcp_listener: TCPListener[_FBListenFail] =
+    TCPListener[_FBListenFail].none()
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_listener =
+      TCPListener[_FBListenFail](
+        TCPListenAuth(_h.env.root),
+        "fake-host",
+        "12345",
+        this)
+
+  fun ref _listener(): TCPListener[_FBListenFail] =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestFakeServerStub[_FBListenFail] ? =>
+    _h.fail("_on_accept should not fire")
+    error
+
+  fun ref _on_listen_failure() =>
+    _h.complete_action("listen_failed")
+
+class \nodoc\ iso _TestFakeAccept is UnitTest
+  """
+  listen succeeds and accept returns one connection. _on_accept fires
+  with the fd.
+  """
+  fun name(): String => "FakeAccept"
+
+  fun apply(h: TestHelper) =>
+    @lori_test_set_accept_step(0)
+
+    h.expect_action("accepted")
+
+    let a = _TestFakeAcceptActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeAcceptActor is TCPListenerActor[_FBListenOk]
+  var _tcp_listener: TCPListener[_FBListenOk] =
+    TCPListener[_FBListenOk].none()
+  let _h: TestHelper
+  var _accepted: (_TestFakeServerStub[_FBListenOk] | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+    _tcp_listener =
+      TCPListener[_FBListenOk](
+        TCPListenAuth(_h.env.root),
+        "fake-host",
+        "12345",
+        this)
+
+  fun ref _listener(): TCPListener[_FBListenOk] =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _TestFakeServerStub[_FBListenOk] =>
+    let stub = _TestFakeServerStub[_FBListenOk](fd, _h)
+    _accepted = stub
+    _h.complete_action("accepted")
+    stub
+
+  fun ref _on_listening() =>
+    _tcp_listener._accept()
+
+  fun ref _on_closed() =>
+    try (_accepted as _TestFakeServerStub[_FBListenOk]).dispose() end
+
+class \nodoc\ iso _TestFakeConnectionLimit is UnitTest
+  """
+  Listener with max_spawn 2 pauses after accepting 2 connections. Closing
+  one resumes accepting.
+  """
+  fun name(): String => "FakeConnectionLimit"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("accept_1")
+    h.expect_action("accept_2")
+    h.expect_action("accept_3")
+
+    let a = _TestFakeConnectionLimitActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeConnectionLimitActor
+  is TCPListenerActor[_FBListenOkMulti]
+  var _tcp_listener: TCPListener[_FBListenOkMulti] =
+    TCPListener[_FBListenOkMulti].none()
+  let _h: TestHelper
+  var _accept_count: U32 = 0
+  var _first_accepted:
+    (_TestFakeServerStub[_FBListenOkMulti] | None) = None
+  var _second_accepted:
+    (_TestFakeServerStub[_FBListenOkMulti] | None) = None
+  var _third_accepted:
+    (_TestFakeServerStub[_FBListenOkMulti] | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+    match \exhaustive\ MakeMaxSpawn(2)
+    | let limit: MaxSpawn =>
+      _tcp_listener =
+        TCPListener[_FBListenOkMulti](
+          TCPListenAuth(_h.env.root),
+          "fake-host",
+          "12345",
+          this where limit = limit)
+    | let _: ValidationFailure =>
+      _h.fail("MakeMaxSpawn(2) failed")
+    end
+
+  fun ref _listener(): TCPListener[_FBListenOkMulti] =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32)
+    : _TestFakeServerStub[_FBListenOkMulti]
+  =>
+    _accept_count = _accept_count + 1
+    let stub = _TestFakeServerStub[_FBListenOkMulti](fd, _h)
+    match _accept_count
+    | 1 =>
+      _first_accepted = stub
+      _h.complete_action("accept_1")
+    | 2 =>
+      _second_accepted = stub
+      _h.complete_action("accept_2")
+    | 3 =>
+      _third_accepted = stub
+      _h.complete_action("accept_3")
+    end
+    stub
+
+  fun ref _on_listening() =>
+    _tcp_listener._accept()
+    _simulate_close()
+
+  be _simulate_close() =>
+    _tcp_listener._connection_closed()
+
+  fun ref _on_closed() =>
+    try
+      (_first_accepted as _TestFakeServerStub[_FBListenOkMulti]).dispose()
+    end
+    try
+      (_second_accepted as _TestFakeServerStub[_FBListenOkMulti]).dispose()
+    end
+    try
+      (_third_accepted as _TestFakeServerStub[_FBListenOkMulti]).dispose()
+    end

--- a/lori/_test_fake_backend.pony
+++ b/lori/_test_fake_backend.pony
@@ -1,0 +1,968 @@
+use "pony_test"
+use net = "net"
+
+// FFI: multi-step scripting state (backed by _test_fake_state.c)
+use @lori_test_get_sendv_failed_step[USize]()
+use @lori_test_set_sendv_failed_step[None](v: USize)
+use @lori_test_inc_sendv_failed_step[None]()
+use @lori_test_get_recv_hello_step[USize]()
+use @lori_test_set_recv_hello_step[None](v: USize)
+use @lori_test_inc_recv_hello_step[None]()
+use @lori_test_get_recv_10_step[USize]()
+use @lori_test_set_recv_10_step[None](v: USize)
+use @lori_test_inc_recv_10_step[None]()
+use @lori_test_get_recv_mute_step[USize]()
+use @lori_test_set_recv_mute_step[None](v: USize)
+use @lori_test_inc_recv_mute_step[None]()
+use @lori_test_get_recv_yield_step[USize]()
+use @lori_test_set_recv_yield_step[None](v: USize)
+use @lori_test_inc_recv_yield_step[None]()
+use @lori_test_get_accept_step[USize]()
+use @lori_test_set_accept_step[None](v: USize)
+use @lori_test_inc_accept_step[None]()
+
+// FFI: memcpy for writing into Pointer[U8] tag buffers in fake receive
+use @memcpy[Pointer[None]](dst: Pointer[None] tag, src: Pointer[None] tag,
+  n: USize)
+
+// FFI: raw socket — declaration lives in _test_stale_foreign_event.pony
+
+// ---------------------------------------------------------------------------
+// Shared stub methods
+// ---------------------------------------------------------------------------
+//
+// Every fake backend is a primitive implementing TCPBackend. Most methods are
+// identical stubs — only sendv, receive, connect, listen, or accept differ.
+// Pony primitives cannot inherit, so the stubs are repeated in each primitive.
+// The per-primitive docstring says which methods carry test behaviour; the rest
+// are stubs.
+
+// ---------------------------------------------------------------------------
+// Server-side fake backends
+// ---------------------------------------------------------------------------
+// Used with TCPConnection[X].server(). The server path never calls connect,
+// listen, or accept, so those are stubs. close releases the raw fd the test
+// allocated.
+
+primitive \nodoc\ _FBSendOkRecvRetry is TCPBackend
+  """
+  sendv: accepts all bytes.  receive: always retries.
+  """
+  fun listen(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    ip_version: IPVersion)
+    : AsioEventID
+  =>
+    AsioEvent.none()
+
+  fun accept(event: AsioEventID): I32 => 0
+
+  fun close(fd: U32) => @pony_os_socket_close(fd)
+
+  fun connect(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    from: String,
+    asio_flags: U32,
+    ip_version: IPVersion)
+    : U32
+  =>
+    0
+
+  fun keepalive(fd: U32, secs: U32) => None
+
+  fun peername(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun shutdown(fd: U32) => None
+
+  fun sockname(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun writev_max(): I32 => 1024
+
+  fun receive(event: AsioEventID,
+    buffer: Pointer[U8] tag,
+    size: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultRetry, 0)
+
+  fun sendv(event: AsioEventID,
+    data: Array[ByteSeq] box,
+    from: USize,
+    count: USize,
+    first_buffer_byte_offset: USize)
+    : (SocketResult, USize) ?
+  =>
+    var total: USize = 0
+    var i = from
+    let stop = from + count
+    while i < stop do
+      let s = data(i)?.size()
+      total = total + if i == from then s - first_buffer_byte_offset else s end
+      i = i + 1
+    end
+    (SocketResultOk, total)
+
+primitive \nodoc\ _FBSendErrorRecvRetry is TCPBackend
+  """
+  sendv: always returns error.  receive: always retries.
+  """
+  fun listen(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    ip_version: IPVersion)
+    : AsioEventID
+  =>
+    AsioEvent.none()
+
+  fun accept(event: AsioEventID): I32 => 0
+
+  fun close(fd: U32) => @pony_os_socket_close(fd)
+
+  fun connect(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    from: String,
+    asio_flags: U32,
+    ip_version: IPVersion)
+    : U32
+  =>
+    0
+
+  fun keepalive(fd: U32, secs: U32) => None
+
+  fun peername(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun shutdown(fd: U32) => None
+
+  fun sockname(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun writev_max(): I32 => 1024
+
+  fun receive(event: AsioEventID,
+    buffer: Pointer[U8] tag,
+    size: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultRetry, 0)
+
+  fun sendv(event: AsioEventID,
+    data: Array[ByteSeq] box,
+    from: USize,
+    count: USize,
+    first_buffer_byte_offset: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultError, 0)
+
+primitive \nodoc\ _FBSendStepRecvRetryFailed is TCPBackend
+  """
+  sendv: step 0 returns retry, step 1+ returns ok (all bytes).
+  receive: always retries.
+  Reset lori_test_set_sendv_failed_step(0) before use.
+  """
+  fun listen(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    ip_version: IPVersion)
+    : AsioEventID
+  =>
+    AsioEvent.none()
+
+  fun accept(event: AsioEventID): I32 => 0
+
+  fun close(fd: U32) => @pony_os_socket_close(fd)
+
+  fun connect(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    from: String,
+    asio_flags: U32,
+    ip_version: IPVersion)
+    : U32
+  =>
+    0
+
+  fun keepalive(fd: U32, secs: U32) => None
+
+  fun peername(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun shutdown(fd: U32) => None
+
+  fun sockname(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun writev_max(): I32 => 1024
+
+  fun receive(event: AsioEventID,
+    buffer: Pointer[U8] tag,
+    size: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultRetry, 0)
+
+  fun sendv(event: AsioEventID,
+    data: Array[ByteSeq] box,
+    from: USize,
+    count: USize,
+    first_buffer_byte_offset: USize)
+    : (SocketResult, USize) ?
+  =>
+    let step = @lori_test_get_sendv_failed_step()
+    @lori_test_inc_sendv_failed_step()
+    if step == 0 then
+      (SocketResultRetry, 0)
+    else
+      var total: USize = 0
+      var i = from
+      let stop = from + count
+      while i < stop do
+        let s = data(i)?.size()
+        total =
+          total + if i == from then s - first_buffer_byte_offset else s end
+        i = i + 1
+      end
+      (SocketResultOk, total)
+    end
+
+primitive \nodoc\ _FBSendOkRecvHello is TCPBackend
+  """
+  sendv: accepts all bytes.  receive: step 0 copies "hello" into buffer,
+  step 1+ returns retry.  Reset lori_test_set_recv_hello_step(0) before use.
+  """
+  fun listen(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    ip_version: IPVersion)
+    : AsioEventID
+  =>
+    AsioEvent.none()
+
+  fun accept(event: AsioEventID): I32 => 0
+
+  fun close(fd: U32) => @pony_os_socket_close(fd)
+
+  fun connect(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    from: String,
+    asio_flags: U32,
+    ip_version: IPVersion)
+    : U32
+  =>
+    0
+
+  fun keepalive(fd: U32, secs: U32) => None
+
+  fun peername(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun shutdown(fd: U32) => None
+
+  fun sockname(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun writev_max(): I32 => 1024
+
+  fun receive(event: AsioEventID,
+    buffer: Pointer[U8] tag,
+    size: USize)
+    : (SocketResult, USize)
+  =>
+    let step = @lori_test_get_recv_hello_step()
+    @lori_test_inc_recv_hello_step()
+    if step == 0 then
+      let src: Array[U8] val = [as U8: 'h'; 'e'; 'l'; 'l'; 'o']
+      @memcpy(buffer, src.cpointer(), 5)
+      (SocketResultOk, 5)
+    else
+      (SocketResultRetry, 0)
+    end
+
+  fun sendv(event: AsioEventID,
+    data: Array[ByteSeq] box,
+    from: USize,
+    count: USize,
+    first_buffer_byte_offset: USize)
+    : (SocketResult, USize) ?
+  =>
+    var total: USize = 0
+    var i = from
+    let stop = from + count
+    while i < stop do
+      let s = data(i)?.size()
+      total = total + if i == from then s - first_buffer_byte_offset else s end
+      i = i + 1
+    end
+    (SocketResultOk, total)
+
+primitive \nodoc\ _FBSendOkRecv10 is TCPBackend
+  """
+  sendv: accepts all bytes.  receive: step 0 copies 10 bytes ('A' repeated)
+  into buffer, step 1+ returns retry.  Reset lori_test_set_recv_10_step(0)
+  before use.
+  """
+  fun listen(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    ip_version: IPVersion)
+    : AsioEventID
+  =>
+    AsioEvent.none()
+
+  fun accept(event: AsioEventID): I32 => 0
+
+  fun close(fd: U32) => @pony_os_socket_close(fd)
+
+  fun connect(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    from: String,
+    asio_flags: U32,
+    ip_version: IPVersion)
+    : U32
+  =>
+    0
+
+  fun keepalive(fd: U32, secs: U32) => None
+
+  fun peername(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun shutdown(fd: U32) => None
+
+  fun sockname(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun writev_max(): I32 => 1024
+
+  fun receive(event: AsioEventID,
+    buffer: Pointer[U8] tag,
+    size: USize)
+    : (SocketResult, USize)
+  =>
+    let step = @lori_test_get_recv_10_step()
+    @lori_test_inc_recv_10_step()
+    if step == 0 then
+      let src: Array[U8] val = recover val Array[U8].init('A', 10) end
+      @memcpy(buffer, src.cpointer(), 10)
+      (SocketResultOk, 10)
+    else
+      (SocketResultRetry, 0)
+    end
+
+  fun sendv(event: AsioEventID,
+    data: Array[ByteSeq] box,
+    from: USize,
+    count: USize,
+    first_buffer_byte_offset: USize)
+    : (SocketResult, USize) ?
+  =>
+    var total: USize = 0
+    var i = from
+    let stop = from + count
+    while i < stop do
+      let s = data(i)?.size()
+      total = total + if i == from then s - first_buffer_byte_offset else s end
+      i = i + 1
+    end
+    (SocketResultOk, total)
+
+primitive \nodoc\ _FBSendOkRecvHelloMute is TCPBackend
+  """
+  sendv: accepts all bytes.  receive: step 0 copies "hello" into buffer,
+  step 1+ returns retry.  Uses recv_mute_step counter (separate from
+  _FBSendOkRecvHello's recv_hello_step) to avoid interference.
+  Reset lori_test_set_recv_mute_step(0) before use.
+  """
+  fun listen(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    ip_version: IPVersion)
+    : AsioEventID
+  =>
+    AsioEvent.none()
+
+  fun accept(event: AsioEventID): I32 => 0
+
+  fun close(fd: U32) => @pony_os_socket_close(fd)
+
+  fun connect(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    from: String,
+    asio_flags: U32,
+    ip_version: IPVersion)
+    : U32
+  =>
+    0
+
+  fun keepalive(fd: U32, secs: U32) => None
+
+  fun peername(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun shutdown(fd: U32) => None
+
+  fun sockname(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun writev_max(): I32 => 1024
+
+  fun receive(event: AsioEventID,
+    buffer: Pointer[U8] tag,
+    size: USize)
+    : (SocketResult, USize)
+  =>
+    let step = @lori_test_get_recv_mute_step()
+    @lori_test_inc_recv_mute_step()
+    if step == 0 then
+      let src: Array[U8] val = [as U8: 'h'; 'e'; 'l'; 'l'; 'o']
+      @memcpy(buffer, src.cpointer(), 5)
+      (SocketResultOk, 5)
+    else
+      (SocketResultRetry, 0)
+    end
+
+  fun sendv(event: AsioEventID,
+    data: Array[ByteSeq] box,
+    from: USize,
+    count: USize,
+    first_buffer_byte_offset: USize)
+    : (SocketResult, USize) ?
+  =>
+    var total: USize = 0
+    var i = from
+    let stop = from + count
+    while i < stop do
+      let s = data(i)?.size()
+      total = total + if i == from then s - first_buffer_byte_offset else s end
+      i = i + 1
+    end
+    (SocketResultOk, total)
+
+primitive \nodoc\ _FBSendOkRecv10Yield is TCPBackend
+  """
+  sendv: accepts all bytes.  receive: step 0 copies 10 bytes ('A' repeated)
+  into buffer, step 1+ returns retry.  Uses recv_yield_step counter
+  (separate from _FBSendOkRecv10's recv_10_step) to avoid interference.
+  Reset lori_test_set_recv_yield_step(0) before use.
+  """
+  fun listen(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    ip_version: IPVersion)
+    : AsioEventID
+  =>
+    AsioEvent.none()
+
+  fun accept(event: AsioEventID): I32 => 0
+
+  fun close(fd: U32) => @pony_os_socket_close(fd)
+
+  fun connect(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    from: String,
+    asio_flags: U32,
+    ip_version: IPVersion)
+    : U32
+  =>
+    0
+
+  fun keepalive(fd: U32, secs: U32) => None
+
+  fun peername(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun shutdown(fd: U32) => None
+
+  fun sockname(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun writev_max(): I32 => 1024
+
+  fun receive(event: AsioEventID,
+    buffer: Pointer[U8] tag,
+    size: USize)
+    : (SocketResult, USize)
+  =>
+    let step = @lori_test_get_recv_yield_step()
+    @lori_test_inc_recv_yield_step()
+    if step == 0 then
+      let src: Array[U8] val = recover val Array[U8].init('A', 10) end
+      @memcpy(buffer, src.cpointer(), 10)
+      (SocketResultOk, 10)
+    else
+      (SocketResultRetry, 0)
+    end
+
+  fun sendv(event: AsioEventID,
+    data: Array[ByteSeq] box,
+    from: USize,
+    count: USize,
+    first_buffer_byte_offset: USize)
+    : (SocketResult, USize) ?
+  =>
+    var total: USize = 0
+    var i = from
+    let stop = from + count
+    while i < stop do
+      let s = data(i)?.size()
+      total = total + if i == from then s - first_buffer_byte_offset else s end
+      i = i + 1
+    end
+    (SocketResultOk, total)
+
+primitive \nodoc\ _FBSendOkRecvError is TCPBackend
+  """
+  sendv: accepts all bytes.  receive: always returns error.
+  """
+  fun listen(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    ip_version: IPVersion)
+    : AsioEventID
+  =>
+    AsioEvent.none()
+
+  fun accept(event: AsioEventID): I32 => 0
+
+  fun close(fd: U32) => @pony_os_socket_close(fd)
+
+  fun connect(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    from: String,
+    asio_flags: U32,
+    ip_version: IPVersion)
+    : U32
+  =>
+    0
+
+  fun keepalive(fd: U32, secs: U32) => None
+
+  fun peername(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun shutdown(fd: U32) => None
+
+  fun sockname(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun writev_max(): I32 => 1024
+
+  fun receive(event: AsioEventID,
+    buffer: Pointer[U8] tag,
+    size: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultError, 0)
+
+  fun sendv(event: AsioEventID,
+    data: Array[ByteSeq] box,
+    from: USize,
+    count: USize,
+    first_buffer_byte_offset: USize)
+    : (SocketResult, USize) ?
+  =>
+    var total: USize = 0
+    var i = from
+    let stop = from + count
+    while i < stop do
+      let s = data(i)?.size()
+      total = total + if i == from then s - first_buffer_byte_offset else s end
+      i = i + 1
+    end
+    (SocketResultOk, total)
+
+// ---------------------------------------------------------------------------
+// Client-side fake backends
+// ---------------------------------------------------------------------------
+// Used with TCPConnection[X].client(). The client path calls connect; the
+// connection never reaches _Open, so sendv/receive are stubs.
+primitive \nodoc\ _FBConnect0 is TCPBackend
+  """
+  connect: returns 0 (all attempts failed — DNS failure path).
+  """
+  fun listen(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    ip_version: IPVersion)
+    : AsioEventID
+  =>
+    AsioEvent.none()
+
+  fun accept(event: AsioEventID): I32 => 0
+
+  fun close(fd: U32) => @pony_os_socket_close(fd)
+
+  fun connect(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    from: String,
+    asio_flags: U32,
+    ip_version: IPVersion)
+    : U32
+  =>
+    0
+
+  fun keepalive(fd: U32, secs: U32) => None
+
+  fun peername(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun shutdown(fd: U32) => None
+
+  fun sockname(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun writev_max(): I32 => 1024
+
+  fun receive(event: AsioEventID,
+    buffer: Pointer[U8] tag,
+    size: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultRetry, 0)
+
+  fun sendv(event: AsioEventID,
+    data: Array[ByteSeq] box,
+    from: USize,
+    count: USize,
+    first_buffer_byte_offset: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultRetry, 0)
+
+primitive \nodoc\ _FBConnect1 is TCPBackend
+  """
+  connect: returns 1 (one inflight attempt).
+  """
+  fun listen(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    ip_version: IPVersion)
+    : AsioEventID
+  =>
+    AsioEvent.none()
+
+  fun accept(event: AsioEventID): I32 => 0
+
+  fun close(fd: U32) => @pony_os_socket_close(fd)
+
+  fun connect(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    from: String,
+    asio_flags: U32,
+    ip_version: IPVersion)
+    : U32
+  =>
+    1
+
+  fun keepalive(fd: U32, secs: U32) => None
+
+  fun peername(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun shutdown(fd: U32) => None
+
+  fun sockname(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun writev_max(): I32 => 1024
+
+  fun receive(event: AsioEventID,
+    buffer: Pointer[U8] tag,
+    size: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultRetry, 0)
+
+  fun sendv(event: AsioEventID,
+    data: Array[ByteSeq] box,
+    from: USize,
+    count: USize,
+    first_buffer_byte_offset: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultRetry, 0)
+
+primitive \nodoc\ _FBConnect2 is TCPBackend
+  """
+  connect: returns 2 (two inflight attempts).
+  """
+  fun listen(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    ip_version: IPVersion)
+    : AsioEventID
+  =>
+    AsioEvent.none()
+
+  fun accept(event: AsioEventID): I32 => 0
+
+  fun close(fd: U32) => @pony_os_socket_close(fd)
+
+  fun connect(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    from: String,
+    asio_flags: U32,
+    ip_version: IPVersion)
+    : U32
+  =>
+    2
+
+  fun keepalive(fd: U32, secs: U32) => None
+
+  fun peername(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun shutdown(fd: U32) => None
+
+  fun sockname(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun writev_max(): I32 => 1024
+
+  fun receive(event: AsioEventID,
+    buffer: Pointer[U8] tag,
+    size: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultRetry, 0)
+
+  fun sendv(event: AsioEventID,
+    data: Array[ByteSeq] box,
+    from: USize,
+    count: USize,
+    first_buffer_byte_offset: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultRetry, 0)
+
+primitive \nodoc\ _FBConnect3 is TCPBackend
+  """
+  connect: returns 3 (three inflight attempts).
+  """
+  fun listen(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    ip_version: IPVersion)
+    : AsioEventID
+  =>
+    AsioEvent.none()
+
+  fun accept(event: AsioEventID): I32 => 0
+
+  fun close(fd: U32) => @pony_os_socket_close(fd)
+
+  fun connect(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    from: String,
+    asio_flags: U32,
+    ip_version: IPVersion)
+    : U32
+  =>
+    3
+
+  fun keepalive(fd: U32, secs: U32) => None
+
+  fun peername(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun shutdown(fd: U32) => None
+
+  fun sockname(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun writev_max(): I32 => 1024
+
+  fun receive(event: AsioEventID,
+    buffer: Pointer[U8] tag,
+    size: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultRetry, 0)
+
+  fun sendv(event: AsioEventID,
+    data: Array[ByteSeq] box,
+    from: USize,
+    count: USize,
+    first_buffer_byte_offset: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultRetry, 0)
+
+// ---------------------------------------------------------------------------
+// Listener fake backends
+// ---------------------------------------------------------------------------
+primitive \nodoc\ _FBListenFail is TCPBackend
+  """
+  listen: returns a null event (failure path).
+  """
+  fun listen(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    ip_version: IPVersion)
+    : AsioEventID
+  =>
+    AsioEvent.none()
+
+  fun accept(event: AsioEventID): I32 => 0
+
+  fun close(fd: U32) => @pony_os_socket_close(fd)
+
+  fun connect(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    from: String,
+    asio_flags: U32,
+    ip_version: IPVersion)
+    : U32
+  =>
+    0
+
+  fun keepalive(fd: U32, secs: U32) => None
+
+  fun peername(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun shutdown(fd: U32) => None
+
+  fun sockname(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun writev_max(): I32 => 1024
+
+  fun receive(event: AsioEventID,
+    buffer: Pointer[U8] tag,
+    size: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultRetry, 0)
+
+  fun sendv(event: AsioEventID,
+    data: Array[ByteSeq] box,
+    from: USize,
+    count: USize,
+    first_buffer_byte_offset: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultRetry, 0)
+
+primitive \nodoc\ _FBListenOk is TCPBackend
+  """
+  listen: creates a valid ASIO event from a raw socket.
+  accept: step 0 returns a raw socket fd, step 1+ returns 0 (would-block).
+  Reset lori_test_set_accept_step(0) before use.
+  """
+  fun listen(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    ip_version: IPVersion)
+    : AsioEventID
+  =>
+    let fd = @socket(I32(2), I32(1), I32(0))
+    if fd < 0 then return AsioEvent.none() end
+    PonyAsio.create_event(the_actor, fd.u32())
+
+  fun accept(event: AsioEventID): I32 =>
+    let step = @lori_test_get_accept_step()
+    @lori_test_inc_accept_step()
+    if step == 0 then
+      @socket(I32(2), I32(1), I32(0))
+    else
+      0
+    end
+
+  fun close(fd: U32) => @pony_os_socket_close(fd)
+
+  fun connect(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    from: String,
+    asio_flags: U32,
+    ip_version: IPVersion)
+    : U32
+  =>
+    0
+
+  fun keepalive(fd: U32, secs: U32) => None
+
+  fun peername(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun shutdown(fd: U32) => None
+
+  fun sockname(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun writev_max(): I32 => 1024
+
+  fun receive(event: AsioEventID,
+    buffer: Pointer[U8] tag,
+    size: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultRetry, 0)
+
+  fun sendv(event: AsioEventID,
+    data: Array[ByteSeq] box,
+    from: USize,
+    count: USize,
+    first_buffer_byte_offset: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultRetry, 0)
+
+primitive \nodoc\ _FBListenOkMulti is TCPBackend
+  """
+  listen: creates a valid ASIO event from a raw socket.
+  accept: always returns a fresh raw socket fd (never returns 0).
+  """
+  fun listen(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    ip_version: IPVersion)
+    : AsioEventID
+  =>
+    let fd = @socket(I32(2), I32(1), I32(0))
+    if fd < 0 then return AsioEvent.none() end
+    PonyAsio.create_event(the_actor, fd.u32())
+
+  fun accept(event: AsioEventID): I32 =>
+    @socket(I32(2), I32(1), I32(0))
+
+  fun close(fd: U32) => @pony_os_socket_close(fd)
+
+  fun connect(the_actor: AsioEventNotify,
+    host: String,
+    port: String,
+    from: String,
+    asio_flags: U32,
+    ip_version: IPVersion)
+    : U32
+  =>
+    0
+
+  fun keepalive(fd: U32, secs: U32) => None
+
+  fun peername(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun shutdown(fd: U32) => None
+
+  fun sockname(fd: U32, ip: net.NetAddress ref): Bool => false
+
+  fun writev_max(): I32 => 1024
+
+  fun receive(event: AsioEventID,
+    buffer: Pointer[U8] tag,
+    size: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultRetry, 0)
+
+  fun sendv(event: AsioEventID,
+    data: Array[ByteSeq] box,
+    from: USize,
+    count: USize,
+    first_buffer_byte_offset: USize)
+    : (SocketResult, USize)
+  =>
+    (SocketResultRetry, 0)
+
+// ---------------------------------------------------------------------------
+// Helper: create a raw socket fd for server-side fake connections
+// ---------------------------------------------------------------------------
+primitive \nodoc\ _FakeServerFd
+  """
+  Allocate a raw TCP socket fd suitable for PonyAsio.create_event. The fd is
+  never bound or connected — it exists only so ASIO has a valid file
+  descriptor. The fake backend handles all I/O.
+  """
+  fun apply(): U32 ? =>
+    let fd = @socket(I32(2), I32(1), I32(0))
+    if fd < 0 then error end
+    fd.u32()

--- a/lori/_test_fake_state.c
+++ b/lori/_test_fake_state.c
@@ -1,0 +1,27 @@
+#include <stddef.h>
+
+static size_t _sendv_failed_step = 0;
+static size_t _recv_hello_step = 0;
+static size_t _recv_10_step = 0;
+static size_t _recv_mute_step = 0;
+static size_t _recv_yield_step = 0;
+static size_t _accept_step = 0;
+
+size_t lori_test_get_sendv_failed_step(void) { return _sendv_failed_step; }
+void lori_test_set_sendv_failed_step(size_t v) { _sendv_failed_step = v; }
+void lori_test_inc_sendv_failed_step(void) { _sendv_failed_step++; }
+size_t lori_test_get_recv_hello_step(void) { return _recv_hello_step; }
+void lori_test_set_recv_hello_step(size_t v) { _recv_hello_step = v; }
+void lori_test_inc_recv_hello_step(void) { _recv_hello_step++; }
+size_t lori_test_get_recv_10_step(void) { return _recv_10_step; }
+void lori_test_set_recv_10_step(size_t v) { _recv_10_step = v; }
+void lori_test_inc_recv_10_step(void) { _recv_10_step++; }
+size_t lori_test_get_recv_mute_step(void) { return _recv_mute_step; }
+void lori_test_set_recv_mute_step(size_t v) { _recv_mute_step = v; }
+void lori_test_inc_recv_mute_step(void) { _recv_mute_step++; }
+size_t lori_test_get_recv_yield_step(void) { return _recv_yield_step; }
+void lori_test_set_recv_yield_step(size_t v) { _recv_yield_step = v; }
+void lori_test_inc_recv_yield_step(void) { _recv_yield_step++; }
+size_t lori_test_get_accept_step(void) { return _accept_step; }
+void lori_test_set_accept_step(size_t v) { _accept_step = v; }
+void lori_test_inc_accept_step(void) { _accept_step++; }

--- a/lori/_test_send.pony
+++ b/lori/_test_send.pony
@@ -3455,9 +3455,6 @@ actor \nodoc\ _TestSendOnSentPrecedesServer
       "_on_sent for the drained send must arrive before _on_throttled")
     _h.complete_action("sent before throttled")
 
-    // The connection is unwriteable here, so this send is refused by the one
-    // check that shares `_do_send` with the accept path. A refused send mints
-    // no token and fires no callback.
     let accepted_before = _accepted
     match \exhaustive\ _tcp_connection.send("nope")
     | SendAccepted =>
@@ -3928,3 +3925,465 @@ actor \nodoc\ _TestSendPrecedesReceivedServer
 
   fun ref _on_sent(token: SendToken) =>
     _sent = _sent + 1
+
+// ===========================================================================
+// Fake-backend send tests (no real sockets for I/O)
+// ===========================================================================
+class \nodoc\ iso _TestFakeSendOk is UnitTest
+  """
+  sendv accepts all bytes. Verify: send returns SendAccepted,
+  _on_send_accepted fires with a token and the data, _on_sent fires with
+  the same token.
+  """
+  fun name(): String => "FakeSendOk"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("on_send_accepted")
+    h.expect_action("on_sent")
+
+    let a = _TestFakeSendOkActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeSendOkActor
+  is (TCPConnectionActor[_FBSendOkRecvRetry]
+    & ServerLifecycleEventReceiver[_FBSendOkRecvRetry])
+  var _tcp_connection: TCPConnection[_FBSendOkRecvRetry] =
+    TCPConnection[_FBSendOkRecvRetry].none()
+  let _h: TestHelper
+  var _expected_token: (SendToken | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+    try
+      let fd = _FakeServerFd()?
+      _tcp_connection =
+        TCPConnection[_FBSendOkRecvRetry].server(
+          TCPServerAuth(_h.env.root),
+          fd,
+          this,
+          this)
+    else
+      _h.fail("could not allocate socket")
+      _h.complete(false)
+    end
+
+  fun ref _connection(): TCPConnection[_FBSendOkRecvRetry] =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    _tcp_connection.mute()
+    match \exhaustive\ _tcp_connection.send("hello")
+    | SendAccepted => None
+    | let _: SendError =>
+      _h.fail("send returned an error")
+      _h.complete(false)
+    end
+
+  fun ref _on_send_accepted(
+    token: SendToken,
+    data: (ByteSeq | ByteSeqIter))
+  =>
+    _expected_token = token
+    _h.complete_action("on_send_accepted")
+
+  fun ref _on_sent(token: SendToken) =>
+    match \exhaustive\ _expected_token
+    | let expected: SendToken =>
+      _h.assert_true(token == expected, "token mismatch")
+      _h.complete_action("on_sent")
+    | None =>
+      _h.fail("_on_sent fired without _on_send_accepted")
+    end
+
+  be dispose() =>
+    _tcp_connection.hard_close()
+
+class \nodoc\ iso _TestFakeSendMultipleTokenOrder is UnitTest
+  """
+  Three sends all succeed. Verify: _on_send_accepted fires three times with
+  distinct tokens, and _on_sent fires three times in the same order.
+  """
+  fun name(): String => "FakeSendMultipleTokenOrder"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("all_sent")
+
+    let a = _TestFakeSendMultipleTokenOrderActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeSendMultipleTokenOrderActor
+  is (TCPConnectionActor[_FBSendOkRecvRetry]
+    & ServerLifecycleEventReceiver[_FBSendOkRecvRetry])
+  var _tcp_connection: TCPConnection[_FBSendOkRecvRetry] =
+    TCPConnection[_FBSendOkRecvRetry].none()
+  let _h: TestHelper
+  let _expected_tokens: Array[SendToken] = Array[SendToken]
+  var _sent_count: USize = 0
+
+  new create(h: TestHelper) =>
+    _h = h
+    try
+      let fd = _FakeServerFd()?
+      _tcp_connection =
+        TCPConnection[_FBSendOkRecvRetry].server(
+          TCPServerAuth(_h.env.root),
+          fd,
+          this,
+          this)
+    else
+      _h.fail("could not allocate socket")
+      _h.complete(false)
+    end
+
+  fun ref _connection(): TCPConnection[_FBSendOkRecvRetry] =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    _tcp_connection.mute()
+    for payload in ["aaa"; "bbb"; "ccc"].values() do
+      match \exhaustive\ _tcp_connection.send(payload)
+      | SendAccepted => None
+      | let _: SendError =>
+        _h.fail("send returned an error")
+        _h.complete(false)
+        return
+      end
+    end
+
+  fun ref _on_send_accepted(
+    token: SendToken,
+    data: (ByteSeq | ByteSeqIter))
+  =>
+    _expected_tokens.push(token)
+
+  fun ref _on_sent(token: SendToken) =>
+    try
+      let expected = _expected_tokens(_sent_count)?
+      _h.assert_true(
+        token == expected,
+        "token order mismatch at index " + _sent_count.string())
+    else
+      _h.fail("_on_sent with no matching _on_send_accepted")
+    end
+    _sent_count = _sent_count + 1
+    if _sent_count == 3 then
+      _h.complete_action("all_sent")
+    end
+
+  be dispose() =>
+    _tcp_connection.hard_close()
+
+class \nodoc\ iso _TestFakeSendOnClosed is UnitTest
+  """
+  send() on a hard-closed connection returns SendErrorNotConnected without
+  firing _on_send_accepted.
+  """
+  fun name(): String => "FakeSendOnClosed"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("send_error_verified")
+
+    let a = _TestFakeSendOnClosedActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeSendOnClosedActor
+  is (TCPConnectionActor[_FBSendOkRecvRetry]
+    & ServerLifecycleEventReceiver[_FBSendOkRecvRetry])
+  var _tcp_connection: TCPConnection[_FBSendOkRecvRetry] =
+    TCPConnection[_FBSendOkRecvRetry].none()
+  let _h: TestHelper
+  var _send_accepted_after_close: Bool = false
+
+  new create(h: TestHelper) =>
+    _h = h
+    try
+      let fd = _FakeServerFd()?
+      _tcp_connection =
+        TCPConnection[_FBSendOkRecvRetry].server(
+          TCPServerAuth(_h.env.root),
+          fd,
+          this,
+          this)
+    else
+      _h.fail("could not allocate socket")
+      _h.complete(false)
+    end
+
+  fun ref _connection(): TCPConnection[_FBSendOkRecvRetry] =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    _tcp_connection.mute()
+    _tcp_connection.hard_close()
+
+  fun ref _on_closed() =>
+    match \exhaustive\ _tcp_connection.send("hello")
+    | SendAccepted =>
+      _h.fail("send on closed connection returned SendAccepted")
+      _h.complete(false)
+    | SendErrorNotConnected =>
+      _h.complete_action("send_error_verified")
+    | SendErrorNotWriteable =>
+      _h.fail("send on closed connection returned SendErrorNotWriteable")
+      _h.complete(false)
+    end
+
+  fun ref _on_send_accepted(
+    token: SendToken,
+    data: (ByteSeq | ByteSeqIter))
+  =>
+    _send_accepted_after_close = true
+    _h.fail("_on_send_accepted fired after hard_close")
+    _h.complete(false)
+
+  be dispose() =>
+    _tcp_connection.hard_close()
+
+class \nodoc\ iso _TestFakeSendError is UnitTest
+  """
+  sendv returns error. Verify: _on_send_accepted fires (token minted before
+  flush), then _on_closed fires (hard close from sendv error), then
+  _on_send_failed fires with the token (deferred).
+  """
+  fun name(): String => "FakeSendError"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("on_send_accepted")
+    h.expect_action("on_closed")
+    h.expect_action("on_send_failed")
+
+    let a = _TestFakeSendErrorActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeSendErrorActor
+  is (TCPConnectionActor[_FBSendErrorRecvRetry]
+    & ServerLifecycleEventReceiver[_FBSendErrorRecvRetry])
+  var _tcp_connection: TCPConnection[_FBSendErrorRecvRetry] =
+    TCPConnection[_FBSendErrorRecvRetry].none()
+  let _h: TestHelper
+  var _expected_token: (SendToken | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+    try
+      let fd = _FakeServerFd()?
+      _tcp_connection =
+        TCPConnection[_FBSendErrorRecvRetry].server(
+          TCPServerAuth(_h.env.root),
+          fd,
+          this,
+          this)
+    else
+      _h.fail("could not allocate socket")
+      _h.complete(false)
+    end
+
+  fun ref _connection(): TCPConnection[_FBSendErrorRecvRetry] =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    _tcp_connection.mute()
+    match \exhaustive\ _tcp_connection.send("hello")
+    | SendAccepted => None
+    | let _: SendError =>
+      _h.fail("send returned an error before flush")
+      _h.complete(false)
+    end
+
+  fun ref _on_send_accepted(
+    token: SendToken,
+    data: (ByteSeq | ByteSeqIter))
+  =>
+    _expected_token = token
+    _h.complete_action("on_send_accepted")
+
+  fun ref _on_closed() =>
+    _h.complete_action("on_closed")
+
+  fun ref _on_send_failed(token: SendToken) =>
+    match \exhaustive\ _expected_token
+    | let expected: SendToken =>
+      _h.assert_true(token == expected, "send_failed token mismatch")
+      _h.complete_action("on_send_failed")
+    | None =>
+      _h.fail("_on_send_failed without _on_send_accepted")
+    end
+
+  be dispose() =>
+    _tcp_connection.hard_close()
+
+class \nodoc\ iso _TestFakeSendFailedAfterClosed is UnitTest
+  """
+  _on_send_failed must arrive after _on_closed when hard_close is called with
+  queued sends. Verify: send queues bytes (sendv returns retry), hard_close
+  fires _on_closed synchronously, then _on_send_failed arrives in a
+  subsequent behavior turn.
+  """
+  fun name(): String => "FakeSendFailedAfterClosed"
+
+  fun apply(h: TestHelper) =>
+    @lori_test_set_sendv_failed_step(0)
+
+    h.expect_action("on_closed")
+    h.expect_action("on_send_failed_after_closed")
+
+    let a = _TestFakeSendFailedAfterClosedActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeSendFailedAfterClosedActor
+  is (TCPConnectionActor[_FBSendStepRecvRetryFailed]
+    & ServerLifecycleEventReceiver[_FBSendStepRecvRetryFailed])
+  var _tcp_connection: TCPConnection[_FBSendStepRecvRetryFailed] =
+    TCPConnection[_FBSendStepRecvRetryFailed].none()
+  let _h: TestHelper
+  var _expected_token: (SendToken | None) = None
+  var _closed: Bool = false
+
+  new create(h: TestHelper) =>
+    _h = h
+    try
+      let fd = _FakeServerFd()?
+      _tcp_connection =
+        TCPConnection[_FBSendStepRecvRetryFailed].server(
+          TCPServerAuth(_h.env.root),
+          fd,
+          this,
+          this)
+    else
+      _h.fail("could not allocate socket")
+      _h.complete(false)
+    end
+
+  fun ref _connection(): TCPConnection[_FBSendStepRecvRetryFailed] =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    _tcp_connection.mute()
+    match \exhaustive\ _tcp_connection.send("hello")
+    | SendAccepted => None
+    | let _: SendError =>
+      _h.fail("send returned an error")
+      _h.complete(false)
+      return
+    end
+    _tcp_connection.hard_close()
+
+  fun ref _on_send_accepted(
+    token: SendToken,
+    data: (ByteSeq | ByteSeqIter))
+  =>
+    _expected_token = token
+
+  fun ref _on_closed() =>
+    _closed = true
+    _h.complete_action("on_closed")
+
+  fun ref _on_send_failed(token: SendToken) =>
+    if not _closed then
+      _h.fail("_on_send_failed fired before _on_closed")
+      _h.complete(false)
+      return
+    end
+    match \exhaustive\ _expected_token
+    | let expected: SendToken =>
+      _h.assert_true(token == expected, "send_failed token mismatch")
+      _h.complete_action("on_send_failed_after_closed")
+    | None =>
+      _h.fail("_on_send_failed without _on_send_accepted")
+    end
+
+  be dispose() =>
+    _tcp_connection.hard_close()
+
+class \nodoc\ iso _TestFakeGracefulClose is UnitTest
+  """
+  Graceful close after a completed send. Verify: _on_sent fires, and
+  close() makes subsequent send() return SendErrorNotConnected (_Closing
+  rejects sends the same way _Closed does).
+  """
+  fun name(): String => "FakeGracefulClose"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("on_sent")
+    h.expect_action("close_rejects_send")
+
+    let a = _TestFakeGracefulCloseActor(h)
+    h.dispose_when_done(a)
+
+    h.long_test(5_000_000_000)
+
+actor \nodoc\ _TestFakeGracefulCloseActor
+  is (TCPConnectionActor[_FBSendOkRecvRetry]
+    & ServerLifecycleEventReceiver[_FBSendOkRecvRetry])
+  var _tcp_connection: TCPConnection[_FBSendOkRecvRetry] =
+    TCPConnection[_FBSendOkRecvRetry].none()
+  let _h: TestHelper
+  var _expected_token: (SendToken | None) = None
+
+  new create(h: TestHelper) =>
+    _h = h
+    try
+      let fd = _FakeServerFd()?
+      _tcp_connection =
+        TCPConnection[_FBSendOkRecvRetry].server(
+          TCPServerAuth(_h.env.root),
+          fd,
+          this,
+          this)
+    else
+      _h.fail("could not allocate socket")
+      _h.complete(false)
+    end
+
+  fun ref _connection(): TCPConnection[_FBSendOkRecvRetry] =>
+    _tcp_connection
+
+  fun ref _on_started() =>
+    _tcp_connection.mute()
+    match \exhaustive\ _tcp_connection.send("aaa")
+    | SendAccepted => None
+    | let _: SendError =>
+      _h.fail("send returned an error")
+      _h.complete(false)
+      return
+    end
+    _tcp_connection.close()
+    match \exhaustive\ _tcp_connection.send("bbb")
+    | SendAccepted =>
+      _h.fail("send after close should fail")
+      _h.complete(false)
+    | SendErrorNotConnected =>
+      _h.complete_action("close_rejects_send")
+    | SendErrorNotWriteable =>
+      _h.fail("send after close returned SendErrorNotWriteable")
+      _h.complete(false)
+    end
+
+  fun ref _on_send_accepted(
+    token: SendToken,
+    data: (ByteSeq | ByteSeqIter))
+  =>
+    _expected_token = token
+
+  fun ref _on_sent(token: SendToken) =>
+    match \exhaustive\ _expected_token
+    | let expected: SendToken =>
+      _h.assert_true(token == expected, "token mismatch")
+      _h.complete_action("on_sent")
+    | None =>
+      _h.fail("_on_sent without _on_send_accepted")
+    end
+
+  be dispose() =>
+    _tcp_connection.hard_close()
+

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -1788,6 +1788,14 @@ class TCPConnection[TCP: TCPBackend val = RuntimeBackend]
       _send_pending_writes()
     end
 
+  fun ref _close_raw_fd() =>
+    """
+    Close the connection's fd directly, bypassing `_close_event_fd`. For use
+    when no ASIO event was ever created for this fd.
+    """
+    _tcp.close(_fd)
+    _fd = -1
+
   fun ref _close_event_fd(fd: U32) =>
     """
     Close the fd backing a subscribed event. On POSIX the stdlib owns the
@@ -1905,6 +1913,15 @@ class TCPConnection[TCP: TCPBackend val = RuntimeBackend]
     end
 
   fun ref _finish_initialization() =>
+    // _finish_initialization is a self→self message queued during the
+    // constructor. dispose() comes from an external actor. Different senders
+    // have no ordering guarantee, so dispose() can race ahead and transition
+    // to _Closed via _ConnectionNone.hard_close(). When that happens, the fd
+    // and TLS session are already cleaned up — skip initialization.
+    match _state
+    | let _: _Closed[TCP] => return
+    end
+
     match \exhaustive\ _lifecycle_event_receiver
     | let s: ServerLifecycleEventReceiver[TCP] ref =>
       _complete_server_initialization(s)


### PR DESCRIPTION
PR #366 made TCPConnection and TCPListener generic over TCPBackend. These 21 tests use fake TCPBackend implementations to exercise the connection lifecycle, send/receive paths, state machine transitions, and listener logic deterministically — no real sockets, no timing dependencies, no platform-specific backpressure thresholds.

The fake backends are `val` primitives that implement the `TCPBackend` trait with scripted return values. Multi-step scenarios use C-backed static globals for step counters, since Pony `val` primitives can't hold instance state (see #367). Each test gets its own counter to prevent interference under concurrent scheduling.

Includes a fix to `_ConnectionNone.hard_close()`: `_finish_initialization` is a self→self message queued during the constructor, while `dispose()` comes from an external actor. Different senders have no ordering guarantee, so `dispose()` can arrive first. When it did, `hard_close()` was a no-op and `_finish_initialization()` still ran, creating an ASIO event that was never destroyed. The leaked noisy event prevented the runtime from exiting.
