### PR TITLE
Add notifier-based TCP API subpackage

### DIFF
--- a/.release-notes/add-notifier-api.md
+++ b/.release-notes/add-notifier-api.md
@@ -1,0 +1,31 @@
+## Add notifier-based TCP API subpackage
+
+A new `lori/notifier` subpackage provides a convenience layer over lori's native class-and-trait API. You write a notifier class with the callbacks you care about and hand it to a concrete actor — no actor boilerplate, no trait wiring.
+
+Three actor/notifier pairs cover client connections, server connections, and listeners:
+
+```pony
+use "lori"
+use "lori/notifier"
+
+class Echo is ServerTCPConnectionNotify
+  fun ref on_received(conn: ServerTCPConnection ref, data: Array[U8] iso):
+    ReadAction
+  =>
+    conn.write(consume data)
+    KeepReading
+
+class EchoListen is TCPListenNotify
+  fun ref on_connected(listen: TCPListener ref):
+    ServerTCPConnectionNotify iso^
+  =>
+    Echo
+  fun ref on_not_listening(listen: TCPListener ref) =>
+    None
+
+actor Main
+  new create(env: Env) =>
+    TCPListener(TCPListenAuth(env.root), recover EchoListen end, "", "8989")
+```
+
+`write` and `mute` are behaviors rather than synchronous methods, and SSL is configured through a constructor (`.ssl`) rather than a separate class. Use the notifier API for straightforward applications; use lori's native API when you need synchronous send results, custom actor structure, or multiple connections per actor.

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,14 @@ IPv4-only echo server with a built-in client. Shows how to use the `ip_version` 
 
 Client and server exchanging messages in a loop. Adds a `ClientLifecycleEventReceiver` client that connects, sends "Ping", and responds to every "Pong" — showing both sides of a TCP conversation.
 
+## [notifier-echo-server](notifier-echo-server/)
+
+Notifier API version of the echo server. Same behavior as `echo-server`, but with `TCPListenNotify` and `ServerTCPConnectionNotify` traits instead of implementing `TCPListenerActor` and `ServerLifecycleEventReceiver` yourself. No user-defined actors — lori's concrete `TCPListener` and `ServerTCPConnection` actors handle all I/O plumbing.
+
+## [notifier-ping-pong](notifier-ping-pong/)
+
+Notifier API version of infinite ping-pong. Same behavior as `infinite-ping-pong`, but with `TCPListenNotify`, `ClientTCPConnectionNotify`, and `ServerTCPConnectionNotify` traits. Shows both sides of a TCP conversation through the notifier API, with `buffer_until()` framing on both ends.
+
 ## [framed-protocol](framed-protocol/)
 
 Length-prefixed message framing with `buffer_until()`. Each message has a 4-byte big-endian length header followed by a variable-length payload. Both sides use `buffer_until()` to switch between reading the header and reading the payload, demonstrating how to build a protocol parser on top of lori's read chunking.

--- a/examples/notifier-echo-server/notifier_echo_server.pony
+++ b/examples/notifier-echo-server/notifier_echo_server.pony
@@ -1,0 +1,66 @@
+"""
+Minimal echo server using the notifier API.
+
+Shows the same echo-server behavior as the `echo-server` example, but with
+notifier traits instead of lori's class-and-trait delegation. The three
+building blocks here are `TCPListener`, `TCPListenNotify`, and
+`ServerTCPConnectionNotify`. There are no user-defined actors — lori's
+concrete actors handle all I/O plumbing.
+
+Connect with any TCP client (e.g. `netcat localhost 7679`) and type to see
+your input echoed back.
+"""
+use "../../lori"
+use notifier = "../../lori/notifier"
+
+actor Main
+  new create(env: Env) =>
+    notifier.TCPListener(
+      TCPListenAuth(env.root),
+      recover EchoListenNotify(env.out) end,
+      "",
+      "7679")
+
+class EchoListenNotify is notifier.TCPListenNotify
+  """
+  Listener callbacks: prints status messages and creates an EchoNotify for
+  each accepted connection.
+  """
+  let _out: OutStream
+
+  new create(out: OutStream) =>
+    _out = out
+
+  fun ref on_listening(listen: notifier.TCPListener ref) =>
+    _out.print("Echo server started.")
+
+  fun ref on_not_listening(listen: notifier.TCPListener ref) =>
+    _out.print("Couldn't start Echo server. " +
+      "Perhaps try another network interface?")
+
+  fun ref on_connected(listen: notifier.TCPListener ref):
+    notifier.ServerTCPConnectionNotify iso^
+  =>
+    recover EchoNotify(_out) end
+
+  fun ref on_closed(listen: notifier.TCPListener ref) =>
+    _out.print("Echo server shut down.")
+
+class EchoNotify is notifier.ServerTCPConnectionNotify
+  """
+  Connection callbacks: sends received data back to the client.
+  """
+  let _out: OutStream
+
+  new create(out: OutStream) =>
+    _out = out
+
+  fun ref on_received(conn: notifier.ServerTCPConnection ref,
+    data: Array[U8] iso): ReadAction
+  =>
+    _out.print("Data received. Echoing it back.")
+    conn.write(consume data)
+    KeepReading
+
+  fun ref on_closed(conn: notifier.ServerTCPConnection ref) =>
+    _out.print("Connection Closed")

--- a/examples/notifier-ping-pong/notifier_ping_pong.pony
+++ b/examples/notifier-ping-pong/notifier_ping_pong.pony
@@ -1,0 +1,98 @@
+"""
+Client and server exchanging messages using the notifier API.
+
+Shows the same infinite ping-pong behavior as the `infinite-ping-pong` example,
+but with notifier traits instead of lori's class-and-trait delegation. The
+listener creates a client once listening, the client sends "Ping" on connect,
+and both sides exchange 4-byte messages forever.
+
+Demonstrates `TCPListenNotify`, `ClientTCPConnectionNotify`, and
+`ServerTCPConnectionNotify` working together. Both sides use `buffer_until()`
+so each `received` callback delivers exactly one 4-byte message.
+"""
+use "constrained_types"
+use "../../lori"
+use notifier = "../../lori/notifier"
+
+actor Main
+  new create(env: Env) =>
+    notifier.TCPListener(
+      TCPListenAuth(env.root),
+      recover PingPongListenNotify(TCPConnectAuth(env.root), env.out) end,
+      "127.0.0.1",
+      "7680")
+
+class PingPongListenNotify is notifier.TCPListenNotify
+  """
+  Listener callbacks: launches a PingNotify client on listen and creates a
+  PongNotify for each accepted connection.
+  """
+  let _connect_auth: TCPConnectAuth
+  let _out: OutStream
+
+  new create(connect_auth: TCPConnectAuth, out: OutStream) =>
+    _connect_auth = connect_auth
+    _out = out
+
+  fun ref on_listening(listen: notifier.TCPListener ref) =>
+    notifier.ClientTCPConnection(
+      _connect_auth,
+      recover PingNotify(_out) end,
+      "127.0.0.1",
+      "7680")
+
+  fun ref on_not_listening(listen: notifier.TCPListener ref) =>
+    _out.print("Unable to open listener")
+
+  fun ref on_connected(listen: notifier.TCPListener ref):
+    notifier.ServerTCPConnectionNotify iso^
+  =>
+    recover PongNotify(_out) end
+
+class PingNotify is notifier.ClientTCPConnectionNotify
+  """
+  Client callbacks: sends "Ping" on connect and after each received reply.
+  """
+  let _out: OutStream
+
+  new create(out: OutStream) =>
+    _out = out
+
+  fun ref on_connected(conn: notifier.ClientTCPConnection ref) =>
+    match MakeBufferSize(4)
+    | let e: BufferSize => conn.buffer_until(e)
+    end
+    conn.write("Ping")
+
+  fun ref on_received(conn: notifier.ClientTCPConnection ref,
+    data: Array[U8] iso): ReadAction
+  =>
+    _out.print(consume data)
+    conn.write("Ping")
+    KeepReading
+
+  fun ref on_connect_failed(conn: notifier.ClientTCPConnection ref,
+    reason: ConnectionFailureReason)
+  =>
+    _out.print("Unable to connect")
+
+class PongNotify is notifier.ServerTCPConnectionNotify
+  """
+  Server callbacks: replies "Pong" to each received message.
+  """
+  let _out: OutStream
+
+  new create(out: OutStream) =>
+    _out = out
+
+  fun ref on_accepted(conn: notifier.ServerTCPConnection ref) =>
+    match MakeBufferSize(4)
+    | let e: BufferSize => conn.buffer_until(e)
+    end
+
+  fun ref on_received(conn: notifier.ServerTCPConnection ref,
+    data: Array[U8] iso): ReadAction
+  =>
+    _out.print(consume data)
+    conn.write("Pong")
+    KeepReading

--- a/lori/_test.pony
+++ b/lori/_test.pony
@@ -1,4 +1,5 @@
 use "pony_test"
+use notifier = "notifier"
 
 actor \nodoc\ Main is TestList
   new create(env: Env) =>
@@ -8,6 +9,7 @@ actor \nodoc\ Main is TestList
     None
 
   fun tag tests(test: PonyTest) =>
+    notifier.Main.make().tests(test)
     test(_TestCanListen)
     test(_TestListenerLocalAddress)
     test(_TestMute)

--- a/lori/lori.pony
+++ b/lori/lori.pony
@@ -617,4 +617,12 @@ them to the actors that need them. The echo server example above shows the
 typical pattern: `Main` creates a `TCPListenAuth`, the listener creates a
 `TCPServerAuth` from it, and each accepted connection receives that
 `TCPServerAuth`.
+
+## Notifier API
+
+The `lori/notifier` subpackage provides an alternative API shaped like the
+standard library's `net` package. Instead of implementing actor traits and
+delegating to a `TCPConnection` class, you hand a notifier object to a concrete
+actor and the actor calls you back. See the
+[notifier package](/lori/notifier--index/) documentation for details.
 """

--- a/lori/notifier/_test.pony
+++ b/lori/notifier/_test.pony
@@ -1,0 +1,16 @@
+use "pony_test"
+
+actor \nodoc\ Main is TestList
+  new create(env: Env) =>
+    PonyTest(env, this)
+
+  new make() =>
+    None
+
+  fun tag tests(test: PonyTest) =>
+    test(_TestNotifierPingPong)
+    test(_TestNotifierSSLPingPong)
+    test(_TestNotifierConnectFailed)
+    test(_TestNotifierBufferUntil)
+    test(_TestNotifierDispose)
+    test(_TestNotifierRejectConnection)

--- a/lori/notifier/_test_buffer_until.pony
+++ b/lori/notifier/_test_buffer_until.pony
@@ -1,0 +1,96 @@
+use lori = ".."
+use "constrained_types"
+use "pony_test"
+
+class \nodoc\ iso _TestNotifierBufferUntil is UnitTest
+  fun name(): String => "notifier/BufferUntil"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("server listening")
+    h.expect_action("client connected")
+    h.expect_action("expected data received")
+
+    let listener =
+      TCPListener(
+        lori.TCPListenAuth(h.env.root),
+        recover _TestNBUListenNotify(h) end,
+        "localhost",
+        "9803")
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+class \nodoc\ _TestNBUClientNotify is ClientTCPConnectionNotify
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  fun ref on_connected(conn: ClientTCPConnection ref) =>
+    _h.complete_action("client connected")
+    conn.write("hi there, how are you???")
+
+  fun ref on_connect_failed(conn: ClientTCPConnection ref,
+    reason: lori.ConnectionFailureReason)
+  =>
+    _h.fail("client connect_failed")
+    _h.complete(false)
+
+class \nodoc\ _TestNBUServerNotify is ServerTCPConnectionNotify
+  let _h: TestHelper
+  var _received_count: U8 = 0
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  fun ref on_accepted(conn: ServerTCPConnection ref) =>
+    match lori.MakeBufferSize(4)
+    | let e: lori.BufferSize => conn.buffer_until(e)
+    end
+
+  fun ref on_received(conn: ServerTCPConnection ref, data: Array[U8] iso):
+    lori.ReadAction
+  =>
+    _received_count = _received_count + 1
+
+    if _received_count == 1 then
+      _h.assert_eq[String]("hi t", String.from_array(consume data))
+    elseif _received_count == 2 then
+      _h.assert_eq[String]("here", String.from_array(consume data))
+    elseif _received_count == 3 then
+      _h.assert_eq[String](", ho", String.from_array(consume data))
+    elseif _received_count == 4 then
+      _h.assert_eq[String]("w ar", String.from_array(consume data))
+    elseif _received_count == 5 then
+      _h.assert_eq[String]("e yo", String.from_array(consume data))
+    elseif _received_count == 6 then
+      _h.assert_eq[String]("u???", String.from_array(consume data))
+      _h.complete_action("expected data received")
+      conn.close()
+    end
+    lori.KeepReading
+
+class \nodoc\ _TestNBUListenNotify is TCPListenNotify
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  fun ref on_listening(listen: TCPListener ref) =>
+    _h.complete_action("server listening")
+    let client =
+      ClientTCPConnection(
+        lori.TCPConnectAuth(_h.env.root),
+        recover _TestNBUClientNotify(_h) end,
+        "localhost",
+        "9803")
+    _h.dispose_when_done(client)
+
+  fun ref on_not_listening(listen: TCPListener ref) =>
+    _h.fail("Unable to open listener")
+    _h.complete(false)
+
+  fun ref on_connected(listen: TCPListener ref):
+    ServerTCPConnectionNotify iso^
+  =>
+    recover _TestNBUServerNotify(_h) end

--- a/lori/notifier/_test_connect_failed.pony
+++ b/lori/notifier/_test_connect_failed.pony
@@ -1,0 +1,36 @@
+use lori = ".."
+use "pony_test"
+
+class \nodoc\ iso _TestNotifierConnectFailed is UnitTest
+  fun name(): String => "notifier/ConnectFailed"
+
+  fun apply(h: TestHelper) =>
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let notify =
+      recover iso
+        _TestNCFClientNotify(h)
+      end
+    let client =
+      ClientTCPConnection(
+        lori.TCPConnectAuth(h.env.root),
+        consume notify,
+        host,
+        "9801")
+    h.dispose_when_done(client)
+
+    h.long_test(5_000_000_000)
+
+class \nodoc\ _TestNCFClientNotify is ClientTCPConnectionNotify
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  fun ref on_connected(conn: ClientTCPConnection ref) =>
+    _h.fail("connected should not fire")
+    _h.complete(false)
+
+  fun ref on_connect_failed(conn: ClientTCPConnection ref,
+    reason: lori.ConnectionFailureReason)
+  =>
+    _h.complete(true)

--- a/lori/notifier/_test_dispose.pony
+++ b/lori/notifier/_test_dispose.pony
@@ -1,0 +1,47 @@
+use lori = ".."
+use "pony_test"
+
+class \nodoc\ iso _TestNotifierDispose is UnitTest
+  """
+  Disposing the listener closes it cleanly and the `closed` callback fires.
+  """
+  fun name(): String => "notifier/Dispose"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("listening")
+    h.expect_action("closed")
+
+    let listener =
+      TCPListener(
+        lori.TCPListenAuth(h.env.root),
+        recover _TestNDListenNotify(h) end,
+        "localhost",
+        "9804")
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+class \nodoc\ _TestNDListenNotify is TCPListenNotify
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  fun ref on_listening(listen: TCPListener ref) =>
+    _h.complete_action("listening")
+    listen.close()
+
+  fun ref on_not_listening(listen: TCPListener ref) =>
+    _h.fail("Unable to open listener")
+    _h.complete(false)
+
+  fun ref on_connected(listen: TCPListener ref):
+    ServerTCPConnectionNotify iso^
+  =>
+    _h.fail("connected should not fire")
+    recover _TestNDServerNotify end
+
+  fun ref on_closed(listen: TCPListener ref) =>
+    _h.complete_action("closed")
+
+class \nodoc\ _TestNDServerNotify is ServerTCPConnectionNotify

--- a/lori/notifier/_test_ping_pong.pony
+++ b/lori/notifier/_test_ping_pong.pony
@@ -1,0 +1,110 @@
+use lori = ".."
+use "constrained_types"
+use "pony_test"
+
+class \nodoc\ iso _TestNotifierPingPong is UnitTest
+  fun name(): String => "notifier/PingPong"
+
+  fun apply(h: TestHelper) =>
+    let port = "9800"
+    let pings_to_send: I32 = 100
+
+    let listener =
+      TCPListener(
+        lori.TCPListenAuth(h.env.root),
+        recover _TestNPPListenNotify(port, pings_to_send, h) end,
+        "localhost",
+        port)
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+class \nodoc\ _TestNPPClientNotify is ClientTCPConnectionNotify
+  var _pings_to_send: I32
+  let _h: TestHelper
+
+  new create(pings_to_send: I32, h: TestHelper) =>
+    _pings_to_send = pings_to_send
+    _h = h
+
+  fun ref on_connected(conn: ClientTCPConnection ref) =>
+    match lori.MakeBufferSize(4)
+    | let e: lori.BufferSize => conn.buffer_until(e)
+    end
+    if _pings_to_send > 0 then
+      conn.write("Ping")
+      _pings_to_send = _pings_to_send - 1
+    end
+
+  fun ref on_received(conn: ClientTCPConnection ref, data: Array[U8] iso):
+    lori.ReadAction
+  =>
+    if _pings_to_send > 0 then
+      conn.write("Ping")
+      _pings_to_send = _pings_to_send - 1
+    elseif _pings_to_send == 0 then
+      _h.complete(true)
+    else
+      _h.fail("Too many pongs received")
+    end
+    lori.KeepReading
+
+  fun ref on_connect_failed(conn: ClientTCPConnection ref,
+    reason: lori.ConnectionFailureReason)
+  =>
+    _h.fail("client connect_failed")
+    _h.complete(false)
+
+class \nodoc\ _TestNPPServerNotify is ServerTCPConnectionNotify
+  var _pings_to_receive: I32
+  let _h: TestHelper
+
+  new create(pings_to_receive: I32, h: TestHelper) =>
+    _pings_to_receive = pings_to_receive
+    _h = h
+
+  fun ref on_accepted(conn: ServerTCPConnection ref) =>
+    match lori.MakeBufferSize(4)
+    | let e: lori.BufferSize => conn.buffer_until(e)
+    end
+
+  fun ref on_received(conn: ServerTCPConnection ref, data: Array[U8] iso):
+    lori.ReadAction
+  =>
+    if _pings_to_receive > 0 then
+      conn.write("Pong")
+      _pings_to_receive = _pings_to_receive - 1
+    elseif _pings_to_receive == 0 then
+      conn.write("Pong")
+    else
+      _h.fail("Too many pings received")
+    end
+    lori.KeepReading
+
+class \nodoc\ _TestNPPListenNotify is TCPListenNotify
+  let _port: String
+  let _pings_to_receive: I32
+  let _h: TestHelper
+
+  new create(port: String, pings_to_receive: I32, h: TestHelper) =>
+    _port = port
+    _pings_to_receive = pings_to_receive
+    _h = h
+
+  fun ref on_listening(listen: TCPListener ref) =>
+    let client =
+      ClientTCPConnection(
+        lori.TCPConnectAuth(_h.env.root),
+        recover _TestNPPClientNotify(_pings_to_receive, _h) end,
+        "localhost",
+        _port)
+    _h.dispose_when_done(client)
+
+  fun ref on_not_listening(listen: TCPListener ref) =>
+    _h.fail("Unable to open listener")
+    _h.complete(false)
+
+  fun ref on_connected(listen: TCPListener ref):
+    ServerTCPConnectionNotify iso^
+  =>
+    recover _TestNPPServerNotify(_pings_to_receive, _h) end

--- a/lori/notifier/_test_reject.pony
+++ b/lori/notifier/_test_reject.pony
@@ -1,0 +1,108 @@
+use lori = ".."
+use "pony_test"
+
+class \nodoc\ iso _TestNotifierRejectConnection is UnitTest
+  """
+  The listener's `connected` callback raises an error, rejecting the
+  connection. The listener stays open and can accept subsequent connections.
+  """
+  fun name(): String => "notifier/RejectConnection"
+
+  fun apply(h: TestHelper) =>
+    h.expect_action("listening")
+    h.expect_action("second_connected")
+
+    let listener =
+      TCPListener(
+        lori.TCPListenAuth(h.env.root),
+        recover
+          _TestNRCListenNotify(
+            lori.TCPConnectAuth(h.env.root), h)
+        end,
+        "localhost",
+        "9805")
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+class \nodoc\ _TestNRCListenNotify is TCPListenNotify
+  let _connect_auth: lori.TCPConnectAuth
+  let _h: TestHelper
+  var _reject_count: USize = 0
+
+  new create(
+    connect_auth: lori.TCPConnectAuth,
+    h: TestHelper)
+  =>
+    _connect_auth = connect_auth
+    _h = h
+
+  fun ref on_listening(listen: TCPListener ref) =>
+    _h.complete_action("listening")
+    let client =
+      ClientTCPConnection(
+        _connect_auth,
+        recover _TestNRCClientNotify(_connect_auth, _h) end,
+        "localhost",
+        "9805")
+    _h.dispose_when_done(client)
+
+  fun ref on_not_listening(listen: TCPListener ref) =>
+    _h.fail("Unable to open listener")
+    _h.complete(false)
+
+  fun ref on_connected(listen: TCPListener ref):
+    ServerTCPConnectionNotify iso^ ?
+  =>
+    _reject_count = _reject_count + 1
+    if _reject_count == 1 then
+      error
+    end
+    _h.complete_action("second_connected")
+    recover _TestNRCServerNotify end
+
+class \nodoc\ _TestNRCClientNotify is ClientTCPConnectionNotify
+  let _connect_auth: lori.TCPConnectAuth
+  let _h: TestHelper
+
+  new create(
+    connect_auth: lori.TCPConnectAuth,
+    h: TestHelper)
+  =>
+    _connect_auth = connect_auth
+    _h = h
+
+  fun ref on_connected(conn: ClientTCPConnection ref) =>
+    conn.close()
+
+  fun ref on_closed(conn: ClientTCPConnection ref) =>
+    let client =
+      ClientTCPConnection(
+        _connect_auth,
+        recover _TestNRCSecondClientNotify(_h) end,
+        "localhost",
+        "9805")
+    _h.dispose_when_done(client)
+
+  fun ref on_connect_failed(conn: ClientTCPConnection ref,
+    reason: lori.ConnectionFailureReason)
+  =>
+    _h.fail("client connect_failed")
+    _h.complete(false)
+
+class \nodoc\ _TestNRCSecondClientNotify is ClientTCPConnectionNotify
+  let _h: TestHelper
+
+  new create(h: TestHelper) =>
+    _h = h
+
+  fun ref on_connected(conn: ClientTCPConnection ref) =>
+    _h.complete(true)
+
+  fun ref on_connect_failed(conn: ClientTCPConnection ref,
+    reason: lori.ConnectionFailureReason)
+  =>
+    _h.fail("second client connect_failed")
+    _h.complete(false)
+
+class \nodoc\ _TestNRCServerNotify is ServerTCPConnectionNotify

--- a/lori/notifier/_test_ssl.pony
+++ b/lori/notifier/_test_ssl.pony
@@ -1,0 +1,133 @@
+use lori = ".."
+use "constrained_types"
+use "files"
+use "pony_test"
+use "ssl/net"
+
+class \nodoc\ iso _TestNotifierSSLPingPong is UnitTest
+  fun name(): String => "notifier/SSLPingPong"
+
+  fun apply(h: TestHelper) ? =>
+    let port = "9802"
+    let pings_to_send: I32 = 100
+    let file_auth = FileAuth(h.env.root)
+    let sslctx: SSLContext val =
+      recover
+        SSLContext
+          .> set_authority(
+            FilePath(file_auth, "assets/cert.pem"))?
+          .> set_cert(
+            FilePath(file_auth, "assets/cert.pem"),
+            FilePath(file_auth, "assets/key.pem"))?
+          .> set_client_verify(false)
+          .> set_server_verify(false)
+      end
+
+    let listener =
+      TCPListener.ssl(
+        lori.TCPListenAuth(h.env.root),
+        recover _TestNSSLListenNotify(port, sslctx, pings_to_send, h) end,
+        sslctx,
+        "localhost",
+        port)
+    h.dispose_when_done(listener)
+
+    h.long_test(5_000_000_000)
+
+class \nodoc\ _TestNSSLClientNotify is ClientTCPConnectionNotify
+  var _pings_to_send: I32
+  let _h: TestHelper
+
+  new create(pings_to_send: I32, h: TestHelper) =>
+    _pings_to_send = pings_to_send
+    _h = h
+
+  fun ref on_connected(conn: ClientTCPConnection ref) =>
+    match lori.MakeBufferSize(4)
+    | let e: lori.BufferSize => conn.buffer_until(e)
+    end
+    if _pings_to_send > 0 then
+      conn.write("Ping")
+      _pings_to_send = _pings_to_send - 1
+    end
+
+  fun ref on_received(conn: ClientTCPConnection ref, data: Array[U8] iso):
+    lori.ReadAction
+  =>
+    if _pings_to_send > 0 then
+      conn.write("Ping")
+      _pings_to_send = _pings_to_send - 1
+    elseif _pings_to_send == 0 then
+      _h.complete(true)
+    else
+      _h.fail("Too many pongs received")
+    end
+    lori.KeepReading
+
+  fun ref on_connect_failed(conn: ClientTCPConnection ref,
+    reason: lori.ConnectionFailureReason)
+  =>
+    _h.fail("SSL client connect_failed")
+    _h.complete(false)
+
+class \nodoc\ _TestNSSLServerNotify is ServerTCPConnectionNotify
+  var _pings_to_receive: I32
+  let _h: TestHelper
+
+  new create(pings_to_receive: I32, h: TestHelper) =>
+    _pings_to_receive = pings_to_receive
+    _h = h
+
+  fun ref on_accepted(conn: ServerTCPConnection ref) =>
+    match lori.MakeBufferSize(4)
+    | let e: lori.BufferSize => conn.buffer_until(e)
+    end
+
+  fun ref on_received(conn: ServerTCPConnection ref, data: Array[U8] iso):
+    lori.ReadAction
+  =>
+    if _pings_to_receive > 0 then
+      conn.write("Pong")
+      _pings_to_receive = _pings_to_receive - 1
+    elseif _pings_to_receive == 0 then
+      conn.write("Pong")
+    else
+      _h.fail("Too many pings received")
+    end
+    lori.KeepReading
+
+class \nodoc\ _TestNSSLListenNotify is TCPListenNotify
+  let _port: String
+  let _sslctx: SSLContext val
+  let _pings_to_receive: I32
+  let _h: TestHelper
+
+  new create(
+    port: String,
+    sslctx: SSLContext val,
+    pings_to_receive: I32,
+    h: TestHelper)
+  =>
+    _port = port
+    _sslctx = sslctx
+    _pings_to_receive = pings_to_receive
+    _h = h
+
+  fun ref on_listening(listen: TCPListener ref) =>
+    let client =
+      ClientTCPConnection.ssl(
+        lori.TCPConnectAuth(_h.env.root),
+        recover _TestNSSLClientNotify(_pings_to_receive, _h) end,
+        _sslctx,
+        "localhost",
+        _port)
+    _h.dispose_when_done(client)
+
+  fun ref on_not_listening(listen: TCPListener ref) =>
+    _h.fail("Unable to open SSL listener")
+    _h.complete(false)
+
+  fun ref on_connected(listen: TCPListener ref):
+    ServerTCPConnectionNotify iso^
+  =>
+    recover _TestNSSLServerNotify(_pings_to_receive, _h) end

--- a/lori/notifier/client_tcp_connection.pony
+++ b/lori/notifier/client_tcp_connection.pony
@@ -1,0 +1,316 @@
+use lori = ".."
+use net = "net"
+use "ssl/net"
+
+actor ClientTCPConnection is
+  (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
+  """
+  A client TCP connection actor driven by a
+  [`ClientTCPConnectionNotify`](/lori/notifier-ClientTCPConnectionNotify/).
+
+  Wraps lori's `TCPConnection` class and `ClientLifecycleEventReceiver` trait
+  into a single actor, forwarding lifecycle callbacks to the notifier you
+  provide. This is the notifier-based alternative to implementing
+  `TCPConnectionActor` and `ClientLifecycleEventReceiver` yourself.
+
+  ## Sending data
+
+  `write` and `writev` are fire-and-forget behaviors: they call `send()` on
+  the underlying connection and discard the result. A send that cannot be
+  accepted (connection not open, backpressure) is silently dropped — no
+  callback fires for it. An accepted send produces `on_send_accepted`, then
+  exactly one of `on_sent` or `on_send_failed` on the notifier.
+
+  ## Synchronous methods
+
+  Callbacks receive `conn: ClientTCPConnection ref`. Synchronous methods on
+  the actor — `buffer_until`, socket options, `close`, `set_timer`, etc. —
+  are callable from any callback and take effect immediately.
+  """
+  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _notify: ClientTCPConnectionNotify ref
+
+  new create(auth: lori.TCPConnectAuth,
+    notify: ClientTCPConnectionNotify iso,
+    host: String,
+    service: String,
+    from: String = "",
+    read_buffer_size: lori.ReadBufferSize = lori.DefaultReadBufferSize(),
+    ip_version: lori.IPVersion = lori.DualStack,
+    connection_timeout: (lori.ConnectionTimeout | None) = None)
+  =>
+    """
+    Open a plaintext client connection to `host`:`service`.
+    """
+    _notify = consume notify
+    _tcp_connection =
+      lori.TCPConnection.client(
+        auth,
+        host,
+        service,
+        from,
+        this,
+        this,
+        read_buffer_size,
+        ip_version,
+        connection_timeout)
+
+  new ssl(auth: lori.TCPConnectAuth,
+    notify: ClientTCPConnectionNotify iso,
+    ctx: SSLContext val,
+    host: String,
+    service: String,
+    from: String = "",
+    read_buffer_size: lori.ReadBufferSize = lori.DefaultReadBufferSize(),
+    ip_version: lori.IPVersion = lori.DualStack,
+    connection_timeout: (lori.ConnectionTimeout | None) = None)
+  =>
+    """
+    Open an SSL client connection to `host`:`service`. The SSL session is
+    created from `ctx`. `on_connected` fires after the TLS handshake completes.
+    """
+    _notify = consume notify
+    _tcp_connection =
+      lori.TCPConnection.ssl_client(
+        auth,
+        ctx,
+        host,
+        service,
+        from,
+        this,
+        this,
+        read_buffer_size,
+        ip_version,
+        connection_timeout)
+
+  // --- TCPConnectionActor ---------------------------------------------------
+  fun ref _connection(): lori.TCPConnection =>
+    _tcp_connection
+
+  // --- Behaviors -------------------------------------------------------------
+  be write(data: ByteSeq) =>
+    """
+    Send data on this connection. Fire-and-forget: the send is silently
+    dropped if the connection is not open or is under backpressure. An
+    accepted send produces `on_send_accepted`, then `on_sent` or
+    `on_send_failed` on the notifier.
+    """
+    _tcp_connection.send(data)
+
+  be writev(data: ByteSeqIter) =>
+    """
+    Send multiple buffers in a single syscall. Same fire-and-forget semantics
+    as `write`.
+    """
+    _tcp_connection.send(data)
+
+  be mute() =>
+    """
+    Stop reading from the socket until `unmute` is called. Takes effect on
+    the next turn, not immediately — use `YieldReading` from `on_received`
+    for an immediate one-shot pause.
+    """
+    _tcp_connection.mute()
+
+  be unmute() =>
+    """
+    Resume reading after a `mute`.
+    """
+    _tcp_connection.unmute()
+
+  // --- Synchronous methods ---------------------------------------------------
+  fun ref buffer_until(qty: (lori.BufferSize | lori.Streaming)):
+    lori.BufferUntilResult
+  =>
+    """
+    Set the number of bytes to buffer before delivering data via `on_received`.
+    Pass `Streaming` to deliver all available data as it arrives.
+    """
+    _tcp_connection.buffer_until(qty)
+
+  fun ref close() =>
+    """
+    Gracefully close the connection. Sends already accepted by the underlying
+    connection are delivered before close completes. Because `close` is
+    synchronous and `write` is a behavior, a `write` call in the same
+    callback runs after `close` — use `write` before `close`, not after.
+    """
+    _tcp_connection.close()
+
+  fun ref hard_close() =>
+    """
+    Close the connection immediately, dropping any queued data.
+    """
+    _tcp_connection.hard_close()
+
+  fun ref start_tls(ssl_ctx: SSLContext val, host: String = ""):
+    (None | lori.StartTLSError)
+  =>
+    """
+    Initiate a TLS handshake on an established plaintext connection. Returns
+    `None` when the handshake starts, or a `StartTLSError` if the upgrade
+    cannot proceed. On success, `on_tls_ready` fires. On failure,
+    `on_tls_failure` fires followed by `on_closed`.
+    """
+    _tcp_connection.start_tls(ssl_ctx, host)
+
+  fun set_nodelay(state: Bool): U32 =>
+    """
+    Turn Nagle on/off. Returns 0 on success, or a non-zero errno on failure.
+    """
+    _tcp_connection.set_nodelay(state)
+
+  fun ref keepalive(secs: U32) =>
+    """
+    Set the TCP keepalive timeout. Pass 0 to disable.
+    """
+    _tcp_connection.keepalive(secs)
+
+  fun ref local_address(): net.NetAddress =>
+    """
+    Return the local IP address.
+    """
+    _tcp_connection.local_address()
+
+  fun ref remote_address(): net.NetAddress =>
+    """
+    Return the remote IP address.
+    """
+    _tcp_connection.remote_address()
+
+  fun ref idle_timeout(duration: (lori.IdleTimeout | None)) =>
+    """
+    Set or disable the idle timeout. The timer fires when no data is sent or
+    received for the configured duration. Pass `None` to disable.
+    """
+    _tcp_connection.idle_timeout(duration)
+
+  fun ref set_timer(duration: lori.TimerDuration):
+    (lori.TimerToken | lori.SetTimerError)
+  =>
+    """
+    Create a one-shot timer. Returns a `TimerToken` on success. Only one
+    timer can be active at a time; cancel the existing one first.
+    """
+    _tcp_connection.set_timer(duration)
+
+  fun ref cancel_timer(token: lori.TimerToken) =>
+    """
+    Cancel an active timer. Safe to call with stale tokens.
+    """
+    _tcp_connection.cancel_timer(token)
+
+  fun ref set_read_buffer_minimum(new_min: lori.ReadBufferSize):
+    (lori.ReadBufferResized | lori.ReadBufferResizeBelowBufferSize)
+  =>
+    """
+    Set the shrink-back floor for the read buffer.
+    """
+    _tcp_connection.set_read_buffer_minimum(new_min)
+
+  fun ref resize_read_buffer(size': lori.ReadBufferSize):
+    lori.ReadBufferResizeResult
+  =>
+    """
+    Force the read buffer to a specific size.
+    """
+    _tcp_connection.resize_read_buffer(size')
+
+  fun get_so_rcvbuf(): (U32, U32) =>
+    """
+    Get the OS receive buffer size. Returns (errno, value).
+    """
+    _tcp_connection.get_so_rcvbuf()
+
+  fun set_so_rcvbuf(bufsize: U32): U32 =>
+    """
+    Set the OS receive buffer size. Returns 0 on success, or errno.
+    """
+    _tcp_connection.set_so_rcvbuf(bufsize)
+
+  fun get_so_sndbuf(): (U32, U32) =>
+    """
+    Get the OS send buffer size. Returns (errno, value).
+    """
+    _tcp_connection.get_so_sndbuf()
+
+  fun set_so_sndbuf(bufsize: U32): U32 =>
+    """
+    Set the OS send buffer size. Returns 0 on success, or errno.
+    """
+    _tcp_connection.set_so_sndbuf(bufsize)
+
+  fun getsockopt_u32(level: I32, option_name: I32): (U32, U32) =>
+    """
+    Get a socket option as a U32. Returns (errno, value).
+    """
+    _tcp_connection.getsockopt_u32(level, option_name)
+
+  fun setsockopt_u32(level: I32, option_name: I32, option: U32): U32 =>
+    """
+    Set a socket option as a U32. Returns 0 on success, or errno.
+    """
+    _tcp_connection.setsockopt_u32(level, option_name, option)
+
+  fun is_closed(): Bool =>
+    """
+    True when the connection is closed or closing.
+    """
+    _tcp_connection.is_closed()
+
+  fun is_writeable(): Bool =>
+    """
+    True when the socket can currently send.
+    """
+    _tcp_connection.is_writeable()
+
+  // --- ClientLifecycleEventReceiver ------------------------------------------
+  fun ref _on_connecting(inflight_connections: U32) =>
+    _notify.on_connecting(this, inflight_connections)
+
+  fun ref _on_connected() =>
+    _notify.on_connected(this)
+
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
+    _notify.on_connect_failed(this, reason)
+
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+    _notify.on_received(this, consume data)
+
+  fun ref _on_send_accepted(token: lori.SendToken,
+    data: (ByteSeq | ByteSeqIter))
+  =>
+    _notify.on_send_accepted(this, token, data)
+
+  fun ref _on_sent(token: lori.SendToken) =>
+    _notify.on_sent(this, token)
+
+  fun ref _on_send_failed(token: lori.SendToken) =>
+    _notify.on_send_failed(this, token)
+
+  fun ref _on_throttled() =>
+    _notify.on_throttled(this)
+
+  fun ref _on_unthrottled() =>
+    _notify.on_unthrottled(this)
+
+  fun ref _on_closed() =>
+    _notify.on_closed(this)
+
+  fun ref _on_tls_ready() =>
+    _notify.on_tls_ready(this)
+
+  fun ref _on_tls_failure(reason: lori.TLSFailureReason) =>
+    _notify.on_tls_failure(this, reason)
+
+  fun ref _on_idle_timeout() =>
+    _notify.on_idle_timeout(this)
+
+  fun ref _on_idle_timer_failure() =>
+    _notify.on_idle_timer_failure(this)
+
+  fun ref _on_timer(token: lori.TimerToken) =>
+    _notify.on_timer(this, token)
+
+  fun ref _on_timer_failure() =>
+    _notify.on_timer_failure(this)

--- a/lori/notifier/client_tcp_connection_notify.pony
+++ b/lori/notifier/client_tcp_connection_notify.pony
@@ -1,0 +1,142 @@
+use lori = ".."
+use net = "net"
+use "ssl/net"
+
+trait ClientTCPConnectionNotify
+  """
+  Callbacks for a client-side TCP connection. Implement this trait and pass it
+  to `ClientTCPConnection` to handle connection events.
+
+  All callbacks receive the connection as `conn ref`, so synchronous methods
+  on the connection (socket options, `buffer_until`, `close`, etc.) are
+  callable from any callback. Behaviors like `write` are also callable but
+  execute on the next turn.
+
+  Every callback has a default implementation except `on_connect_failed`,
+  which must be implemented because ignoring a failed connection is never
+  correct.
+  """
+  fun ref on_connecting(conn: ClientTCPConnection ref, count: U32) =>
+    """
+    Called when at least one TCP connection attempt is in progress. `count` is
+    the number of attempts currently inflight. Called again each time the count
+    changes, until `on_connected` or `on_connect_failed` fires.
+    """
+    None
+
+  fun ref on_connected(conn: ClientTCPConnection ref) =>
+    """
+    Called when the connection is ready for application data. For SSL
+    connections, this fires after the TLS handshake completes.
+    """
+    None
+
+  fun ref on_connect_failed(conn: ClientTCPConnection ref,
+    reason: lori.ConnectionFailureReason)
+    """
+    Called when the connection cannot be established. `reason` identifies the
+    failure stage: DNS resolution, TCP connect, SSL handshake, timeout, or
+    timer error.
+    """
+
+  fun ref on_received(conn: ClientTCPConnection ref, data: Array[U8] iso):
+    lori.ReadAction
+  =>
+    """
+    Called when data arrives on the connection. Return `KeepReading` to
+    continue reading or `YieldReading` to stop after this message and give
+    other actors a turn.
+    """
+    lori.KeepReading
+
+  fun ref on_send_accepted(conn: ClientTCPConnection ref,
+    token: lori.SendToken,
+    data: (ByteSeq | ByteSeqIter))
+  =>
+    """
+    Called when a `write` or `writev` is accepted. Because `write` and `writev`
+    are behaviors, this fires in their behavior turn, not during the callback
+    that called `write`. `token` identifies this send and arrives exactly once
+    more at `on_sent` or `on_send_failed`.
+    """
+    None
+
+  fun ref on_sent(conn: ClientTCPConnection ref, token: lori.SendToken) =>
+    """
+    Called when the bytes from an accepted send have been handed to the OS.
+    The token matches the one delivered by `on_send_accepted`.
+    """
+    None
+
+  fun ref on_send_failed(conn: ClientTCPConnection ref,
+    token: lori.SendToken)
+  =>
+    """
+    Called when an accepted send's bytes could not reach the OS because the
+    connection was lost or hard-closed first. Arrives after `on_closed`.
+    """
+    None
+
+  fun ref on_throttled(conn: ClientTCPConnection ref) =>
+    """
+    Called when the connection applies backpressure. `write` calls after this
+    are silently dropped until `on_unthrottled` fires.
+    """
+    None
+
+  fun ref on_unthrottled(conn: ClientTCPConnection ref) =>
+    """
+    Called when backpressure is released and the connection is writeable again.
+    """
+    None
+
+  fun ref on_closed(conn: ClientTCPConnection ref) =>
+    """
+    Called when the connection is closed.
+    """
+    None
+
+  fun ref on_tls_ready(conn: ClientTCPConnection ref) =>
+    """
+    Called when a TLS handshake initiated by `start_tls()` completes. The
+    connection is now encrypted.
+    """
+    None
+
+  fun ref on_tls_failure(conn: ClientTCPConnection ref,
+    reason: lori.TLSFailureReason)
+  =>
+    """
+    Called when a TLS handshake initiated by `start_tls()` fails. `on_closed`
+    follows.
+    """
+    None
+
+  fun ref on_idle_timeout(conn: ClientTCPConnection ref) =>
+    """
+    Called when no data has been sent or received for the duration configured
+    by `conn.idle_timeout()`. The timer re-arms automatically.
+    """
+    None
+
+  fun ref on_idle_timer_failure(conn: ClientTCPConnection ref) =>
+    """
+    Called when the idle timer's ASIO event subscription fails. The timer has
+    been cancelled; call `conn.idle_timeout(duration)` to retry.
+    """
+    None
+
+  fun ref on_timer(conn: ClientTCPConnection ref, token: lori.TimerToken) =>
+    """
+    Called when a one-shot timer created by `conn.set_timer()` fires. The
+    token matches the one returned by `set_timer()`. Call `set_timer()` again
+    to re-arm.
+    """
+    None
+
+  fun ref on_timer_failure(conn: ClientTCPConnection ref) =>
+    """
+    Called when a user timer's ASIO event subscription fails. The timer has
+    been cancelled; call `conn.set_timer(duration)` to create a new one.
+    """
+    None

--- a/lori/notifier/notifier.pony
+++ b/lori/notifier/notifier.pony
@@ -1,0 +1,104 @@
+"""
+# Notifier Package
+
+A convenience layer over lori for straightforward TCP applications. You write
+a notifier class with the callbacks you care about, hand it to an actor, and
+the actor handles the rest — connection setup, calling your notifier when data
+arrives or the connection state changes, and cleanup.
+
+Lori's native API gives you full control: you build your own actor, mix in
+traits, and manage a `TCPConnection` class directly. That control matters when
+you need synchronous send results, custom actor structure, or multiple
+connections per actor. The notifier layer trades that control for less code:
+three concrete actors and three notifier traits cover the common cases without
+any actor boilerplate.
+
+## Actors and notifiers
+
+- `ClientTCPConnection` + `ClientTCPConnectionNotify` —
+  client connections
+- `ServerTCPConnection` + `ServerTCPConnectionNotify` —
+  server connections
+- `TCPListener` + `TCPListenNotify` — listeners
+
+The actors are concrete — only the notifiers are traits.
+
+## Echo Server
+
+```pony
+use "lori"
+use "lori/notifier"
+
+class Echo is ServerTCPConnectionNotify
+  fun ref on_received(conn: ServerTCPConnection ref, data: Array[U8] iso):
+    ReadAction
+  =>
+    conn.write(consume data)
+    KeepReading
+
+class EchoListen is TCPListenNotify
+  fun ref on_connected(listen: TCPListener ref):
+    ServerTCPConnectionNotify iso^
+  =>
+    Echo
+  fun ref on_not_listening(listen: TCPListener ref) =>
+    None
+
+actor Main
+  new create(env: Env) =>
+    TCPListener(TCPListenAuth(env.root), recover EchoListen end, "", "8989")
+```
+
+## Client
+
+```pony
+use "lori"
+use "lori/notifier"
+
+class MyClient is ClientTCPConnectionNotify
+  fun ref on_connected(conn: ClientTCPConnection ref) =>
+    conn.write("hello")
+  fun ref on_connect_failed(conn: ClientTCPConnection ref,
+    reason: ConnectionFailureReason)
+  =>
+    None
+
+actor Main
+  new create(env: Env) =>
+    ClientTCPConnection(TCPConnectAuth(env.root), recover MyClient end,
+      "localhost", "8989")
+```
+
+## What the notifier layer changes
+
+**`write`/`writev` are fire-and-forget behaviors.** Lori's native `send()`
+is synchronous and returns a result the caller can act on immediately. The
+notifier's `write` is a behavior — it queues the data for the next turn. The
+actor calls `send()` internally; use the `on_send_accepted`/`on_sent`/
+`on_send_failed` callbacks to track whether each send reached the OS.
+
+**`mute`/`unmute` are behaviors.** Lori's native `mute()` takes effect
+immediately during a received callback. The notifier's `mute()` queues for
+the next turn. For an immediate one-shot pause within `on_received`, return
+`YieldReading`.
+
+**SSL is a constructor parameter.** Use the `.ssl` constructor on
+`ClientTCPConnection` or `TCPListener` to create an SSL-enabled connection
+or listener.
+
+## Naming
+
+`TCPListener` exists in both `lori` and `lori/notifier`. When using both
+packages, qualify the import:
+
+```pony
+use "lori"
+use notifier = "lori/notifier"
+
+// lori's class-based listener
+let l1: TCPListener = ...
+
+// notifier's actor-based listener
+let l2: notifier.TCPListener = ...
+```
+"""

--- a/lori/notifier/server_tcp_connection.pony
+++ b/lori/notifier/server_tcp_connection.pony
@@ -1,0 +1,287 @@
+use lori = ".."
+use net = "net"
+use "ssl/net"
+
+actor ServerTCPConnection is
+  (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver)
+  """
+  A server-side TCP connection actor driven by a
+  [`ServerTCPConnectionNotify`](/lori/notifier-ServerTCPConnectionNotify/).
+
+  Created by [`TCPListener`](/lori/notifier-TCPListener/) when a client
+  connects — there is no public constructor. Wraps lori's `TCPConnection`
+  class and `ServerLifecycleEventReceiver` trait, forwarding lifecycle
+  callbacks to the notifier returned by `TCPListenNotify.on_connected()`.
+
+  ## Sending data
+
+  `write` and `writev` are fire-and-forget behaviors: they call `send()` on
+  the underlying connection and discard the result. A send that cannot be
+  accepted (connection not open, backpressure) is silently dropped — no
+  callback fires for it. An accepted send produces `on_send_accepted`, then
+  exactly one of `on_sent` or `on_send_failed` on the notifier.
+
+  ## Synchronous methods
+
+  Callbacks receive `conn: ServerTCPConnection ref`. Synchronous methods on
+  the actor — `buffer_until`, socket options, `close`, `set_timer`, etc. —
+  are callable from any callback and take effect immediately.
+  """
+  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _notify: ServerTCPConnectionNotify ref
+
+  new _create(auth: lori.TCPServerAuth,
+    fd: U32,
+    notify: ServerTCPConnectionNotify iso,
+    read_buffer_size: lori.ReadBufferSize = lori.DefaultReadBufferSize())
+  =>
+    """
+    Create a plaintext server connection from an accepted socket.
+    """
+    _notify = consume notify
+    _tcp_connection =
+      lori.TCPConnection.server(
+        auth, fd, this, this, read_buffer_size)
+
+  new _ssl_create(auth: lori.TCPServerAuth,
+    ctx: SSLContext val,
+    fd: U32,
+    notify: ServerTCPConnectionNotify iso,
+    read_buffer_size: lori.ReadBufferSize = lori.DefaultReadBufferSize())
+  =>
+    """
+    Create an SSL server connection from an accepted socket.
+    """
+    _notify = consume notify
+    _tcp_connection =
+      lori.TCPConnection.ssl_server(
+        auth, ctx, fd, this, this, read_buffer_size)
+
+  // --- TCPConnectionActor ---------------------------------------------------
+  fun ref _connection(): lori.TCPConnection =>
+    _tcp_connection
+
+  // --- Behaviors -------------------------------------------------------------
+  be write(data: ByteSeq) =>
+    """
+    Send data on this connection. Fire-and-forget: the send is silently
+    dropped if the connection is not open or is under backpressure. An
+    accepted send produces `on_send_accepted`, then `on_sent` or
+    `on_send_failed` on the notifier.
+    """
+    _tcp_connection.send(data)
+
+  be writev(data: ByteSeqIter) =>
+    """
+    Send multiple buffers in a single syscall. Same fire-and-forget semantics
+    as `write`.
+    """
+    _tcp_connection.send(data)
+
+  be mute() =>
+    """
+    Stop reading from the socket until `unmute` is called. Takes effect on
+    the next turn, not immediately — use `YieldReading` from `on_received`
+    for an immediate one-shot pause.
+    """
+    _tcp_connection.mute()
+
+  be unmute() =>
+    """
+    Resume reading after a `mute`.
+    """
+    _tcp_connection.unmute()
+
+  // --- Synchronous methods ---------------------------------------------------
+  fun ref buffer_until(qty: (lori.BufferSize | lori.Streaming)):
+    lori.BufferUntilResult
+  =>
+    """
+    Set the number of bytes to buffer before delivering data via `on_received`.
+    Pass `Streaming` to deliver all available data as it arrives.
+    """
+    _tcp_connection.buffer_until(qty)
+
+  fun ref close() =>
+    """
+    Gracefully close the connection. Sends already accepted by the underlying
+    connection are delivered before close completes. Because `close` is
+    synchronous and `write` is a behavior, a `write` call in the same
+    callback runs after `close` — use `write` before `close`, not after.
+    """
+    _tcp_connection.close()
+
+  fun ref hard_close() =>
+    """
+    Close the connection immediately, dropping any queued data.
+    """
+    _tcp_connection.hard_close()
+
+  fun ref start_tls(ssl_ctx: SSLContext val, host: String = ""):
+    (None | lori.StartTLSError)
+  =>
+    """
+    Initiate a TLS handshake on an established plaintext connection. Returns
+    `None` when the handshake starts, or a `StartTLSError` if the upgrade
+    cannot proceed. On success, `on_tls_ready` fires. On failure,
+    `on_tls_failure` fires followed by `on_closed`.
+    """
+    _tcp_connection.start_tls(ssl_ctx, host)
+
+  fun set_nodelay(state: Bool): U32 =>
+    """
+    Turn Nagle on/off. Returns 0 on success, or a non-zero errno on failure.
+    """
+    _tcp_connection.set_nodelay(state)
+
+  fun ref keepalive(secs: U32) =>
+    """
+    Set the TCP keepalive timeout. Pass 0 to disable.
+    """
+    _tcp_connection.keepalive(secs)
+
+  fun ref local_address(): net.NetAddress =>
+    """
+    Return the local IP address.
+    """
+    _tcp_connection.local_address()
+
+  fun ref remote_address(): net.NetAddress =>
+    """
+    Return the remote IP address.
+    """
+    _tcp_connection.remote_address()
+
+  fun ref idle_timeout(duration: (lori.IdleTimeout | None)) =>
+    """
+    Set or disable the idle timeout. The timer fires when no data is sent or
+    received for the configured duration. Pass `None` to disable.
+    """
+    _tcp_connection.idle_timeout(duration)
+
+  fun ref set_timer(duration: lori.TimerDuration):
+    (lori.TimerToken | lori.SetTimerError)
+  =>
+    """
+    Create a one-shot timer. Returns a `TimerToken` on success. Only one
+    timer can be active at a time; cancel the existing one first.
+    """
+    _tcp_connection.set_timer(duration)
+
+  fun ref cancel_timer(token: lori.TimerToken) =>
+    """
+    Cancel an active timer. Safe to call with stale tokens.
+    """
+    _tcp_connection.cancel_timer(token)
+
+  fun ref set_read_buffer_minimum(new_min: lori.ReadBufferSize):
+    (lori.ReadBufferResized | lori.ReadBufferResizeBelowBufferSize)
+  =>
+    """
+    Set the shrink-back floor for the read buffer.
+    """
+    _tcp_connection.set_read_buffer_minimum(new_min)
+
+  fun ref resize_read_buffer(size': lori.ReadBufferSize):
+    lori.ReadBufferResizeResult
+  =>
+    """
+    Force the read buffer to a specific size.
+    """
+    _tcp_connection.resize_read_buffer(size')
+
+  fun get_so_rcvbuf(): (U32, U32) =>
+    """
+    Get the OS receive buffer size. Returns (errno, value).
+    """
+    _tcp_connection.get_so_rcvbuf()
+
+  fun set_so_rcvbuf(bufsize: U32): U32 =>
+    """
+    Set the OS receive buffer size. Returns 0 on success, or errno.
+    """
+    _tcp_connection.set_so_rcvbuf(bufsize)
+
+  fun get_so_sndbuf(): (U32, U32) =>
+    """
+    Get the OS send buffer size. Returns (errno, value).
+    """
+    _tcp_connection.get_so_sndbuf()
+
+  fun set_so_sndbuf(bufsize: U32): U32 =>
+    """
+    Set the OS send buffer size. Returns 0 on success, or errno.
+    """
+    _tcp_connection.set_so_sndbuf(bufsize)
+
+  fun getsockopt_u32(level: I32, option_name: I32): (U32, U32) =>
+    """
+    Get a socket option as a U32. Returns (errno, value).
+    """
+    _tcp_connection.getsockopt_u32(level, option_name)
+
+  fun setsockopt_u32(level: I32, option_name: I32, option: U32): U32 =>
+    """
+    Set a socket option as a U32. Returns 0 on success, or errno.
+    """
+    _tcp_connection.setsockopt_u32(level, option_name, option)
+
+  fun is_closed(): Bool =>
+    """
+    True when the connection is closed or closing.
+    """
+    _tcp_connection.is_closed()
+
+  fun is_writeable(): Bool =>
+    """
+    True when the socket can currently send.
+    """
+    _tcp_connection.is_writeable()
+
+  // --- ServerLifecycleEventReceiver ------------------------------------------
+  fun ref _on_started() =>
+    _notify.on_accepted(this)
+
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+    _notify.on_received(this, consume data)
+
+  fun ref _on_send_accepted(token: lori.SendToken,
+    data: (ByteSeq | ByteSeqIter))
+  =>
+    _notify.on_send_accepted(this, token, data)
+
+  fun ref _on_sent(token: lori.SendToken) =>
+    _notify.on_sent(this, token)
+
+  fun ref _on_send_failed(token: lori.SendToken) =>
+    _notify.on_send_failed(this, token)
+
+  fun ref _on_throttled() =>
+    _notify.on_throttled(this)
+
+  fun ref _on_unthrottled() =>
+    _notify.on_unthrottled(this)
+
+  fun ref _on_closed() =>
+    _notify.on_closed(this)
+
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    _notify.on_start_failure(this, reason)
+
+  fun ref _on_tls_ready() =>
+    _notify.on_tls_ready(this)
+
+  fun ref _on_tls_failure(reason: lori.TLSFailureReason) =>
+    _notify.on_tls_failure(this, reason)
+
+  fun ref _on_idle_timeout() =>
+    _notify.on_idle_timeout(this)
+
+  fun ref _on_idle_timer_failure() =>
+    _notify.on_idle_timer_failure(this)
+
+  fun ref _on_timer(token: lori.TimerToken) =>
+    _notify.on_timer(this, token)
+
+  fun ref _on_timer_failure() =>
+    _notify.on_timer_failure(this)

--- a/lori/notifier/server_tcp_connection_notify.pony
+++ b/lori/notifier/server_tcp_connection_notify.pony
@@ -1,0 +1,138 @@
+use lori = ".."
+use net = "net"
+use "ssl/net"
+
+trait ServerTCPConnectionNotify
+  """
+  Callbacks for a server-side TCP connection. Implement this trait and return
+  it from `TCPListenNotify.connected()` to handle events on an accepted
+  connection.
+
+  All callbacks receive the connection as `conn ref`, so synchronous methods
+  on the connection (socket options, `buffer_until`, `close`, etc.) are
+  callable from any callback. Behaviors like `write` are also callable but
+  execute on the next turn.
+
+  Every callback has a default implementation. Override the ones your
+  application cares about.
+  """
+  fun ref on_accepted(conn: ServerTCPConnection ref) =>
+    """
+    Called when a server connection is ready for application data. For SSL
+    connections, this fires after the TLS handshake completes.
+
+    Server connections start with the default read buffer size (16 KiB).
+    Call `conn.resize_read_buffer()` here to use a different size.
+    """
+    None
+
+  fun ref on_received(conn: ServerTCPConnection ref, data: Array[U8] iso):
+    lori.ReadAction
+  =>
+    """
+    Called when data arrives on the connection. Return `KeepReading` to
+    continue reading or `YieldReading` to stop after this message and give
+    other actors a turn.
+    """
+    lori.KeepReading
+
+  fun ref on_send_accepted(conn: ServerTCPConnection ref,
+    token: lori.SendToken,
+    data: (ByteSeq | ByteSeqIter))
+  =>
+    """
+    Called when a `write` or `writev` is accepted. Because `write` and `writev`
+    are behaviors, this fires in their behavior turn, not during the callback
+    that called `write`. `token` identifies this send and arrives exactly once
+    more at `on_sent` or `on_send_failed`.
+    """
+    None
+
+  fun ref on_sent(conn: ServerTCPConnection ref, token: lori.SendToken) =>
+    """
+    Called when the bytes from an accepted send have been handed to the OS.
+    The token matches the one delivered by `on_send_accepted`.
+    """
+    None
+
+  fun ref on_send_failed(conn: ServerTCPConnection ref,
+    token: lori.SendToken)
+  =>
+    """
+    Called when an accepted send's bytes could not reach the OS because the
+    connection was lost or hard-closed first. Arrives after `on_closed`.
+    """
+    None
+
+  fun ref on_throttled(conn: ServerTCPConnection ref) =>
+    """
+    Called when the connection applies backpressure. `write` calls after this
+    are silently dropped until `on_unthrottled` fires.
+    """
+    None
+
+  fun ref on_unthrottled(conn: ServerTCPConnection ref) =>
+    """
+    Called when backpressure is released and the connection is writeable again.
+    """
+    None
+
+  fun ref on_closed(conn: ServerTCPConnection ref) =>
+    """
+    Called when the connection is closed.
+    """
+    None
+
+  fun ref on_start_failure(conn: ServerTCPConnection ref,
+    reason: lori.StartFailureReason)
+  =>
+    """
+    Called when a server connection fails to start — for example, an SSL
+    handshake failure before `on_accepted` would have fired.
+    """
+    None
+
+  fun ref on_tls_ready(conn: ServerTCPConnection ref) =>
+    """
+    Called when a TLS handshake initiated by `start_tls()` completes. The
+    connection is now encrypted.
+    """
+    None
+
+  fun ref on_tls_failure(conn: ServerTCPConnection ref,
+    reason: lori.TLSFailureReason)
+  =>
+    """
+    Called when a TLS handshake initiated by `start_tls()` fails. `on_closed`
+    follows.
+    """
+    None
+
+  fun ref on_idle_timeout(conn: ServerTCPConnection ref) =>
+    """
+    Called when no data has been sent or received for the duration configured
+    by `conn.idle_timeout()`. The timer re-arms automatically.
+    """
+    None
+
+  fun ref on_idle_timer_failure(conn: ServerTCPConnection ref) =>
+    """
+    Called when the idle timer's ASIO event subscription fails. The timer has
+    been cancelled; call `conn.idle_timeout(duration)` to retry.
+    """
+    None
+
+  fun ref on_timer(conn: ServerTCPConnection ref, token: lori.TimerToken) =>
+    """
+    Called when a one-shot timer created by `conn.set_timer()` fires. The
+    token matches the one returned by `set_timer()`. Call `set_timer()` again
+    to re-arm.
+    """
+    None
+
+  fun ref on_timer_failure(conn: ServerTCPConnection ref) =>
+    """
+    Called when a user timer's ASIO event subscription fails. The timer has
+    been cancelled; call `conn.set_timer(duration)` to create a new one.
+    """
+    None

--- a/lori/notifier/tcp_listen_notify.pony
+++ b/lori/notifier/tcp_listen_notify.pony
@@ -1,0 +1,34 @@
+trait TCPListenNotify
+  """
+  Callbacks for a TCP listener. Implement this trait and pass it to
+  `TCPListener` to handle listener events.
+
+  `on_connected` and `on_not_listening` have no default implementations.
+  `on_connected` is where you create the notifier for each accepted
+  connection. `on_not_listening` must be implemented because ignoring a listen
+  failure silently is never correct.
+  """
+  fun ref on_listening(listen: TCPListener ref) =>
+    """
+    Called when the listener is ready to accept connections.
+    """
+    None
+
+  fun ref on_not_listening(listen: TCPListener ref)
+    """
+    Called when the listener could not open its socket.
+    """
+
+  fun ref on_connected(listen: TCPListener ref):
+    ServerTCPConnectionNotify iso^
+  ?
+    """
+    Called when a client connects. Return a `ServerTCPConnectionNotify` for
+    the new connection. Raise an error to reject the connection.
+    """
+
+  fun ref on_closed(listen: TCPListener ref) =>
+    """
+    Called after the listener is closed.
+    """
+    None

--- a/lori/notifier/tcp_listener.pony
+++ b/lori/notifier/tcp_listener.pony
@@ -1,0 +1,89 @@
+use lori = ".."
+use net = "net"
+use "ssl/net"
+
+actor TCPListener is lori.TCPListenerActor
+  """
+  A TCP listener actor driven by a
+  [`TCPListenNotify`](/lori/notifier-TCPListenNotify/).
+
+  Wraps lori's `TCPListener` class and `TCPListenerActor` trait into a single
+  actor. When a client connects, the listener asks the notifier for a
+  `ServerTCPConnectionNotify` and creates a `ServerTCPConnection` internally.
+  """
+  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
+  var _notify: TCPListenNotify ref
+  let _server_auth: lori.TCPServerAuth
+  let _ssl_ctx: (SSLContext val | None)
+
+  new create(auth: lori.TCPListenAuth,
+    notify: TCPListenNotify iso,
+    host: String,
+    service: String,
+    limit: (lori.MaxSpawn | None) = lori.DefaultMaxSpawn(),
+    ip_version: lori.IPVersion = lori.DualStack)
+  =>
+    """
+    Open a plaintext TCP listener on `host`:`service`.
+    """
+    _notify = consume notify
+    _server_auth = lori.TCPServerAuth(auth)
+    _ssl_ctx = None
+    _tcp_listener =
+      lori.TCPListener(
+        auth, host, service, this, ip_version, limit)
+
+  new ssl(auth: lori.TCPListenAuth,
+    notify: TCPListenNotify iso,
+    ctx: SSLContext val,
+    host: String,
+    service: String,
+    limit: (lori.MaxSpawn | None) = lori.DefaultMaxSpawn(),
+    ip_version: lori.IPVersion = lori.DualStack)
+  =>
+    """
+    Open an SSL TCP listener on `host`:`service`. Accepted connections use
+    `ctx` for the TLS handshake.
+    """
+    _notify = consume notify
+    _server_auth = lori.TCPServerAuth(auth)
+    _ssl_ctx = ctx
+    _tcp_listener =
+      lori.TCPListener(
+        auth, host, service, this, ip_version, limit)
+
+  // --- TCPListenerActor ------------------------------------------------------
+  fun ref _listener(): lori.TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): ServerTCPConnection ? =>
+    let notify = _notify.on_connected(this)?
+    match _ssl_ctx
+    | let ctx: SSLContext val =>
+      ServerTCPConnection._ssl_create(_server_auth, ctx, fd, consume notify)
+    else
+      ServerTCPConnection._create(_server_auth, fd, consume notify)
+    end
+
+  fun ref _on_listening() =>
+    _notify.on_listening(this)
+
+  fun ref _on_listen_failure() =>
+    _notify.on_not_listening(this)
+
+  fun ref _on_closed() =>
+    _notify.on_closed(this)
+
+  // --- Synchronous methods ---------------------------------------------------
+  fun ref local_address(): net.NetAddress =>
+    """
+    Return the local IP address the listener is bound to.
+    """
+    _tcp_listener.local_address()
+
+  fun ref close() =>
+    """
+    Close the listener. No further connections are accepted. `on_closed` fires
+    on the notifier.
+    """
+    _tcp_listener.close()


### PR DESCRIPTION
A notifier-based TCP API in `lori/notifier` that wraps lori's class-and-trait delegation into concrete actors with notifier traits, shaped like the standard library's `net` package.

Three actor/trait pairs:
- `ClientTCPConnection` / `ClientTCPConnectionNotify` — client connections
- `ServerTCPConnection` / `ServerTCPConnectionNotify` — server connections
- `TCPListener` / `TCPListenNotify` — listeners

The actors are concrete — only the notifiers are traits. Users hand a notifier to an actor and the actor calls them back, instead of implementing `TCPConnectionActor` and lifecycle event receiver traits themselves.

Key differences from the native API:
- `write`/`writev` are fire-and-forget behaviors (the underlying `send()` return is discarded; completion tracking via `on_send_accepted`/`on_sent`/`on_send_failed` callbacks)
- `mute`/`unmute` are behaviors (deferred to next turn)
- SSL via constructor (`.ssl`) rather than a separate class

Six tests cover the notifier wiring: plaintext ping-pong, SSL ping-pong, connect-failed, buffer-until framing, dispose/close lifecycle, and connection rejection. Two examples demonstrate the API.

Closes #7
