### PR TITLE
Reshape the macOS TCP swarm workload to avoid the loopback send-block

### DIFF
--- a/stress-tests/tcp-swarm/README.md
+++ b/stress-tests/tcp-swarm/README.md
@@ -144,6 +144,11 @@ The draw is stable per seed, so a failure replays its *workload* from its number
   slow).
 - `--lldb <path>` — run each seed under lldb so a crash leaves a backtrace.
 
+On macOS the orchestrator draws each workload from a narrower profile automatically
+(no flag), because macOS loopback shares a finite kernel buffer pool a wide workload
+can exhaust — which stalls a send and hangs the run; see `WORKLOAD_PROFILES` (the
+`macos` profile) in `orchestrate_tcp.py` for the lists and why.
+
 A run is a failure only if it crashes, mismatches, or hangs — makes no progress for
 `--no-progress-seconds` (the completed count stops rising). A failure writes
 `bundle-<seed>.json` to `--out`. A healthy run is never failed for running long: one

--- a/stress-tests/tcp-swarm/orchestrate_tcp.py
+++ b/stress-tests/tcp-swarm/orchestrate_tcp.py
@@ -69,49 +69,87 @@ def die(message):
 
 # ------------------------------------------------------------------- the draw
 
-# Feature levers (each drawn independently -- omission is the swarm). Magnitudes
-# are bucketed small/medium/large at 25/50/25 then uniform within the bucket.
-WRITE_SHAPES = ["write", "writev"]
-# writev buffer counts (writev only). 2048 exceeds POSIX IOV_MAX (1024): drawn
-# with a payload at least that large, a single vectored send then queues more
-# buffers than one writev() syscall can send, so lori's `_send_pending_writes()`
-# takes its multi-batch path (one writev_max-sized batch per pass). 4 and 64 are
-# ordinary small vector writes. COUPLING: the large value must stay above
-# PonyTCP.writev_max()'s POSIX return, or the multi-batch coverage silently
-# vanishes.
-WRITEV_CHUNKS = [4, 64, 2048]
-CLOSE_KINDS = ["graceful", "hard"]
-# Payload sizes span the runtime's 16384-byte default read buffer: below, at, and
-# above it, so runs straddle the read-chunk boundary rather than clustering small.
-PAYLOAD_SIZES = [1, 8, 64, 256, 1024, 4096, 16384, 65536]
-# macOS-only: cap the drawn payload at 16384 (applied in resolve_config when the
-# orchestrator runs on macOS). WHY: macOS loopback has no wire rate limit, so at
-# the largest payload the swarm pushes data onto lo0 faster than the interface's
-# buffer pool drains. sendmsg then BLOCKS in the kernel waiting for buffers (and
-# returns ENOBUFS) EVEN on a non-blocking socket -- O_NONBLOCK/MSG_DONTWAIT govern
-# the socket buffer, not the interface's buffer pool. A blocked send freezes the
-# scheduler thread that issued it and stalls the whole run, which the swarm reports
-# as a failure. This is a macOS kernel behavior, not a runtime bug: the runtime
-# cannot force the send non-blocking from userspace short of moving socket I/O off
-# the scheduler threads (an I/O-model change that is deliberately not being made).
-# The 65536 payload paired with small read buffers (slow drain) triggers it reliably
-# on a real runner; 16384 stays clear of it while keeping the small-read-buffer yield
-# coverage. Linux and Windows loopback do not behave this way, so they are uncapped.
-# (The separate defect where the pony runtime treated ENOBUFS as fatal was fixed in
-# ponylang/ponyc#5823; that fix does not stop the send from blocking.)
-MACOS_MAX_PAYLOAD = 16384
-# Read buffer + yield thresholds: small values drive frequent yields back to the
-# scheduler on any payload size; the 16384 default anchors the "unchanged" end.
-READ_BUFFER_SIZES = [128, 1024, 16384, 65536]
-YIELD_SIZES = [64, 1024, 16384]
-CONCURRENCY = [8, 16, 32, 64, 128, 256]
-# COUPLING: the max per-connection work -- max `messages` (64) below * max
-# `payload-size` (65536) ~ 4 MiB, with concurrency >= 8 -- must keep the slowest single
-# connection completing well within the orchestrator's no-progress window, or a healthy
-# run reads as a hang.
-MESSAGE_BUCKETS = {"small": (1, 2), "medium": (3, 16), "large": (17, 64)}
-CONNECTION_BUCKETS = {"small": (100, 2000), "medium": (2001, 20000),
-                      "large": (20001, 100000)}
+# The draw is parameterized by a workload PROFILE: a complete, self-contained set of
+# the lists each lever draws from. main() selects a profile from the host (the machine
+# driving loopback); resolve_config draws every workload field from the selected
+# profile's lists and nothing else. The profiles are fully separate -- each carries its
+# own copy of every list, so editing one profile's lists cannot change another's.
+# Values that match across profiles are duplicated on purpose; that duplication is what
+# keeps them independent. Each lever is drawn independently (omission is the swarm);
+# magnitudes are bucketed small/medium/large at 25/50/25, then uniform within the
+# bucket.
+
+# The default profile: Linux and Windows, whose loopback has no shared buffer pool, so
+# the full lever ranges run as drawn.
+DEFAULT_PROFILE = {
+    "write_shapes": ["write", "writev"],
+    # writev buffer counts (writev only). 2048 exceeds POSIX IOV_MAX (1024): drawn with
+    # a payload at least that large, a single vectored send then queues more buffers
+    # than one writev() syscall can send, so lori's `_send_pending_writes()` takes its
+    # multi-batch path (one writev_max-sized batch per pass). 4 and 64 are ordinary
+    # small vector writes. The large value must stay above PonyTCP.writev_max()'s POSIX
+    # return, or the multi-batch coverage silently vanishes.
+    "writev_chunks": [4, 64, 2048],
+    "close_kinds": ["graceful", "hard"],
+    # Payload sizes span the runtime's 16384-byte default read buffer: below, at, and
+    # above it, so runs straddle the read-chunk boundary rather than clustering small.
+    "payload_sizes": [1, 8, 64, 256, 1024, 4096, 16384, 65536],
+    # Read buffer + yield thresholds: small values drive frequent yields back to the
+    # scheduler on any payload size; the 16384 default anchors the "unchanged" end.
+    "read_buffer_sizes": [128, 1024, 16384, 65536],
+    "yield_sizes": [64, 1024, 16384],
+    "concurrency": [8, 16, 32, 64, 128, 256],
+    # COUPLING: the max per-connection work -- max messages (64) * max payload (65536)
+    # ~ 4 MiB, with concurrency >= 8 -- must keep the slowest single connection
+    # completing well within the no-progress window, or a healthy run reads as a hang.
+    "message_buckets": {"small": (1, 2), "medium": (3, 16), "large": (17, 64)},
+    "connection_buckets": {"small": (100, 2000), "medium": (2001, 20000),
+                           "large": (20001, 100000)},
+}
+
+# The macos profile: macOS loopback shares a finite kernel buffer pool that every
+# socket draws from. A wide workload exhausts it, and a non-blocking sendmsg then
+# blocks in the kernel for many seconds -- freezing the scheduler thread that issued it
+# and hanging the run. (The runtime treats the ENOBUFS this surfaces as retryable,
+# ponylang/ponyc#5823, but the block happens before any errno returns, so the workload
+# has to stay out of the exhaustion regime on its own.) So macOS draws from its own
+# narrower lists, chosen so every combination they can produce is block-free -- verified
+# by drawing across them at 8x the loopback pressure of a single CI process (more than
+# CI's one-at-a-time runs ever reach) and timing every send: within these lists no send
+# blocks longer than about 60 ms and every run completes, versus the many seconds -- a
+# minute at worst -- a wider workload froze a scheduler thread and hung the run. Capping
+# payload alone did not do it (#373): the block is driven by send shape, drain rate, and
+# per-connection byte total together, and each list below answers one.
+MACOS_PROFILE = {
+    # write only: a scatter-gather writev pins a kernel mbuf per iovec segment, draining
+    # the shared pool faster per byte than a contiguous write -- even a 4-segment writev
+    # blocks under a high message count where the same bytes as one write do not, and
+    # the multi-batch path (thousands of segments) blocks readily. The writev batching
+    # logic is platform-independent and stays covered on the other hosts; only the macOS
+    # writev() syscall goes unexercised.
+    "write_shapes": ["write"],
+    "writev_chunks": [4],       # inert (write only), but the draw still picks one
+    "close_kinds": ["graceful", "hard"],
+    # no 65536: a single send larger than 16384 blocks even when the reader drains as
+    # fast as data arrives -- the send size alone is the trigger.
+    "payload_sizes": [1, 8, 64, 256, 1024, 4096, 16384],
+    # every value >= 2x the largest payload (16384), and the read yield draws from the
+    # same list, so the reader always drains at least as fast as data arrives -- the
+    # drain margin holds because the list makes it hold, not by a per-draw rule.
+    "read_buffer_sizes": [32768, 65536],
+    "yield_sizes": [32768, 65536],
+    "concurrency": [8, 16, 32, 64, 128, 256],
+    # max 8: what freezes a send here is the per-connection byte total, and the onset
+    # sits between 128 KB and 256 KB (measured); 8 * the largest payload (16384) is
+    # 128 KB, held under the onset with margin. The cap is a flat count, not a payload
+    # rule -- so the small payloads carry it too, costing their high-message coverage,
+    # which is the price of bounding it with the list rather than a per-draw rule.
+    "message_buckets": {"small": (1, 2), "medium": (3, 5), "large": (6, 8)},
+    "connection_buckets": {"small": (100, 2000), "medium": (2001, 20000),
+                           "large": (20001, 100000)},
+}
+
+WORKLOAD_PROFILES = {"default": DEFAULT_PROFILE, "macos": MACOS_PROFILE}
 
 # Per-run bounds -- BEST GUESSES, to be tuned from CI timings (the local WSL2
 # loopback caps throughput at ~100 conns/s, which makes local run-time meaningless
@@ -246,19 +284,26 @@ def _fit_continuous(key, drawn, chosen, floor):
     return best
 
 
-def _draw_memory_levers(rng, use_writev):
-    """Draw the memory levers in a per-seed random order against MEM_BUDGET_BYTES.
-    Undrawn levers reserve their minimum, so every pick leaves room for the rest and
-    the draw can never wedge (all-minimums is ~80 KB, far under budget). Each lever
-    consumes its usual draw once; the fit is a no-rng clamp, so total rng consumption
-    is fixed per seed. Returns the chosen values under internal keys."""
+def _draw_memory_levers(rng, use_writev, profile):
+    """Draw the memory levers in a per-seed random order against MEM_BUDGET_BYTES,
+    pulling every list from `profile`. Undrawn levers reserve their minimum, so every
+    pick leaves room for the rest and the draw can never wedge (all-minimums is ~80 KB,
+    far under budget). Each lever consumes its usual draw once; the fit is a no-rng
+    clamp, so total rng consumption is fixed per seed regardless of profile. Returns the
+    chosen values under internal keys."""
+    message_buckets = profile["message_buckets"]
+    connection_buckets = profile["connection_buckets"]
+    concurrency = profile["concurrency"]
+    payload_sizes = profile["payload_sizes"]
+    writev_chunks = profile["writev_chunks"]
+    read_buffer_sizes = profile["read_buffer_sizes"]
     chosen = {
         "connections": MIN_CONNECTIONS,
-        "concurrency": min(CONCURRENCY),
-        "messages": MESSAGE_BUCKETS["small"][0],
-        "payload": min(PAYLOAD_SIZES),
-        "writev_chunks": min(WRITEV_CHUNKS),
-        "read_buffer": min(READ_BUFFER_SIZES),
+        "concurrency": min(concurrency),
+        "messages": message_buckets["small"][0],
+        "payload": min(payload_sizes),
+        "writev_chunks": min(writev_chunks),
+        "read_buffer": min(read_buffer_sizes),
         "use_writev": use_writev,
     }
     order = list(MEM_LEVERS)
@@ -266,29 +311,29 @@ def _draw_memory_levers(rng, use_writev):
     for lever in order:
         if lever == "connections":
             chosen[lever] = _fit_continuous(
-                lever, draw_bucketed(rng, CONNECTION_BUCKETS), chosen,
+                lever, draw_bucketed(rng, connection_buckets), chosen,
                 MIN_CONNECTIONS)
         elif lever == "messages":
             chosen[lever] = _fit_continuous(
-                lever, draw_bucketed(rng, MESSAGE_BUCKETS), chosen,
-                MESSAGE_BUCKETS["small"][0])
+                lever, draw_bucketed(rng, message_buckets), chosen,
+                message_buckets["small"][0])
         elif lever == "concurrency":
             chosen[lever] = _fit_discrete(
-                lever, rng.choice(CONCURRENCY), chosen, CONCURRENCY)
+                lever, rng.choice(concurrency), chosen, concurrency)
         elif lever == "payload":
             chosen[lever] = _fit_discrete(
-                lever, rng.choice(PAYLOAD_SIZES), chosen, PAYLOAD_SIZES)
+                lever, rng.choice(payload_sizes), chosen, payload_sizes)
         elif lever == "writev_chunks":
             chosen[lever] = _fit_discrete(
-                lever, rng.choice(WRITEV_CHUNKS), chosen, WRITEV_CHUNKS)
+                lever, rng.choice(writev_chunks), chosen, writev_chunks)
         elif lever == "read_buffer":
             chosen[lever] = _fit_discrete(
-                lever, rng.choice(READ_BUFFER_SIZES), chosen, READ_BUFFER_SIZES)
+                lever, rng.choice(read_buffer_sizes), chosen, read_buffer_sizes)
     return chosen
 
 
 def resolve_config(master_seed, max_threads, max_connections=None,
-                   max_payload=None):
+                   profile="default"):
     """Draw one TCP workload from a master seed. Any change to the draw remaps every
     seed, so a seed recorded under old code no longer reproduces its workload
     (breaking a historical --replay) -- change the draw deliberately. It stays
@@ -304,27 +349,22 @@ def resolve_config(master_seed, max_threads, max_connections=None,
     because Windows opens TCP connections very slowly -- ~5.5/s, so 10k connections
     is ~30 min and 100k would never finish inside the job's time budget.
 
-    max_payload, if set, caps the drawn payload size (macOS passes MACOS_MAX_PAYLOAD;
-    see that constant for why). Like ponymaxthreads it makes the draw host-dependent,
-    but deterministically (the same cap is always applied on the same host), so
-    --replay still holds within a host. It caps payload BEFORE payload is used for
-    `expect` and the byte ceilings, so those reflect the capped size; it consumes no
-    rng."""
+    profile names the host workload profile the draw pulls every list from (see
+    WORKLOAD_PROFILES); main() selects it from the platform. The profiles are fully
+    separate, so a constrained profile (macOS) draws different values and remaps
+    relative to the default -- intended, since the platform needs its own lists -- and
+    keeps its own pinned goldens in orchestrate_tcp_test.py."""
     rng = random.Random(master_seed)
+    profile = WORKLOAD_PROFILES[profile]
 
     workload = {}
     # write-shape is drawn BEFORE the memory levers: it carries no magnitude, but the
     # memory budget needs to know whether a writev-chunks draw counts (chunks_eff is 1
     # for a plain write). The memory levers then draw in a shuffled order against the
     # budget so no config can exceed the RLIMIT_AS cap; see _draw_memory_levers.
-    use_writev = rng.choice(WRITE_SHAPES) == "writev"
-    mem = _draw_memory_levers(rng, use_writev)
+    use_writev = rng.choice(profile["write_shapes"]) == "writev"
+    mem = _draw_memory_levers(rng, use_writev, profile)
     payload = mem["payload"]
-    # macOS loopback cap (see MACOS_MAX_PAYLOAD). Applied here, before payload is
-    # used for `expect` and the byte ceilings, so a capped run stays self-consistent
-    # (e.g. expect never exceeds the payload). Consumes no rng.
-    if max_payload is not None:
-        payload = min(payload, max_payload)
     read_buffer = mem["read_buffer"]
     workload["connections"] = mem["connections"]
     workload["concurrency"] = mem["concurrency"]
@@ -333,7 +373,7 @@ def resolve_config(master_seed, max_threads, max_connections=None,
     workload["write-shape"] = "writev" if use_writev else "write"
     workload["writev-chunks"] = mem["writev_chunks"]
     workload["read-buffer-size"] = read_buffer
-    workload["yield-after-reading"] = rng.choice(YIELD_SIZES)
+    workload["yield-after-reading"] = rng.choice(profile["yield_sizes"])
     # expect: on/off. When on, the frame must not exceed the read buffer (the
     # engine's expect() errors above it), so clamp to it -- the oracle is
     # positional over the whole stream, so any valid frame size verifies.
@@ -341,7 +381,7 @@ def resolve_config(master_seed, max_threads, max_connections=None,
         workload["expect"] = min(payload, read_buffer)
     else:
         workload["expect"] = 0
-    workload["close"] = rng.choice(CLOSE_KINDS)
+    workload["close"] = rng.choice(profile["close_kinds"])
 
     # Post-draw clamp to the per-run ceilings (consumes no rng, so seeds stay
     # stable). Keeps connections and payload; trims messages, then connections.
@@ -795,14 +835,12 @@ def main():
                        if args.mem_limit_mb > 0 else None)
 
     failures = []
-
-    # macOS caps the payload to keep the swarm clear of the loopback sendmsg-block
-    # (see MACOS_MAX_PAYLOAD). Other platforms draw uncapped.
-    max_payload = MACOS_MAX_PAYLOAD if sys.platform == "darwin" else None
+    # The workload profile keys off the host the orchestrator runs on -- it is the
+    # machine driving loopback -- so it can't be forgotten by a missed CI flag.
+    profile = "macos" if sys.platform == "darwin" else "default"
 
     def run_seed(seed):
-        config = resolve_config(seed, max_threads, args.max_connections,
-                                max_payload)
+        config = resolve_config(seed, max_threads, args.max_connections, profile)
         result = execute(binary, config, args.out,
                          args.timeout_seconds, mem_limit_bytes,
                          args.no_progress_seconds, args.lldb)

--- a/stress-tests/tcp-swarm/orchestrate_tcp_test.py
+++ b/stress-tests/tcp-swarm/orchestrate_tcp_test.py
@@ -90,18 +90,21 @@ def test_memory_budget_trims():
     # The fit helpers -- the building block of the rotating draw -- trim a value that
     # would break the budget down to the largest one that fits (never below the
     # minimum) and leave a fitting value alone.
-    mins = {"connections": o.MIN_CONNECTIONS, "concurrency": min(o.CONCURRENCY),
-            "messages": o.MESSAGE_BUCKETS["small"][0], "payload": min(o.PAYLOAD_SIZES),
-            "writev_chunks": min(o.WRITEV_CHUNKS),
-            "read_buffer": min(o.READ_BUFFER_SIZES), "use_writev": True}
+    dp = o.DEFAULT_PROFILE
+    read_buffers = dp["read_buffer_sizes"]
+    mins = {"connections": o.MIN_CONNECTIONS, "concurrency": min(dp["concurrency"]),
+            "messages": dp["message_buckets"]["small"][0],
+            "payload": min(dp["payload_sizes"]),
+            "writev_chunks": min(dp["writev_chunks"]),
+            "read_buffer": min(read_buffers), "use_writev": True}
     check("fit_discrete: a fitting value passes through unchanged",
-          o._fit_discrete("read_buffer", 65536, mins, o.READ_BUFFER_SIZES) == 65536)
+          o._fit_discrete("read_buffer", 65536, mins, read_buffers) == 65536)
     # With connections at the max, a 64 KiB read buffer blows the budget -> trimmed to
     # a smaller listed value. Boundary: the trimmed value fits and the NEXT larger
     # listed value would not (so the helper returns the largest that fits, not any).
     loaded = dict(mins, connections=100000)
-    trimmed = o._fit_discrete("read_buffer", 65536, loaded, o.READ_BUFFER_SIZES)
-    nxt = o.READ_BUFFER_SIZES[o.READ_BUFFER_SIZES.index(trimmed) + 1]
+    trimmed = o._fit_discrete("read_buffer", 65536, loaded, read_buffers)
+    nxt = read_buffers[read_buffers.index(trimmed) + 1]
     check("fit_discrete: trims to the largest listed value that fits (next would not)",
           trimmed < 65536
           and o.est_peak_bytes(**dict(loaded, read_buffer=trimmed))
@@ -126,11 +129,11 @@ def test_est_peak_bytes_monotonic():
     base = {"connections": 10000, "concurrency": 32, "messages": 8, "payload": 1024,
             "writev_chunks": 64, "read_buffer": 16384, "use_writev": True}
     domains = {"connections": range(100, 100001, 2500),
-               "concurrency": o.CONCURRENCY,
+               "concurrency": o.DEFAULT_PROFILE["concurrency"],
                "messages": range(1, 65),
-               "payload": o.PAYLOAD_SIZES,
-               "writev_chunks": o.WRITEV_CHUNKS,
-               "read_buffer": o.READ_BUFFER_SIZES}
+               "payload": o.DEFAULT_PROFILE["payload_sizes"],
+               "writev_chunks": o.DEFAULT_PROFILE["writev_chunks"],
+               "read_buffer": o.DEFAULT_PROFILE["read_buffer_sizes"]}
     non_monotone = []
     for lever, values in domains.items():
         prev = None
@@ -177,17 +180,17 @@ def test_memory_budget_rotates_the_trimmed_lever():
     try:
         for seed in range(4000):
             w = o.resolve_config(seed, 8)["workload"]
-            if w["concurrency"] == max(o.CONCURRENCY):
+            if w["concurrency"] == max(o.DEFAULT_PROFILE["concurrency"]):
                 reached["concurrency"] = True
-            if w["payload-size"] == max(o.PAYLOAD_SIZES):
+            if w["payload-size"] == max(o.DEFAULT_PROFILE["payload_sizes"]):
                 reached["payload"] = True
-            if w["writev-chunks"] == max(o.WRITEV_CHUNKS):
+            if w["writev-chunks"] == max(o.DEFAULT_PROFILE["writev_chunks"]):
                 reached["writev_chunks"] = True
-            if w["read-buffer-size"] == max(o.READ_BUFFER_SIZES):
+            if w["read-buffer-size"] == max(o.DEFAULT_PROFILE["read_buffer_sizes"]):
                 reached["read_buffer"] = True
-            if w["connections"] > o.CONNECTION_BUCKETS["medium"][1]:
+            if w["connections"] > o.DEFAULT_PROFILE["connection_buckets"]["medium"][1]:
                 reached["connections"] = True   # into the large connection bucket
-            if w["messages"] == o.MESSAGE_BUCKETS["large"][1]:
+            if w["messages"] == o.DEFAULT_PROFILE["message_buckets"]["large"][1]:
                 reached["messages"] = True
     finally:
         o._fit_discrete, o._fit_continuous = orig_d, orig_c
@@ -245,27 +248,28 @@ def test_resolve_config_coverage_and_invariants():
         # it fails here instead of hanging a CI run.
         if w["expect"] > 0 and (w["payload-size"] * w["messages"]) % w["expect"]:
             invariants = False
-        if w["concurrency"] not in o.CONCURRENCY:
+        if w["concurrency"] not in o.DEFAULT_PROFILE["concurrency"]:
             invariants = False
-        if w["payload-size"] not in o.PAYLOAD_SIZES:
+        if w["payload-size"] not in o.DEFAULT_PROFILE["payload_sizes"]:
             invariants = False
-        if w["read-buffer-size"] not in o.READ_BUFFER_SIZES:
+        if w["read-buffer-size"] not in o.DEFAULT_PROFILE["read_buffer_sizes"]:
             invariants = False
-        if w["write-shape"] not in o.WRITE_SHAPES:
+        if w["write-shape"] not in o.DEFAULT_PROFILE["write_shapes"]:
             invariants = False
-        if w["writev-chunks"] not in o.WRITEV_CHUNKS:
+        if w["writev-chunks"] not in o.DEFAULT_PROFILE["writev_chunks"]:
             invariants = False
-        if w["close"] not in o.CLOSE_KINDS:
+        if w["close"] not in o.DEFAULT_PROFILE["close_kinds"]:
             invariants = False
         if not (1 <= r["ponymaxthreads"] <= 8):
             invariants = False
-        clo, chi = o.CONNECTION_BUCKETS["small"][0], o.CONNECTION_BUCKETS["large"][1]
+        cb = o.DEFAULT_PROFILE["connection_buckets"]
+        clo, chi = cb["small"][0], cb["large"][1]
         if not (clo <= w["connections"] <= chi):
             invariants = False
         if r.get("ponypinasio") and not r.get("ponypin"):
             invariants = False           # pinasio requires pin
     check("both write shapes appear", write_shapes == {"write", "writev"})
-    # Hardcoded literal (not set(o.WRITEV_CHUNKS)) so narrowing the constant is
+    # Hardcoded literal (not derived from the profile list) so narrowing the list is
     # caught here, matching the sibling write-shape/close checks.
     check("all writev-chunk counts appear", chunk_vals == {4, 64, 2048})
     # Hardcoded literal for the same reason as writev-chunks above: narrowing
@@ -304,36 +308,79 @@ def test_max_connections_cap():
     check("max_connections: actually caps some seeds (not vacuous)", capped_any)
 
 
-def test_macos_payload_cap():
-    # macOS caps the payload (MACOS_MAX_PAYLOAD) to stay clear of the loopback
-    # sendmsg-block. Confirm it caps to min(drawn, cap); keeps the run consistent
-    # (expect must never exceed the capped payload, or the framed read never
-    # completes); leaves the independent levers alone; is deterministic; and isn't
-    # vacuous. The cap MAY change messages/connections too, since the byte-ceiling
-    # clamp (clamp_run) is a function of payload -- so those are not checked here.
-    cap = o.MACOS_MAX_PAYLOAD
+def test_macos_draw_from_own_sets():
+    # macOS draws every field from its own profile lists, not the default's -- there is
+    # no reshape, nothing is drawn then modified. So every macOS workload lands in those
+    # lists, and the per-connection byte total stays under the freeze-free ceiling the
+    # lists were measured to bound (largest payload * largest messages). The draw is
+    # deterministic per seed (so --replay holds) and remaps freely relative to the
+    # default -- the profiles are separate, so nothing here is compared to the default
+    # draw. The coverage flags confirm the lists are exercised.
+    mp = o.WORKLOAD_PROFILES["macos"]
+    max_total = max(mp["payload_sizes"]) * mp["message_buckets"]["large"][1]
+    msg_hi = mp["message_buckets"]["large"][1]
     ok = True
-    capped_any = False
-    untouched = ("concurrency", "read-buffer-size", "write-shape", "writev-chunks",
-                 "yield-after-reading", "close")
-    for seed in range(300):
-        base = o.resolve_config(seed, 8)
-        capped = o.resolve_config(seed, 8, max_payload=cap)
-        w = capped["workload"]
-        if w["payload-size"] != min(base["workload"]["payload-size"], cap):
+    payloads = set()
+    rbufs = set()
+    yields = set()
+    concs = set()
+    closes = set()
+    expect_states = set()
+    msg_hit_max = False
+    for seed in range(500):
+        mac = o.resolve_config(seed, 8, profile="macos")
+        mw = mac["workload"]
+        p, rb = mw["payload-size"], mw["read-buffer-size"]
+        # Deterministic per seed.
+        if o.resolve_config(seed, 8, profile="macos") != mac:
             ok = False
-        if w["expect"] > w["payload-size"]:
+        # Every field is drawn from macOS's own lists.
+        if mw["write-shape"] != "write":
             ok = False
-        if any(w[k] != base["workload"][k] for k in untouched):
+        if p not in mp["payload_sizes"]:
             ok = False
-        if capped["runtime"] != base["runtime"]:
+        if rb not in mp["read_buffer_sizes"]:
             ok = False
-        if o.resolve_config(seed, 8, max_payload=cap) != capped:
+        if mw["yield-after-reading"] not in mp["yield_sizes"]:
             ok = False
-        if base["workload"]["payload-size"] > cap:
-            capped_any = True
-    check("macOS payload cap: caps to min(drawn, cap), expect stays <= payload", ok)
-    check("macOS payload cap: actually caps some seeds (not vacuous)", capped_any)
+        if mw["writev-chunks"] not in mp["writev_chunks"]:
+            ok = False
+        if mw["concurrency"] not in mp["concurrency"]:
+            ok = False
+        if mw["close"] not in mp["close_kinds"]:
+            ok = False
+        # messages: clamp_run may trim, so 1..msg_hi; the read buffer out-drains any
+        # payload (min read buffer >= 2 * max payload); the total stays freeze-free;
+        # expect is off or a valid frame no larger than the read buffer.
+        if not (1 <= mw["messages"] <= msg_hi):
+            ok = False
+        if rb < 2 * p:
+            ok = False
+        if p * mw["messages"] > max_total:
+            ok = False
+        if mw["expect"] not in (0, min(p, rb)):
+            ok = False
+        payloads.add(p)
+        rbufs.add(rb)
+        yields.add(mw["yield-after-reading"])
+        concs.add(mw["concurrency"])
+        closes.add(mw["close"])
+        expect_states.add(mw["expect"] > 0)
+        msg_hit_max = msg_hit_max or (mw["messages"] == msg_hi)
+    check("macOS draw: deterministic, every field drawn from macOS's own lists, and "
+          "the per-connection total stays freeze-free", ok)
+    check("macOS draw: every payload size appears",
+          payloads == set(mp["payload_sizes"]))
+    check("macOS draw: both read buffers appear",
+          rbufs == set(mp["read_buffer_sizes"]))
+    check("macOS draw: both yields appear", yields == set(mp["yield_sizes"]))
+    check("macOS draw: every concurrency appears",
+          concs == set(mp["concurrency"]))
+    check("macOS draw: both close kinds appear", closes == set(mp["close_kinds"]))
+    check("macOS draw: expect appears both on and off",
+          expect_states == {True, False})
+    check("macOS draw: the largest message count is reached (%d)" % msg_hi,
+          msg_hit_max)
 
 
 def test_ponymaxthreads_is_last_and_host_dependent():
@@ -757,7 +804,7 @@ def main():
                test_memory_budget, test_memory_budget_trims,
                test_est_peak_bytes_monotonic,
                test_memory_budget_rotates_the_trimmed_lever,
-               test_max_connections_cap, test_macos_payload_cap,
+               test_max_connections_cap, test_macos_draw_from_own_sets,
                test_resolve_config_coverage_and_invariants,
                test_ponymaxthreads_is_last_and_host_dependent,
                test_resolve_seeds, test_validate_args,


### PR DESCRIPTION
The macOS TCP swarm stress test hung in CI while Linux and Windows passed. macOS loopback shares a finite kernel buffer pool; a wide workload exhausts it, and a non-blocking `sendmsg` then blocks in-kernel for many seconds — freezing the scheduler thread that issued it and hanging the run past the no-progress watchdog. (The runtime half — treating the ENOBUFS this surfaces as retryable — is fixed in the ponyc runtime this depends on, ponylang/ponyc#5823.)

The draw now takes a workload **profile**: a complete, self-contained set of the lists each lever draws from, selected from the host. macOS draws from its own narrower lists — write only, payload ≤ 16384, read buffers that out-drain any payload, and a message count bounded so the per-connection total stays under the freeze onset. The two profiles are **fully separate** (no shared lists), so a change to the default draw cannot move macOS, and vice versa. Linux and Windows draw exactly as before.

The macOS lists were chosen by measurement — running the engine at 8× the loopback pressure of a single CI process (CI runs one at a time) and timing every send. Every workload macOS's lists can produce stays under a 128 KB per-connection total, which is freeze-free (the blocking send appears past ~256 KB); the residual is rare sub-60 ms contention that completes. Capping payload alone did not cover it (#373).

Note: macOS CI installs the ponyc release, which does not yet contain ponylang/ponyc#5823 (0.68.0 predates it). The profile keeps the workload out of the sustained-block region regardless; the retry fix only matters for the rare brief residual, so this is fully robust once a ponyc release with #5823 ships.

Stress-test tooling only — no library change, so no release note.
