### PR TITLE
Run stress tests against nightly ponyc

### DIFF
--- a/.github/workflows/stress-tests.yml
+++ b/.github/workflows/stress-tests.yml
@@ -15,7 +15,7 @@ jobs:
 
     name: Linux
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
     steps:
       - name: Checkout
         uses: actions/checkout@v6.0.2
@@ -56,7 +56,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6.0.2
       - name: Install pony tools
-        run: bash .ci-scripts/macOS-install-release-pony-tools.bash
+        run: bash .ci-scripts/macOS-install-nightly-pony-tools.bash
       - name: Configure networking
         run: bash .ci-scripts/macOS-configure-networking.bash
       - name: Build
@@ -100,7 +100,7 @@ jobs:
       - name: Tune Windows Networking
         run: .ci-scripts\windows-configure-networking.ps1
       - name: Install Pony tools
-        run: .ci-scripts\windows-install-pony-tools.ps1 releases
+        run: .ci-scripts\windows-install-pony-tools.ps1 nightlies
       - name: Cache LibreSSL libs
         id: cache-libressl
         uses: actions/cache@v5.0.3


### PR DESCRIPTION
Switch stress tests from release to nightly ponyc on all three platforms so regressions surface before a release ships.
