### PR TITLE
Make _on_start_failure abstract

### DIFF
--- a/.release-notes/make-on-start-failure-abstract.md
+++ b/.release-notes/make-on-start-failure-abstract.md
@@ -1,0 +1,29 @@
+## Make _on_start_failure abstract
+
+`ServerLifecycleEventReceiver._on_start_failure` no longer has a default body. Every type that implements `ServerLifecycleEventReceiver` must now provide the method. The compiler enforces this at build time.
+
+The previous default silently discarded server-side SSL handshake failures. A failed handshake meant no `_on_started`, no `_on_closed`, no error — the connection simply vanished. Making the method abstract forces the application to handle the failure.
+
+Actors that do not use SSL will never receive the callback, but still must provide a body:
+
+Before (compiled, silently ignored failures):
+
+```pony
+actor MyServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+```
+
+After:
+
+```pony
+actor MyServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+```

--- a/examples/backpressure/backpressure.pony
+++ b/examples/backpressure/backpressure.pony
@@ -62,6 +62,8 @@ actor Sink is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _bytes_received = _bytes_received + data.size()
     KeepReading

--- a/examples/echo-server/echo_server.pony
+++ b/examples/echo-server/echo_server.pony
@@ -63,6 +63,8 @@ actor Echoer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_closed() =>
     _out.print("Connection Closed")
 

--- a/examples/framed-protocol/framed_protocol.pony
+++ b/examples/framed-protocol/framed_protocol.pony
@@ -71,6 +71,8 @@ actor FramedServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _reading_header then
       try

--- a/examples/idle-timeout/idle_timeout.pony
+++ b/examples/idle-timeout/idle_timeout.pony
@@ -63,6 +63,8 @@ actor IdleTimeoutEchoer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     _out.print("Connection established. 10-second idle timeout active.")
     match MakeIdleTimeout(10_000)

--- a/examples/infinite-ping-pong/infinite_ping_pong.pony
+++ b/examples/infinite-ping-pong/infinite_ping_pong.pony
@@ -66,6 +66,8 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _out.print(consume data)
     _tcp_connection.send("Pong")

--- a/examples/ip-version/ip_version.pony
+++ b/examples/ip-version/ip_version.pony
@@ -70,6 +70,8 @@ actor IP4Echoer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_closed() =>
     _out.print("Server: connection closed.")
 

--- a/examples/net-ssl-echo-server/net_ssl_echo_server.pony
+++ b/examples/net-ssl-echo-server/net_ssl_echo_server.pony
@@ -94,6 +94,8 @@ actor Echoer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_closed() =>
     _out.print("Connection Closed")
 

--- a/examples/net-ssl-infinite-ping-pong/net_ssl_infinite_ping_pong.pony
+++ b/examples/net-ssl-infinite-ping-pong/net_ssl_infinite_ping_pong.pony
@@ -94,6 +94,8 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _out.print(consume data)
     _tcp_connection.send("Pong")

--- a/examples/read-buffer-size/read_buffer_size.pony
+++ b/examples/read-buffer-size/read_buffer_size.pony
@@ -75,6 +75,8 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _control_phase then
       let cmd = String.from_array(consume data)

--- a/examples/send-completion/send_completion.pony
+++ b/examples/send-completion/send_completion.pony
@@ -79,6 +79,8 @@ actor Sink is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     KeepReading
 

--- a/examples/socket-options/socket_options.pony
+++ b/examples/socket-options/socket_options.pony
@@ -70,6 +70,8 @@ actor SocketOptionsServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     // Disable Nagle for low-latency responses
     _tcp_connection.set_nodelay(true)

--- a/examples/starttls-ping-pong/starttls_ping_pong.pony
+++ b/examples/starttls-ping-pong/starttls_ping_pong.pony
@@ -108,6 +108,8 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     let msg = String.from_array(consume data)
     if msg == "STARTTLS" then

--- a/examples/timer/timer.pony
+++ b/examples/timer/timer.pony
@@ -66,6 +66,8 @@ actor SlowServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _out.print("[server] Received query. Pretending to think forever...")
     // Never responds — simulating a slow query

--- a/examples/yield-read/yield_read.pony
+++ b/examples/yield-read/yield_read.pony
@@ -68,6 +68,8 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _received_count = _received_count + 1
 

--- a/lori/_test_backpressure_drain.pony
+++ b/lori/_test_backpressure_drain.pony
@@ -109,6 +109,8 @@ actor \nodoc\ _TestBackpressureDrainServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     _h.complete_action("server started")
     // Frame incoming messages: "ready" is 5 bytes
@@ -323,6 +325,8 @@ actor \nodoc\ _TestWriteOnlyEventReadRecoveryServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     _h.complete_action("server started")
@@ -542,6 +546,8 @@ actor \nodoc\ _TestReadableEventWriteRecoveryServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     _h.complete_action("server started")

--- a/lori/_test_connection.pony
+++ b/lori/_test_connection.pony
@@ -124,6 +124,8 @@ actor \nodoc\ _TestPonger is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _pings_to_receive > 0 then
       _tcp_connection.send("Pong")
@@ -265,6 +267,8 @@ actor \nodoc\ _TestBasicBufferUntilServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _received_count = _received_count + 1
 
@@ -340,6 +344,8 @@ actor \nodoc\ _TestDoNothingServerActor
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
 class \nodoc\ iso _TestListenerLocalAddress is UnitTest
   """
@@ -493,6 +499,8 @@ actor \nodoc\ _TestHardCloseDuringReceiveServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     // Hard close from inside the read callback (see the class docstring).
     _closed_in_receive = true
@@ -614,6 +622,8 @@ actor \nodoc\ _TestHardCloseAfterFramedReceiveServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _received_count = _received_count + 1
     if _received_count == 1 then
@@ -676,6 +686,8 @@ actor \nodoc\ _TestFakeRecvErrorActor
   fun ref _connection(): TCPConnection[_FBSendOkRecvError] =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _h.fail("_on_received should not fire when receive errors")
     _h.complete(false)
@@ -726,6 +738,8 @@ actor \nodoc\ _TestFakeRecvRetryActor
 
   fun ref _connection(): TCPConnection[_FBSendOkRecvRetry] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     _tcp_connection.mute()
@@ -778,6 +792,8 @@ actor \nodoc\ _TestFakeRecvDataActor
 
   fun ref _connection(): TCPConnection[_FBSendOkRecvHello] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     let s = String.from_iso_array(consume data)
@@ -838,6 +854,8 @@ actor \nodoc\ _TestFakeRecvFramedActor
   fun ref _connection(): TCPConnection[_FBSendOkRecv10] =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _received_count = _received_count + 1
     _h.assert_eq[USize](
@@ -893,6 +911,8 @@ actor \nodoc\ _TestFakeMuteActor
 
   fun ref _connection(): TCPConnection[_FBSendOkRecvHelloMute] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     _tcp_connection.mute()
@@ -960,6 +980,8 @@ actor \nodoc\ _TestFakeYieldReadingActor
 
   fun ref _connection(): TCPConnection[_FBSendOkRecv10Yield] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _received_count = _received_count + 1
@@ -1298,6 +1320,8 @@ actor \nodoc\ _TestFakeServerStub[TCP: TCPBackend ref]
 
   fun ref _connection(): TCPConnection[TCP] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     _tcp_connection.mute()

--- a/lori/_test_connection_timeout.pony
+++ b/lori/_test_connection_timeout.pony
@@ -147,6 +147,8 @@ actor \nodoc\ _TestConnectionTimeoutCancelServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
 class \nodoc\ iso _TestSSLConnectionTimeoutFires is UnitTest
   """
   Test that the connection timeout fires during SSL handshake. Connects an
@@ -264,6 +266,8 @@ actor \nodoc\ _TestSSLConnectionTimeoutFiresServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
 class \nodoc\ iso _TestSSLConnectionTimeoutCancelledOnConnect is UnitTest
   """
   Test that the connect timer is cancelled when an SSL handshake completes.
@@ -374,6 +378,8 @@ actor \nodoc\ _TestSSLConnectionTimeoutCancelSSLServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
 class \nodoc\ iso _TestCloseWhileConnectingWithTimeout is UnitTest
   """

--- a/lori/_test_flow_control.pony
+++ b/lori/_test_flow_control.pony
@@ -123,6 +123,8 @@ actor \nodoc\ _TestMuteServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     _h.complete_action("server started")
     _tcp_connection.mute()
@@ -273,6 +275,8 @@ actor \nodoc\ _TestUnmuteServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     _h.complete_action("server started")
@@ -507,6 +511,8 @@ actor \nodoc\ _TestMuteWithFullReadBufferServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _muted then
@@ -766,6 +772,8 @@ actor \nodoc\ _TestSSLMuteServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _muted then
       _h.fail("server received data while muted")
@@ -953,6 +961,8 @@ actor \nodoc\ _TestSSLMuteCloseServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _received = _received + 1
 
@@ -1089,6 +1099,8 @@ actor \nodoc\ _TestMuteFromOnSentServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     match \exhaustive\ _tcp_connection.send("ask")

--- a/lori/_test_idle_timeout.pony
+++ b/lori/_test_idle_timeout.pony
@@ -82,6 +82,8 @@ actor \nodoc\ _TestIdleTimeoutServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     match MakeIdleTimeout(5_000)
     | let t: IdleTimeout =>
@@ -203,6 +205,8 @@ actor \nodoc\ _TestIdleTimeoutResetServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     match MakeIdleTimeout(5_000)
     | let t: IdleTimeout =>
@@ -312,6 +316,8 @@ actor \nodoc\ _TestIdleTimeoutDisableServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     match MakeIdleTimeout(5_000)
@@ -445,6 +451,8 @@ actor \nodoc\ _TestSSLIdleTimeoutServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     match MakeIdleTimeout(5_000)
     | let t: IdleTimeout =>
@@ -575,6 +583,8 @@ actor \nodoc\ _TestSSLIdleTimeoutNotArmedServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
 class \nodoc\ iso _TestSSLIdleTimeoutDeferredArm is UnitTest
   """
   Test the deferred-arm path: an SSL client configures an idle timeout
@@ -680,6 +690,8 @@ actor \nodoc\ _TestSSLIdleTimeoutDeferredArmServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
 class \nodoc\ iso _TestIdleTimeoutRearms is UnitTest
   """
   Test that the idle timeout fires again on a connection that stays idle.
@@ -766,6 +778,8 @@ actor \nodoc\ _TestIdleTimeoutRearmsServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     match \exhaustive\ MakeIdleTimeout(1_000)
@@ -878,6 +892,8 @@ actor \nodoc\ _TestIdleTimeoutNoRearmServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     match \exhaustive\ MakeIdleTimeout(1_000)

--- a/lori/_test_ip_version.pony
+++ b/lori/_test_ip_version.pony
@@ -87,6 +87,8 @@ actor \nodoc\ _TestIP4Ponger
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _pings_to_receive > 0 then
       _tcp_connection.send("Pong")
@@ -221,6 +223,8 @@ actor \nodoc\ _TestIP6Ponger
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _pings_to_receive > 0 then

--- a/lori/_test_read_buffer.pony
+++ b/lori/_test_read_buffer.pony
@@ -58,6 +58,8 @@ actor \nodoc\ _TestReadBufferConstructorSizeServer is
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     // set_read_buffer_minimum to 256 should succeed (lowering the minimum)
     match \exhaustive\ MakeReadBufferSize(256)
@@ -138,6 +140,8 @@ actor \nodoc\ _TestSetReadBufferMinSuccessServer is
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     // Setting minimum to 512 should succeed and grow the buffer
     match \exhaustive\ MakeReadBufferSize(512)
@@ -214,6 +218,8 @@ actor \nodoc\ _TestSetReadBufferMinBelowBufferSizeServer is
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     // Set buffer_until to 100
@@ -305,6 +311,8 @@ actor \nodoc\ _TestResizeReadBufferSuccessServer is
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     // Resize to larger
     match \exhaustive\ MakeReadBufferSize(4096)
@@ -385,6 +393,8 @@ actor \nodoc\ _TestResizeReadBufferBelowBufferSizeServer is
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     // Set buffer_until to 200
@@ -467,6 +477,8 @@ actor \nodoc\ _TestResizeReadBufferBelowMinServer is
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     // Resize to 256 — this should lower the minimum from 1024 to 256
@@ -562,6 +574,8 @@ actor \nodoc\ _TestBufferSizeAboveMinServer is
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     // buffer_until(256) should fail because minimum is 128
     match MakeBufferSize(256)
@@ -630,6 +644,8 @@ actor \nodoc\ _TestBufferSizeAtMinServer is
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     // buffer_until(256) should succeed (equals minimum)

--- a/lori/_test_send.pony
+++ b/lori/_test_send.pony
@@ -108,6 +108,8 @@ actor \nodoc\ _TestSendTokenServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
 class \nodoc\ iso _TestSendAfterClose is UnitTest
   """
   Test that send() returns SendErrorNotConnected after the connection has been
@@ -212,6 +214,8 @@ actor \nodoc\ _TestSendAfterCloseServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
 class \nodoc\ iso _TestSendv is UnitTest
   """
@@ -322,6 +326,8 @@ actor \nodoc\ _TestSendvServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _h.assert_eq[String]("Hello, world!", String.from_array(consume data))
@@ -509,6 +515,8 @@ actor \nodoc\ _TestSendvMixedEmptyServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _h.assert_eq[String]("Helloworld", String.from_array(consume data))
     _h.complete_action("data verified")
@@ -639,6 +647,8 @@ actor \nodoc\ _TestSendPerTokenServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     // Frame the client's "ready" (5 bytes).
@@ -848,6 +858,8 @@ actor \nodoc\ _TestSendSSLLargeSingleSendServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     _tcp_connection.set_so_rcvbuf(4096)
 
@@ -985,6 +997,8 @@ actor \nodoc\ _TestSendMidFlightDropServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     match MakeBufferSize(5)
@@ -1238,6 +1252,8 @@ actor \nodoc\ _TestSendSSLPerTokenServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _assert_accepted(r: SendResult) =>
     match \exhaustive\ r
     | SendAccepted => None
@@ -1439,6 +1455,8 @@ actor \nodoc\ _TestSendSSLMidFlightDropServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _assert_accepted(r: SendResult) =>
     match \exhaustive\ r
@@ -1678,6 +1696,8 @@ actor \nodoc\ _TestSendGracefulCloseServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     match MakeBufferSize(5)
     | let b: BufferSize => _tcp_connection.buffer_until(b)
@@ -1901,6 +1921,8 @@ actor \nodoc\ _TestSendSSLGracefulCloseServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _assert_accepted(r: SendResult) =>
     match \exhaustive\ r
     | SendAccepted => None
@@ -2095,6 +2117,8 @@ actor \nodoc\ _TestSendCloseFromThrottledServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     match MakeBufferSize(5)
     | let b: BufferSize => _tcp_connection.buffer_until(b)
@@ -2248,6 +2272,8 @@ actor \nodoc\ _TestSendHardCloseFromThrottledServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     match MakeBufferSize(5)
@@ -2425,6 +2451,8 @@ actor \nodoc\ _TestSendSSLHardCloseFromThrottledServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     match MakeBufferSize(5)
@@ -2619,6 +2647,8 @@ actor \nodoc\ _TestSendDeliveredServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     match MakeBufferSize(5)
@@ -2944,6 +2974,8 @@ actor \nodoc\ _TestSendCloseFromAcceptedServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _h.assert_eq[String]("payload", String.from_array(consume data))
     _h.complete_action("server saw payload")
@@ -3065,6 +3097,8 @@ actor \nodoc\ _TestSendCloseFromSentServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _h.assert_eq[String]("payload", String.from_array(consume data))
@@ -3409,6 +3443,8 @@ actor \nodoc\ _TestSendOnSentPrecedesServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     match MakeBufferSize(5)
     | let b: BufferSize => _tcp_connection.buffer_until(b)
@@ -3594,6 +3630,8 @@ actor \nodoc\ _TestSendThrottleSuppressedServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     match MakeBufferSize(5)
@@ -3789,6 +3827,8 @@ actor \nodoc\ _TestSendKeepsDeliveredServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _received.append(String.from_array(consume data))
     if _received == "AAAABBBB" then
@@ -3906,6 +3946,8 @@ actor \nodoc\ _TestSendPrecedesReceivedServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _received = _received + 1
     if _received == 1 then
@@ -3971,6 +4013,8 @@ actor \nodoc\ _TestFakeSendOkActor
 
   fun ref _connection(): TCPConnection[_FBSendOkRecvRetry] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     _tcp_connection.mute()
@@ -4041,6 +4085,8 @@ actor \nodoc\ _TestFakeSendMultipleTokenOrderActor
 
   fun ref _connection(): TCPConnection[_FBSendOkRecvRetry] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     _tcp_connection.mute()
@@ -4118,6 +4164,8 @@ actor \nodoc\ _TestFakeSendOnClosedActor
   fun ref _connection(): TCPConnection[_FBSendOkRecvRetry] =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     _tcp_connection.mute()
     _tcp_connection.hard_close()
@@ -4188,6 +4236,8 @@ actor \nodoc\ _TestFakeSendErrorActor
 
   fun ref _connection(): TCPConnection[_FBSendErrorRecvRetry] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     _tcp_connection.mute()
@@ -4264,6 +4314,8 @@ actor \nodoc\ _TestFakeSendFailedAfterClosedActor
 
   fun ref _connection(): TCPConnection[_FBSendStepRecvRetryFailed] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     _tcp_connection.mute()
@@ -4345,6 +4397,8 @@ actor \nodoc\ _TestFakeGracefulCloseActor
 
   fun ref _connection(): TCPConnection[_FBSendOkRecvRetry] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     _tcp_connection.mute()

--- a/lori/_test_socket_options.pony
+++ b/lori/_test_socket_options.pony
@@ -50,6 +50,8 @@ actor \nodoc\ _TestSocketOptionsServer is
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     // set_nodelay: enable and disable should both succeed
     _h.assert_eq[U32](

--- a/lori/_test_ssl.pony
+++ b/lori/_test_ssl.pony
@@ -108,6 +108,8 @@ actor \nodoc\ _TestSSLPonger
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _pings_to_receive > 0 then
       _tcp_connection.send("Pong")
@@ -305,6 +307,8 @@ actor \nodoc\ _TestSSLSendvServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _h.assert_eq[String]("SSL Hello World", String.from_array(consume data))
     _h.complete_action("data verified")
@@ -401,6 +405,8 @@ actor \nodoc\ _TestSSLHandshakeFailurePlainServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     _tcp_connection.send("XXXXXXXXXX")
@@ -674,6 +680,8 @@ actor \nodoc\ _TestSSLTransitionToOpenServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
 class \nodoc\ iso _TestSSLIsWriteableDuringHandshake is UnitTest
   """
   Test that is_writeable() returns false during the initial SSL handshake
@@ -772,6 +780,8 @@ actor \nodoc\ _TestSSLIsWriteableServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   be check_writeable() =>
     _h.assert_false(
@@ -921,6 +931,8 @@ actor \nodoc\ _TestSSLHardCloseReceiveServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     // hard_close() below disposes the SSL session and fires _on_closed. The
     // client's second record is still in that session, so a read loop that
@@ -1056,6 +1068,8 @@ actor \nodoc\ _TestSSLHardCloseOnConnectedServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
 class \nodoc\ iso _TestSSLHardCloseOnStarted is UnitTest
   """
   Test that hard_close() from inside _on_started on an SSL server is safe.
@@ -1165,6 +1179,8 @@ actor \nodoc\ _TestSSLHardCloseOnStartedServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     _tcp_connection.hard_close()
@@ -1283,6 +1299,8 @@ actor \nodoc\ _TestSSLCloseReceiveServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _receives = _receives + 1
@@ -1444,6 +1462,8 @@ actor \nodoc\ _TestSSLLargePayloadServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if data.size() != 1000 then

--- a/lori/_test_start_tls.pony
+++ b/lori/_test_start_tls.pony
@@ -120,6 +120,8 @@ actor \nodoc\ _TestStartTLSServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     let msg = String.from_array(consume data)
     if msg == "STARTTLS" then
@@ -620,6 +622,8 @@ actor \nodoc\ _TestStartTLSHandshakeFailureServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _awaiting_client_hello then
       // Client sent a ClientHello — respond with garbage to break the
@@ -908,6 +912,8 @@ actor \nodoc\ _TestStartTLSAuthFailureServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     let msg = String.from_array(consume data)
     if msg == "STARTTLS" then
@@ -1098,6 +1104,8 @@ actor \nodoc\ _TestSetTimerAfterTLSUpgradeServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     let msg = String.from_array(consume data)
@@ -1303,6 +1311,8 @@ actor \nodoc\ _TestStartTLSHardCloseServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     let msg = String.from_array(consume data)

--- a/lori/_test_timer.pony
+++ b/lori/_test_timer.pony
@@ -94,6 +94,8 @@ actor \nodoc\ _TestTimerFiresServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     match \exhaustive\ MakeTimerDuration(2_000)
     | let d: TimerDuration =>
@@ -200,6 +202,8 @@ actor \nodoc\ _TestTimerCancelServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     match \exhaustive\ MakeTimerDuration(5_000)
@@ -367,6 +371,8 @@ actor \nodoc\ _TestTimerNotResetByIOServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     match \exhaustive\ MakeTimerDuration(3_000)
     | let d: TimerDuration =>
@@ -493,6 +499,8 @@ actor \nodoc\ _TestSetTimerAlreadyActiveServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     match \exhaustive\ MakeTimerDuration(5_000)
     | let d: TimerDuration =>
@@ -615,6 +623,8 @@ actor \nodoc\ _TestTimerRearmServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     _set_one_second_timer()
 
@@ -718,6 +728,8 @@ actor \nodoc\ _TestTimerCancelWrongTokenServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     match \exhaustive\ MakeTimerDuration(5_000)
@@ -833,6 +845,8 @@ actor \nodoc\ _TestTimerHardCloseServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     match MakeTimerDuration(5_000)
     | let d: TimerDuration =>
@@ -947,6 +961,8 @@ actor \nodoc\ _TestTimerSetDuringClosingServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     _tcp_connection.close()
@@ -1104,6 +1120,8 @@ actor \nodoc\ _TestSetTimerNotOpenSSLServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
 class \nodoc\ iso _TestSetTimerNotOpenDuringSSLHandshakeServer is UnitTest
   """
   Test that set_timer returns SetTimerNotOpen during initial SSL handshake
@@ -1256,6 +1274,8 @@ actor \nodoc\ _TestSetTimerNotOpenSSLServerConn
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_started() =>
     _h.fail("SSL handshake should not complete against plain TCP client")
     _h.complete(false)
@@ -1364,6 +1384,8 @@ actor \nodoc\ _TestTimerSurvivesCloseServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   fun ref _on_started() =>
     // Mute so we never read the client's FIN, preventing the close

--- a/lori/_test_yield_read.pony
+++ b/lori/_test_yield_read.pony
@@ -111,6 +111,8 @@ actor \nodoc\ _TestYieldReadServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   be mark() =>
     _marked = true
 
@@ -264,6 +266,8 @@ actor \nodoc\ _TestSSLYieldReadServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) => None
 
   be mark() =>
     _marked = true

--- a/lori/lori.pony
+++ b/lori/lori.pony
@@ -64,6 +64,8 @@ actor Echoer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _tcp_connection.send(consume data)
     KeepReading

--- a/lori/server_lifecycle_event_receiver.pony
+++ b/lori/server_lifecycle_event_receiver.pony
@@ -104,7 +104,7 @@ trait ServerLifecycleEventReceiver[TCP: TCPBackend ref = RuntimeBackend]
     """
     None
 
-  fun ref _on_start_failure(reason: StartFailureReason) =>
+  fun ref _on_start_failure(reason: StartFailureReason)
     """
     Called when a server connection fails to start. This covers failures
     that occur before _on_started would have fired, such as an SSL
@@ -115,7 +115,6 @@ trait ServerLifecycleEventReceiver[TCP: TCPBackend ref = RuntimeBackend]
     the only reason is `StartFailedSSL` (SSL session creation or handshake
     failure).
     """
-    None
 
   fun ref _on_tls_ready() =>
     """

--- a/stress-tests/tcp-swarm/tcp_swarm.pony
+++ b/stress-tests/tcp-swarm/tcp_swarm.pony
@@ -690,6 +690,8 @@ actor EchoServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) => None
+
   fun ref _set_framing() =>
     if _config.expect_frame > 0 then
       // Unreachable branches: expect_frame is > 0 here (guarded above) and


### PR DESCRIPTION
`ServerLifecycleEventReceiver._on_start_failure` no longer has a default body. Every type that implements `ServerLifecycleEventReceiver` must now provide the method.

The previous default silently discarded server-side SSL handshake failures — a failed handshake produced no `_on_started`, no `_on_closed`, no error. The connection vanished. Making the method abstract forces the application to handle it.

**Parked from code review — needs your input:**

The issue states that `_on_connection_failure` on `ClientLifecycleEventReceiver` is already abstract, but it isn't — it has a default `=> None` body too. After this PR the two traits are asymmetric: the server side forces handling, the client side doesn't. Should `_on_connection_failure` also be made abstract? That would be a separate PR.
