### PR TITLE
Require explicit start-failure handling for server connections

### DIFF
--- a/.release-notes/make-on-start-failure-abstract.md
+++ b/.release-notes/make-on-start-failure-abstract.md
@@ -1,0 +1,51 @@
+## Require explicit start-failure handling for server connections
+
+`ServerLifecycleEventReceiver` and `ServerTCPConnectionNotify` no longer provide a default for start-failure handling. Every implementor must now provide an explicit method body.
+
+Native API — before:
+
+```pony
+actor MyServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+```
+
+Native API — after:
+
+```pony
+actor MyServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+```
+
+Notifier API — before:
+
+```pony
+class MyNotify is ServerTCPConnectionNotify
+  fun ref on_received(conn: ServerTCPConnection ref, data: Array[U8] iso):
+    ReadAction
+  =>
+    KeepReading
+```
+
+Notifier API — after:
+
+```pony
+class MyNotify is ServerTCPConnectionNotify
+  fun ref on_start_failure(conn: ServerTCPConnection ref,
+    reason: StartFailureReason)
+  =>
+    None
+
+  fun ref on_received(conn: ServerTCPConnection ref, data: Array[U8] iso):
+    ReadAction
+  =>
+    KeepReading
+```

--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -61,6 +61,11 @@ use "lori"
 use "lori/notifier"
 
 class Echo is ServerTCPConnectionNotify
+  fun ref on_start_failure(conn: ServerTCPConnection ref,
+    reason: StartFailureReason)
+  =>
+    None
+
   fun ref on_received(conn: ServerTCPConnection ref, data: Array[U8] iso):
     ReadAction
   =>

--- a/examples/backpressure/backpressure.pony
+++ b/examples/backpressure/backpressure.pony
@@ -62,6 +62,9 @@ actor Sink is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _bytes_received = _bytes_received + data.size()
     KeepReading

--- a/examples/echo-server/echo_server.pony
+++ b/examples/echo-server/echo_server.pony
@@ -63,6 +63,9 @@ actor Echoer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_closed() =>
     _out.print("Connection Closed")
 

--- a/examples/framed-protocol/framed_protocol.pony
+++ b/examples/framed-protocol/framed_protocol.pony
@@ -71,6 +71,9 @@ actor FramedServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _reading_header then
       try

--- a/examples/idle-timeout/idle_timeout.pony
+++ b/examples/idle-timeout/idle_timeout.pony
@@ -63,6 +63,9 @@ actor IdleTimeoutEchoer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     _out.print("Connection established. 10-second idle timeout active.")
     match MakeIdleTimeout(10_000)

--- a/examples/infinite-ping-pong/infinite_ping_pong.pony
+++ b/examples/infinite-ping-pong/infinite_ping_pong.pony
@@ -66,6 +66,9 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _out.print(consume data)
     _tcp_connection.send("Pong")

--- a/examples/ip-version/ip_version.pony
+++ b/examples/ip-version/ip_version.pony
@@ -70,6 +70,9 @@ actor IP4Echoer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_closed() =>
     _out.print("Server: connection closed.")
 

--- a/examples/net-ssl-echo-server/net_ssl_echo_server.pony
+++ b/examples/net-ssl-echo-server/net_ssl_echo_server.pony
@@ -94,6 +94,9 @@ actor Echoer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_closed() =>
     _out.print("Connection Closed")
 

--- a/examples/net-ssl-infinite-ping-pong/net_ssl_infinite_ping_pong.pony
+++ b/examples/net-ssl-infinite-ping-pong/net_ssl_infinite_ping_pong.pony
@@ -94,6 +94,9 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _out.print(consume data)
     _tcp_connection.send("Pong")

--- a/examples/notifier-echo-server/notifier_echo_server.pony
+++ b/examples/notifier-echo-server/notifier_echo_server.pony
@@ -55,6 +55,11 @@ class EchoNotify is notifier.ServerTCPConnectionNotify
   new create(out: OutStream) =>
     _out = out
 
+  fun ref on_start_failure(conn: notifier.ServerTCPConnection ref,
+    reason: StartFailureReason)
+  =>
+    None
+
   fun ref on_received(conn: notifier.ServerTCPConnection ref,
     data: Array[U8] iso): ReadAction
   =>

--- a/examples/notifier-ping-pong/notifier_ping_pong.pony
+++ b/examples/notifier-ping-pong/notifier_ping_pong.pony
@@ -85,6 +85,11 @@ class PongNotify is notifier.ServerTCPConnectionNotify
   new create(out: OutStream) =>
     _out = out
 
+  fun ref on_start_failure(conn: notifier.ServerTCPConnection ref,
+    reason: StartFailureReason)
+  =>
+    None
+
   fun ref on_accepted(conn: notifier.ServerTCPConnection ref) =>
     match MakeBufferSize(4)
     | let e: BufferSize => conn.buffer_until(e)

--- a/examples/read-buffer-size/read_buffer_size.pony
+++ b/examples/read-buffer-size/read_buffer_size.pony
@@ -75,6 +75,9 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _control_phase then
       let cmd = String.from_array(consume data)

--- a/examples/send-completion/send_completion.pony
+++ b/examples/send-completion/send_completion.pony
@@ -79,6 +79,9 @@ actor Sink is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     KeepReading
 

--- a/examples/socket-options/socket_options.pony
+++ b/examples/socket-options/socket_options.pony
@@ -70,6 +70,9 @@ actor SocketOptionsServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     // Disable Nagle for low-latency responses
     _tcp_connection.set_nodelay(true)

--- a/examples/starttls-ping-pong/starttls_ping_pong.pony
+++ b/examples/starttls-ping-pong/starttls_ping_pong.pony
@@ -108,6 +108,9 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     let msg = String.from_array(consume data)
     if msg == "STARTTLS" then

--- a/examples/timer/timer.pony
+++ b/examples/timer/timer.pony
@@ -66,6 +66,9 @@ actor SlowServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _out.print("[server] Received query. Pretending to think forever...")
     // Never responds — simulating a slow query

--- a/examples/yield-read/yield_read.pony
+++ b/examples/yield-read/yield_read.pony
@@ -68,6 +68,9 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _received_count = _received_count + 1
 

--- a/lori/_test_backpressure_drain.pony
+++ b/lori/_test_backpressure_drain.pony
@@ -109,6 +109,9 @@ actor \nodoc\ _TestBackpressureDrainServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     _h.complete_action("server started")
     // Frame incoming messages: "ready" is 5 bytes
@@ -323,6 +326,9 @@ actor \nodoc\ _TestWriteOnlyEventReadRecoveryServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     _h.complete_action("server started")
@@ -542,6 +548,9 @@ actor \nodoc\ _TestReadableEventWriteRecoveryServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     _h.complete_action("server started")

--- a/lori/_test_connection.pony
+++ b/lori/_test_connection.pony
@@ -124,6 +124,9 @@ actor \nodoc\ _TestPonger is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _pings_to_receive > 0 then
       _tcp_connection.send("Pong")
@@ -265,6 +268,9 @@ actor \nodoc\ _TestBasicBufferUntilServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _received_count = _received_count + 1
 
@@ -340,6 +346,9 @@ actor \nodoc\ _TestDoNothingServerActor
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
 class \nodoc\ iso _TestListenerLocalAddress is UnitTest
   """
@@ -493,6 +502,9 @@ actor \nodoc\ _TestHardCloseDuringReceiveServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     // Hard close from inside the read callback (see the class docstring).
     _closed_in_receive = true
@@ -614,6 +626,9 @@ actor \nodoc\ _TestHardCloseAfterFramedReceiveServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _received_count = _received_count + 1
     if _received_count == 1 then
@@ -676,6 +691,9 @@ actor \nodoc\ _TestFakeRecvErrorActor
   fun ref _connection(): TCPConnection[_FBSendOkRecvError] =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _h.fail("_on_received should not fire when receive errors")
     _h.complete(false)
@@ -726,6 +744,9 @@ actor \nodoc\ _TestFakeRecvRetryActor
 
   fun ref _connection(): TCPConnection[_FBSendOkRecvRetry] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     _tcp_connection.mute()
@@ -778,6 +799,9 @@ actor \nodoc\ _TestFakeRecvDataActor
 
   fun ref _connection(): TCPConnection[_FBSendOkRecvHello] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     let s = String.from_iso_array(consume data)
@@ -838,6 +862,9 @@ actor \nodoc\ _TestFakeRecvFramedActor
   fun ref _connection(): TCPConnection[_FBSendOkRecv10] =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _received_count = _received_count + 1
     _h.assert_eq[USize](
@@ -893,6 +920,9 @@ actor \nodoc\ _TestFakeMuteActor
 
   fun ref _connection(): TCPConnection[_FBSendOkRecvHelloMute] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     _tcp_connection.mute()
@@ -960,6 +990,9 @@ actor \nodoc\ _TestFakeYieldReadingActor
 
   fun ref _connection(): TCPConnection[_FBSendOkRecv10Yield] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _received_count = _received_count + 1
@@ -1298,6 +1331,9 @@ actor \nodoc\ _TestFakeServerStub[TCP: TCPBackend ref]
 
   fun ref _connection(): TCPConnection[TCP] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     _tcp_connection.mute()

--- a/lori/_test_connection_timeout.pony
+++ b/lori/_test_connection_timeout.pony
@@ -147,6 +147,9 @@ actor \nodoc\ _TestConnectionTimeoutCancelServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
 class \nodoc\ iso _TestSSLConnectionTimeoutFires is UnitTest
   """
   Test that the connection timeout fires during SSL handshake. Connects an
@@ -264,6 +267,9 @@ actor \nodoc\ _TestSSLConnectionTimeoutFiresServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
 class \nodoc\ iso _TestSSLConnectionTimeoutCancelledOnConnect is UnitTest
   """
   Test that the connect timer is cancelled when an SSL handshake completes.
@@ -374,6 +380,9 @@ actor \nodoc\ _TestSSLConnectionTimeoutCancelSSLServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
 class \nodoc\ iso _TestCloseWhileConnectingWithTimeout is UnitTest
   """

--- a/lori/_test_flow_control.pony
+++ b/lori/_test_flow_control.pony
@@ -123,6 +123,9 @@ actor \nodoc\ _TestMuteServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     _h.complete_action("server started")
     _tcp_connection.mute()
@@ -273,6 +276,9 @@ actor \nodoc\ _TestUnmuteServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     _h.complete_action("server started")
@@ -507,6 +513,9 @@ actor \nodoc\ _TestMuteWithFullReadBufferServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _muted then
@@ -766,6 +775,9 @@ actor \nodoc\ _TestSSLMuteServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _muted then
       _h.fail("server received data while muted")
@@ -953,6 +965,9 @@ actor \nodoc\ _TestSSLMuteCloseServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _received = _received + 1
 
@@ -1089,6 +1104,9 @@ actor \nodoc\ _TestMuteFromOnSentServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     match \exhaustive\ _tcp_connection.send("ask")

--- a/lori/_test_idle_timeout.pony
+++ b/lori/_test_idle_timeout.pony
@@ -82,6 +82,9 @@ actor \nodoc\ _TestIdleTimeoutServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     match MakeIdleTimeout(5_000)
     | let t: IdleTimeout =>
@@ -203,6 +206,9 @@ actor \nodoc\ _TestIdleTimeoutResetServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     match MakeIdleTimeout(5_000)
     | let t: IdleTimeout =>
@@ -312,6 +318,9 @@ actor \nodoc\ _TestIdleTimeoutDisableServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     match MakeIdleTimeout(5_000)
@@ -445,6 +454,9 @@ actor \nodoc\ _TestSSLIdleTimeoutServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     match MakeIdleTimeout(5_000)
     | let t: IdleTimeout =>
@@ -575,6 +587,9 @@ actor \nodoc\ _TestSSLIdleTimeoutNotArmedServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
 class \nodoc\ iso _TestSSLIdleTimeoutDeferredArm is UnitTest
   """
   Test the deferred-arm path: an SSL client configures an idle timeout
@@ -680,6 +695,9 @@ actor \nodoc\ _TestSSLIdleTimeoutDeferredArmServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
 class \nodoc\ iso _TestIdleTimeoutRearms is UnitTest
   """
   Test that the idle timeout fires again on a connection that stays idle.
@@ -766,6 +784,9 @@ actor \nodoc\ _TestIdleTimeoutRearmsServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     match \exhaustive\ MakeIdleTimeout(1_000)
@@ -878,6 +899,9 @@ actor \nodoc\ _TestIdleTimeoutNoRearmServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     match \exhaustive\ MakeIdleTimeout(1_000)

--- a/lori/_test_ip_version.pony
+++ b/lori/_test_ip_version.pony
@@ -87,6 +87,9 @@ actor \nodoc\ _TestIP4Ponger
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _pings_to_receive > 0 then
       _tcp_connection.send("Pong")
@@ -221,6 +224,9 @@ actor \nodoc\ _TestIP6Ponger
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _pings_to_receive > 0 then

--- a/lori/_test_read_buffer.pony
+++ b/lori/_test_read_buffer.pony
@@ -58,6 +58,9 @@ actor \nodoc\ _TestReadBufferConstructorSizeServer is
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     // set_read_buffer_minimum to 256 should succeed (lowering the minimum)
     match \exhaustive\ MakeReadBufferSize(256)
@@ -138,6 +141,9 @@ actor \nodoc\ _TestSetReadBufferMinSuccessServer is
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     // Setting minimum to 512 should succeed and grow the buffer
     match \exhaustive\ MakeReadBufferSize(512)
@@ -214,6 +220,9 @@ actor \nodoc\ _TestSetReadBufferMinBelowBufferSizeServer is
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     // Set buffer_until to 100
@@ -305,6 +314,9 @@ actor \nodoc\ _TestResizeReadBufferSuccessServer is
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     // Resize to larger
     match \exhaustive\ MakeReadBufferSize(4096)
@@ -385,6 +397,9 @@ actor \nodoc\ _TestResizeReadBufferBelowBufferSizeServer is
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     // Set buffer_until to 200
@@ -467,6 +482,9 @@ actor \nodoc\ _TestResizeReadBufferBelowMinServer is
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     // Resize to 256 — this should lower the minimum from 1024 to 256
@@ -562,6 +580,9 @@ actor \nodoc\ _TestBufferSizeAboveMinServer is
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     // buffer_until(256) should fail because minimum is 128
     match MakeBufferSize(256)
@@ -630,6 +651,9 @@ actor \nodoc\ _TestBufferSizeAtMinServer is
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     // buffer_until(256) should succeed (equals minimum)

--- a/lori/_test_send.pony
+++ b/lori/_test_send.pony
@@ -108,6 +108,9 @@ actor \nodoc\ _TestSendTokenServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
 class \nodoc\ iso _TestSendAfterClose is UnitTest
   """
   Test that send() returns SendErrorNotConnected after the connection has been
@@ -212,6 +215,9 @@ actor \nodoc\ _TestSendAfterCloseServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
 class \nodoc\ iso _TestSendv is UnitTest
   """
@@ -322,6 +328,9 @@ actor \nodoc\ _TestSendvServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _h.assert_eq[String]("Hello, world!", String.from_array(consume data))
@@ -509,6 +518,9 @@ actor \nodoc\ _TestSendvMixedEmptyServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _h.assert_eq[String]("Helloworld", String.from_array(consume data))
     _h.complete_action("data verified")
@@ -639,6 +651,9 @@ actor \nodoc\ _TestSendPerTokenServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     // Frame the client's "ready" (5 bytes).
@@ -848,6 +863,9 @@ actor \nodoc\ _TestSendSSLLargeSingleSendServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     _tcp_connection.set_so_rcvbuf(4096)
 
@@ -985,6 +1003,9 @@ actor \nodoc\ _TestSendMidFlightDropServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     match MakeBufferSize(5)
@@ -1238,6 +1259,9 @@ actor \nodoc\ _TestSendSSLPerTokenServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _assert_accepted(r: SendResult) =>
     match \exhaustive\ r
     | SendAccepted => None
@@ -1439,6 +1463,9 @@ actor \nodoc\ _TestSendSSLMidFlightDropServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _assert_accepted(r: SendResult) =>
     match \exhaustive\ r
@@ -1678,6 +1705,9 @@ actor \nodoc\ _TestSendGracefulCloseServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     match MakeBufferSize(5)
     | let b: BufferSize => _tcp_connection.buffer_until(b)
@@ -1901,6 +1931,9 @@ actor \nodoc\ _TestSendSSLGracefulCloseServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _assert_accepted(r: SendResult) =>
     match \exhaustive\ r
     | SendAccepted => None
@@ -2095,6 +2128,9 @@ actor \nodoc\ _TestSendCloseFromThrottledServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     match MakeBufferSize(5)
     | let b: BufferSize => _tcp_connection.buffer_until(b)
@@ -2248,6 +2284,9 @@ actor \nodoc\ _TestSendHardCloseFromThrottledServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     match MakeBufferSize(5)
@@ -2425,6 +2464,9 @@ actor \nodoc\ _TestSendSSLHardCloseFromThrottledServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     match MakeBufferSize(5)
@@ -2619,6 +2661,9 @@ actor \nodoc\ _TestSendDeliveredServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     match MakeBufferSize(5)
@@ -2944,6 +2989,9 @@ actor \nodoc\ _TestSendCloseFromAcceptedServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _h.assert_eq[String]("payload", String.from_array(consume data))
     _h.complete_action("server saw payload")
@@ -3065,6 +3113,9 @@ actor \nodoc\ _TestSendCloseFromSentServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _h.assert_eq[String]("payload", String.from_array(consume data))
@@ -3409,6 +3460,9 @@ actor \nodoc\ _TestSendOnSentPrecedesServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     match MakeBufferSize(5)
     | let b: BufferSize => _tcp_connection.buffer_until(b)
@@ -3594,6 +3648,9 @@ actor \nodoc\ _TestSendThrottleSuppressedServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     match MakeBufferSize(5)
@@ -3789,6 +3846,9 @@ actor \nodoc\ _TestSendKeepsDeliveredServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _received.append(String.from_array(consume data))
     if _received == "AAAABBBB" then
@@ -3906,6 +3966,9 @@ actor \nodoc\ _TestSendPrecedesReceivedServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _received = _received + 1
     if _received == 1 then
@@ -3971,6 +4034,9 @@ actor \nodoc\ _TestFakeSendOkActor
 
   fun ref _connection(): TCPConnection[_FBSendOkRecvRetry] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     _tcp_connection.mute()
@@ -4041,6 +4107,9 @@ actor \nodoc\ _TestFakeSendMultipleTokenOrderActor
 
   fun ref _connection(): TCPConnection[_FBSendOkRecvRetry] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     _tcp_connection.mute()
@@ -4118,6 +4187,9 @@ actor \nodoc\ _TestFakeSendOnClosedActor
   fun ref _connection(): TCPConnection[_FBSendOkRecvRetry] =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     _tcp_connection.mute()
     _tcp_connection.hard_close()
@@ -4188,6 +4260,9 @@ actor \nodoc\ _TestFakeSendErrorActor
 
   fun ref _connection(): TCPConnection[_FBSendErrorRecvRetry] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     _tcp_connection.mute()
@@ -4264,6 +4339,9 @@ actor \nodoc\ _TestFakeSendFailedAfterClosedActor
 
   fun ref _connection(): TCPConnection[_FBSendStepRecvRetryFailed] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     _tcp_connection.mute()
@@ -4345,6 +4423,9 @@ actor \nodoc\ _TestFakeGracefulCloseActor
 
   fun ref _connection(): TCPConnection[_FBSendOkRecvRetry] =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     _tcp_connection.mute()

--- a/lori/_test_socket_options.pony
+++ b/lori/_test_socket_options.pony
@@ -50,6 +50,9 @@ actor \nodoc\ _TestSocketOptionsServer is
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     // set_nodelay: enable and disable should both succeed
     _h.assert_eq[U32](

--- a/lori/_test_ssl.pony
+++ b/lori/_test_ssl.pony
@@ -108,6 +108,9 @@ actor \nodoc\ _TestSSLPonger
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _pings_to_receive > 0 then
       _tcp_connection.send("Pong")
@@ -305,6 +308,9 @@ actor \nodoc\ _TestSSLSendvServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _h.assert_eq[String]("SSL Hello World", String.from_array(consume data))
     _h.complete_action("data verified")
@@ -401,6 +407,9 @@ actor \nodoc\ _TestSSLHandshakeFailurePlainServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     _tcp_connection.send("XXXXXXXXXX")
@@ -674,6 +683,9 @@ actor \nodoc\ _TestSSLTransitionToOpenServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
 class \nodoc\ iso _TestSSLIsWriteableDuringHandshake is UnitTest
   """
   Test that is_writeable() returns false during the initial SSL handshake
@@ -772,6 +784,9 @@ actor \nodoc\ _TestSSLIsWriteableServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   be check_writeable() =>
     _h.assert_false(
@@ -921,6 +936,9 @@ actor \nodoc\ _TestSSLHardCloseReceiveServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     // hard_close() below disposes the SSL session and fires _on_closed. The
     // client's second record is still in that session, so a read loop that
@@ -1056,6 +1074,9 @@ actor \nodoc\ _TestSSLHardCloseOnConnectedServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
 class \nodoc\ iso _TestSSLHardCloseOnStarted is UnitTest
   """
   Test that hard_close() from inside _on_started on an SSL server is safe.
@@ -1165,6 +1186,9 @@ actor \nodoc\ _TestSSLHardCloseOnStartedServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     _tcp_connection.hard_close()
@@ -1283,6 +1307,9 @@ actor \nodoc\ _TestSSLCloseReceiveServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _receives = _receives + 1
@@ -1444,6 +1471,9 @@ actor \nodoc\ _TestSSLLargePayloadServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if data.size() != 1000 then

--- a/lori/_test_start_tls.pony
+++ b/lori/_test_start_tls.pony
@@ -120,6 +120,9 @@ actor \nodoc\ _TestStartTLSServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     let msg = String.from_array(consume data)
     if msg == "STARTTLS" then
@@ -620,6 +623,9 @@ actor \nodoc\ _TestStartTLSHandshakeFailureServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if _awaiting_client_hello then
       // Client sent a ClientHello — respond with garbage to break the
@@ -908,6 +914,9 @@ actor \nodoc\ _TestStartTLSAuthFailureServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     let msg = String.from_array(consume data)
     if msg == "STARTTLS" then
@@ -1098,6 +1107,9 @@ actor \nodoc\ _TestSetTimerAfterTLSUpgradeServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     let msg = String.from_array(consume data)
@@ -1303,6 +1315,9 @@ actor \nodoc\ _TestStartTLSHardCloseServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     let msg = String.from_array(consume data)

--- a/lori/_test_timer.pony
+++ b/lori/_test_timer.pony
@@ -94,6 +94,9 @@ actor \nodoc\ _TestTimerFiresServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     match \exhaustive\ MakeTimerDuration(2_000)
     | let d: TimerDuration =>
@@ -200,6 +203,9 @@ actor \nodoc\ _TestTimerCancelServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     match \exhaustive\ MakeTimerDuration(5_000)
@@ -367,6 +373,9 @@ actor \nodoc\ _TestTimerNotResetByIOServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     match \exhaustive\ MakeTimerDuration(3_000)
     | let d: TimerDuration =>
@@ -493,6 +502,9 @@ actor \nodoc\ _TestSetTimerAlreadyActiveServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     match \exhaustive\ MakeTimerDuration(5_000)
     | let d: TimerDuration =>
@@ -615,6 +627,9 @@ actor \nodoc\ _TestTimerRearmServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     _set_one_second_timer()
 
@@ -718,6 +733,9 @@ actor \nodoc\ _TestTimerCancelWrongTokenServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     match \exhaustive\ MakeTimerDuration(5_000)
@@ -833,6 +851,9 @@ actor \nodoc\ _TestTimerHardCloseServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     match MakeTimerDuration(5_000)
     | let d: TimerDuration =>
@@ -947,6 +968,9 @@ actor \nodoc\ _TestTimerSetDuringClosingServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     _tcp_connection.close()
@@ -1104,6 +1128,9 @@ actor \nodoc\ _TestSetTimerNotOpenSSLServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
 class \nodoc\ iso _TestSetTimerNotOpenDuringSSLHandshakeServer is UnitTest
   """
   Test that set_timer returns SetTimerNotOpen during initial SSL handshake
@@ -1256,6 +1283,9 @@ actor \nodoc\ _TestSetTimerNotOpenSSLServerConn
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_started() =>
     _h.fail("SSL handshake should not complete against plain TCP client")
     _h.complete(false)
@@ -1364,6 +1394,9 @@ actor \nodoc\ _TestTimerSurvivesCloseServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   fun ref _on_started() =>
     // Mute so we never read the client's FIN, preventing the close

--- a/lori/_test_yield_read.pony
+++ b/lori/_test_yield_read.pony
@@ -111,6 +111,9 @@ actor \nodoc\ _TestYieldReadServer
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   be mark() =>
     _marked = true
 
@@ -264,6 +267,9 @@ actor \nodoc\ _TestSSLYieldReadServer
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
 
   be mark() =>
     _marked = true

--- a/lori/lori.pony
+++ b/lori/lori.pony
@@ -64,6 +64,9 @@ actor Echoer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     _tcp_connection.send(consume data)
     KeepReading

--- a/lori/notifier/_test_buffer_until.pony
+++ b/lori/notifier/_test_buffer_until.pony
@@ -43,6 +43,11 @@ class \nodoc\ _TestNBUServerNotify is ServerTCPConnectionNotify
   new create(h: TestHelper) =>
     _h = h
 
+  fun ref on_start_failure(conn: ServerTCPConnection ref,
+    reason: lori.StartFailureReason)
+  =>
+    None
+
   fun ref on_accepted(conn: ServerTCPConnection ref) =>
     match lori.MakeBufferSize(4)
     | let e: lori.BufferSize => conn.buffer_until(e)

--- a/lori/notifier/_test_dispose.pony
+++ b/lori/notifier/_test_dispose.pony
@@ -45,3 +45,7 @@ class \nodoc\ _TestNDListenNotify is TCPListenNotify
     _h.complete_action("closed")
 
 class \nodoc\ _TestNDServerNotify is ServerTCPConnectionNotify
+  fun ref on_start_failure(conn: ServerTCPConnection ref,
+    reason: lori.StartFailureReason)
+  =>
+    None

--- a/lori/notifier/_test_ping_pong.pony
+++ b/lori/notifier/_test_ping_pong.pony
@@ -63,6 +63,11 @@ class \nodoc\ _TestNPPServerNotify is ServerTCPConnectionNotify
     _pings_to_receive = pings_to_receive
     _h = h
 
+  fun ref on_start_failure(conn: ServerTCPConnection ref,
+    reason: lori.StartFailureReason)
+  =>
+    None
+
   fun ref on_accepted(conn: ServerTCPConnection ref) =>
     match lori.MakeBufferSize(4)
     | let e: lori.BufferSize => conn.buffer_until(e)

--- a/lori/notifier/_test_reject.pony
+++ b/lori/notifier/_test_reject.pony
@@ -106,3 +106,7 @@ class \nodoc\ _TestNRCSecondClientNotify is ClientTCPConnectionNotify
     _h.complete(false)
 
 class \nodoc\ _TestNRCServerNotify is ServerTCPConnectionNotify
+  fun ref on_start_failure(conn: ServerTCPConnection ref,
+    reason: lori.StartFailureReason)
+  =>
+    None

--- a/lori/notifier/_test_ssl.pony
+++ b/lori/notifier/_test_ssl.pony
@@ -78,6 +78,11 @@ class \nodoc\ _TestNSSLServerNotify is ServerTCPConnectionNotify
     _pings_to_receive = pings_to_receive
     _h = h
 
+  fun ref on_start_failure(conn: ServerTCPConnection ref,
+    reason: lori.StartFailureReason)
+  =>
+    None
+
   fun ref on_accepted(conn: ServerTCPConnection ref) =>
     match lori.MakeBufferSize(4)
     | let e: lori.BufferSize => conn.buffer_until(e)

--- a/lori/notifier/notifier.pony
+++ b/lori/notifier/notifier.pony
@@ -30,6 +30,11 @@ use "lori"
 use "lori/notifier"
 
 class Echo is ServerTCPConnectionNotify
+  fun ref on_start_failure(conn: ServerTCPConnection ref,
+    reason: StartFailureReason)
+  =>
+    None
+
   fun ref on_received(conn: ServerTCPConnection ref, data: Array[U8] iso):
     ReadAction
   =>

--- a/lori/notifier/server_tcp_connection_notify.pony
+++ b/lori/notifier/server_tcp_connection_notify.pony
@@ -13,8 +13,9 @@ trait ServerTCPConnectionNotify
   callable from any callback. Behaviors like `write` are also callable but
   execute on the next turn.
 
-  Every callback has a default implementation. Override the ones your
-  application cares about.
+  Every callback has a default implementation except `on_start_failure`,
+  which must be implemented because ignoring a server-side start failure
+  is never correct.
   """
   fun ref on_accepted(conn: ServerTCPConnection ref) =>
     """
@@ -85,12 +86,10 @@ trait ServerTCPConnectionNotify
 
   fun ref on_start_failure(conn: ServerTCPConnection ref,
     reason: lori.StartFailureReason)
-  =>
     """
     Called when a server connection fails to start — for example, an SSL
     handshake failure before `on_accepted` would have fired.
     """
-    None
 
   fun ref on_tls_ready(conn: ServerTCPConnection ref) =>
     """

--- a/lori/server_lifecycle_event_receiver.pony
+++ b/lori/server_lifecycle_event_receiver.pony
@@ -104,18 +104,16 @@ trait ServerLifecycleEventReceiver[TCP: TCPBackend ref = RuntimeBackend]
     """
     None
 
-  fun ref _on_start_failure(reason: StartFailureReason) =>
+  fun ref _on_start_failure(reason: StartFailureReason)
     """
     Called when a server connection fails to start. This covers failures
     that occur before _on_started would have fired, such as an SSL
     handshake failure. The application was never notified of the connection
     via _on_started.
 
-    The `reason` parameter identifies the cause of the failure. Currently
-    the only reason is `StartFailedSSL` (SSL session creation or handshake
-    failure).
+    The `reason` parameter identifies the cause of the failure.
+    `StartFailedSSL` indicates SSL session creation or handshake failure.
     """
-    None
 
   fun ref _on_tls_ready() =>
     """

--- a/stress-tests/tcp-swarm/tcp_swarm.pony
+++ b/stress-tests/tcp-swarm/tcp_swarm.pony
@@ -690,6 +690,9 @@ actor EchoServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_start_failure(reason: StartFailureReason) =>
+    None
+
   fun ref _set_framing() =>
     if _config.expect_frame > 0 then
       // Unreachable branches: expect_frame is > 0 here (guarded above) and


### PR DESCRIPTION
`ServerLifecycleEventReceiver` and `ServerTCPConnectionNotify` had default no-op implementations for their start-failure callbacks. Implementors that forgot the method compiled and silently swallowed failures. Removing the defaults makes both abstract — the compiler now forces every implementor to provide an explicit body.

Closes #372
