### PR TITLE
Require explicit connection-failure handling for client connections

### DIFF
--- a/.release-notes/make-on-connection-failure-abstract.md
+++ b/.release-notes/make-on-connection-failure-abstract.md
@@ -1,0 +1,26 @@
+## Require explicit connection-failure handling for client connections
+
+`ClientLifecycleEventReceiver` no longer provides a default for `_on_connection_failure`. Every implementor must now provide an explicit method body.
+
+Before:
+
+```pony
+actor MyClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+```
+
+After:
+
+```pony
+actor MyClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
+  var _tcp_connection: TCPConnection = TCPConnection.none()
+
+  fun ref _connection(): TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+```

--- a/examples/infinite-ping-pong/infinite_ping_pong.pony
+++ b/examples/infinite-ping-pong/infinite_ping_pong.pony
@@ -96,6 +96,9 @@ actor Client is (TCPConnectionActor & ClientLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     _tcp_connection.send("Ping")
 

--- a/examples/net-ssl-infinite-ping-pong/net_ssl_infinite_ping_pong.pony
+++ b/examples/net-ssl-infinite-ping-pong/net_ssl_infinite_ping_pong.pony
@@ -127,6 +127,9 @@ actor Client is (TCPConnectionActor & ClientLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     _tcp_connection.send("Ping")
 

--- a/examples/socket-options/socket_options.pony
+++ b/examples/socket-options/socket_options.pony
@@ -127,6 +127,9 @@ actor SocketOptionsClient is
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     _tcp_connection.send("Hello")
 

--- a/examples/starttls-ping-pong/starttls_ping_pong.pony
+++ b/examples/starttls-ping-pong/starttls_ping_pong.pony
@@ -155,6 +155,9 @@ actor Client is (TCPConnectionActor & ClientLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     _out.print("Client: connected (plaintext), requesting STARTTLS")
     _tcp_connection.send("STARTTLS")

--- a/lori/_test_connection.pony
+++ b/lori/_test_connection.pony
@@ -82,6 +82,9 @@ actor \nodoc\ _TestPinger is (TCPConnectionActor & ClientLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     if _pings_to_send > 0 then
       _tcp_connection.send("Ping")
@@ -208,6 +211,9 @@ actor \nodoc\ _TestBasicBufferUntilClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     _h.complete_action("client connected")
@@ -475,6 +481,9 @@ actor \nodoc\ _TestHardCloseDuringReceiveClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     // Give the server data so its `_on_received` fires.
     match \exhaustive\ _tcp_connection.send("ping")
@@ -595,6 +604,9 @@ actor \nodoc\ _TestHardCloseAfterFramedReceiveClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     // Two 4-byte frames in a single send, so both land in one server read.
@@ -1101,6 +1113,9 @@ actor \nodoc\ _TestFakeConnectInflightActor
   fun ref _connection(): TCPConnection[_FBConnect3] =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connecting(inflight_connections: U32) =>
     if inflight_connections == 3 then
       _h.complete_action("on_connecting_3")
@@ -1148,6 +1163,9 @@ actor \nodoc\ _TestFakeSendWhileConnectingActor
   fun ref _connection(): TCPConnection[_FBConnect1] =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connecting(inflight_connections: U32) =>
     match \exhaustive\ _tcp_connection.send("aaa")
     | SendAccepted =>
@@ -1194,6 +1212,9 @@ actor \nodoc\ _TestFakeSendWhileUnconnectedClosingActor
 
   fun ref _connection(): TCPConnection[_FBConnect1] =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connecting(inflight_connections: U32) =>
     _tcp_connection.close()

--- a/lori/_test_idle_timeout.pony
+++ b/lori/_test_idle_timeout.pony
@@ -65,6 +65,9 @@ actor \nodoc\ _TestIdleTimeoutClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
 actor \nodoc\ _TestIdleTimeoutServer
   is (TCPConnectionActor & ServerLifecycleEventReceiver)
   var _tcp_connection: TCPConnection = TCPConnection.none()
@@ -162,6 +165,9 @@ actor \nodoc\ _TestIdleTimeoutResetClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     _tcp_connection.send("ping")
@@ -301,6 +307,9 @@ actor \nodoc\ _TestIdleTimeoutDisableClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
 actor \nodoc\ _TestIdleTimeoutDisableServer
   is (TCPConnectionActor & ServerLifecycleEventReceiver)
   var _tcp_connection: TCPConnection = TCPConnection.none()
@@ -435,6 +444,9 @@ actor \nodoc\ _TestSSLIdleTimeoutClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
 actor \nodoc\ _TestSSLIdleTimeoutServer
   is (TCPConnectionActor & ServerLifecycleEventReceiver)
@@ -674,6 +686,9 @@ actor \nodoc\ _TestSSLIdleTimeoutDeferredArmClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_idle_timeout() =>
     _h.complete(true)
 
@@ -766,6 +781,9 @@ actor \nodoc\ _TestIdleTimeoutRearmsClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
 actor \nodoc\ _TestIdleTimeoutRearmsServer
   is (TCPConnectionActor & ServerLifecycleEventReceiver)
@@ -875,6 +893,9 @@ actor \nodoc\ _TestIdleTimeoutNoRearmClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     // Never read: the server's FIN goes unanswered and it stays in _Closing.

--- a/lori/_test_ip_version.pony
+++ b/lori/_test_ip_version.pony
@@ -44,6 +44,9 @@ actor \nodoc\ _TestIP4Pinger
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     if _pings_to_send > 0 then
       _tcp_connection.send("Ping")
@@ -181,6 +184,9 @@ actor \nodoc\ _TestIP6Pinger
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     if _pings_to_send > 0 then

--- a/lori/_test_read_buffer.pony
+++ b/lori/_test_read_buffer.pony
@@ -683,5 +683,8 @@ actor \nodoc\ _TestReadBufferTriggerClient is
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     _tcp_connection.close()

--- a/lori/_test_send.pony
+++ b/lori/_test_send.pony
@@ -70,6 +70,9 @@ actor \nodoc\ _TestSendTokenClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     _h.complete_action("client connected")
     match \exhaustive\ _tcp_connection.send("hello")
@@ -177,6 +180,9 @@ actor \nodoc\ _TestSendAfterCloseClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     _h.complete_action("client connected")
@@ -286,6 +292,9 @@ actor \nodoc\ _TestSendvClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     _h.complete_action("client connected")
@@ -405,6 +414,9 @@ actor \nodoc\ _TestSendvEmptyClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     _h.complete_action("client connected")
     match \exhaustive\ _tcp_connection.send(
@@ -492,6 +504,9 @@ actor \nodoc\ _TestSendvMixedEmptyClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     _h.complete_action("client connected")

--- a/lori/_test_ssl.pony
+++ b/lori/_test_ssl.pony
@@ -63,6 +63,9 @@ actor \nodoc\ _TestSSLPinger
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     if _pings_to_send > 0 then
       _tcp_connection.send("Ping")
@@ -260,6 +263,9 @@ actor \nodoc\ _TestSSLSendvClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     _h.complete_action("client connected")
@@ -569,6 +575,9 @@ actor \nodoc\ _TestSSLHandshakeFailurePlainClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     _tcp_connection.send("XXXXXXXXXX")
     _tcp_connection.close()
@@ -655,6 +664,9 @@ actor \nodoc\ _TestSSLTransitionToOpenClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     match \exhaustive\ _tcp_connection.send("test")
@@ -820,6 +832,9 @@ actor \nodoc\ _TestSSLIsWriteablePlainClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
 class \nodoc\ iso _TestSSLHardCloseDuringReceive is UnitTest
   """
   Test that hard_close() from inside _on_received on an SSL connection stops
@@ -912,6 +927,9 @@ actor \nodoc\ _TestSSLHardCloseReceiveClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     // Two buffers, so two TLS records, encrypted and flushed together.
@@ -1046,6 +1064,9 @@ actor \nodoc\ _TestSSLHardCloseOnConnectedClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     _tcp_connection.hard_close()
 
@@ -1169,6 +1190,9 @@ actor \nodoc\ _TestSSLHardCloseOnStartedClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
 actor \nodoc\ _TestSSLHardCloseOnStartedServer
   is (TCPConnectionActor & ServerLifecycleEventReceiver)
   var _tcp_connection: TCPConnection = TCPConnection.none()
@@ -1284,6 +1308,9 @@ actor \nodoc\ _TestSSLCloseReceiveClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     // Two buffers, so two TLS records, encrypted and flushed together.

--- a/lori/_test_start_tls.pony
+++ b/lori/_test_start_tls.pony
@@ -66,6 +66,9 @@ actor \nodoc\ _TestStartTLSClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     _tcp_connection.send("STARTTLS")
 
@@ -248,6 +251,9 @@ actor \nodoc\ _TestStartTLSPreconditionsNotConnectedClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     _tcp_connection.close()
     match _tcp_connection.start_tls(_sslctx)
@@ -286,6 +292,9 @@ actor \nodoc\ _TestStartTLSPreconditionsAlreadyTLSClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     // First start_tls sets _ssl
@@ -329,6 +338,9 @@ actor \nodoc\ _TestStartTLSPreconditionsNotReadyClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     _tcp_connection.mute()
@@ -447,6 +459,9 @@ actor \nodoc\ _TestStartTLSSendDuringUpgradeClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     // Initiate TLS upgrade
@@ -573,6 +588,9 @@ actor \nodoc\ _TestStartTLSHandshakeFailureClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     _tcp_connection.send("STARTTLS")
@@ -734,6 +752,9 @@ actor \nodoc\ _TestStartTLSIsWriteableClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     // Initiate TLS upgrade
     match \exhaustive\ _tcp_connection.start_tls(_sslctx, "localhost")
@@ -856,6 +877,9 @@ actor \nodoc\ _TestStartTLSAuthFailureClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     _tcp_connection.send("STARTTLS")
@@ -1036,6 +1060,9 @@ actor \nodoc\ _TestSetTimerAfterTLSUpgradeClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     _tcp_connection.send("STARTTLS")
@@ -1262,6 +1289,9 @@ actor \nodoc\ _TestStartTLSHardCloseClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     _tcp_connection.send("STARTTLS")

--- a/lori/_test_timer.pony
+++ b/lori/_test_timer.pony
@@ -73,6 +73,9 @@ actor \nodoc\ _TestTimerFiresClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     _h.complete_action("client connected")
 
@@ -185,6 +188,9 @@ actor \nodoc\ _TestTimerCancelClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
 actor \nodoc\ _TestTimerCancelServer
   is (TCPConnectionActor & ServerLifecycleEventReceiver)
@@ -319,6 +325,9 @@ actor \nodoc\ _TestTimerNotResetByIOClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     _tcp_connection.send("ping")
@@ -485,6 +494,9 @@ actor \nodoc\ _TestSetTimerAlreadyActiveClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
 actor \nodoc\ _TestSetTimerAlreadyActiveServer
   is (TCPConnectionActor & ServerLifecycleEventReceiver)
   var _tcp_connection: TCPConnection = TCPConnection.none()
@@ -609,6 +621,9 @@ actor \nodoc\ _TestTimerRearmClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
 actor \nodoc\ _TestTimerRearmServer
   is (TCPConnectionActor & ServerLifecycleEventReceiver)
   var _tcp_connection: TCPConnection = TCPConnection.none()
@@ -716,6 +731,9 @@ actor \nodoc\ _TestTimerCancelWrongTokenClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
 actor \nodoc\ _TestTimerCancelWrongTokenServer
   is (TCPConnectionActor & ServerLifecycleEventReceiver)
@@ -832,6 +850,9 @@ actor \nodoc\ _TestTimerHardCloseClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
 actor \nodoc\ _TestTimerHardCloseServer
   is (TCPConnectionActor & ServerLifecycleEventReceiver)
@@ -951,6 +972,9 @@ actor \nodoc\ _TestTimerSetDuringClosingClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
 actor \nodoc\ _TestTimerSetDuringClosingServer
   is (TCPConnectionActor & ServerLifecycleEventReceiver)
@@ -1239,6 +1263,9 @@ actor \nodoc\ _TestSetTimerNotOpenSSLServerClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
 actor \nodoc\ _TestSetTimerNotOpenSSLServerConn
   is (TCPConnectionActor & ServerLifecycleEventReceiver)
   var _tcp_connection: TCPConnection = TCPConnection.none()
@@ -1356,6 +1383,9 @@ actor \nodoc\ _TestTimerSurvivesCloseClient
 
   fun ref _connection(): TCPConnection =>
     _tcp_connection
+
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
 
   fun ref _on_connected() =>
     match \exhaustive\ MakeTimerDuration(2_000)

--- a/lori/_test_yield_read.pony
+++ b/lori/_test_yield_read.pony
@@ -78,6 +78,9 @@ actor \nodoc\ _TestYieldReadClient
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     // One send, so all twenty messages come out of a single TCP read. Twenty
     // separate sends could arrive as separate reads, and a broken yield would

--- a/lori/client_lifecycle_event_receiver.pony
+++ b/lori/client_lifecycle_event_receiver.pony
@@ -2,6 +2,10 @@ trait ClientLifecycleEventReceiver[TCP: TCPBackend ref = RuntimeBackend]
   """
   Application-level callbacks for client-side TCP connections.
   One receiver per connection, no chaining.
+
+  Every callback has a default implementation except `_on_connection_failure`,
+  which must be implemented because ignoring a failed connection is never
+  correct.
   """
   fun ref _connection(): TCPConnection[TCP]
 
@@ -21,7 +25,7 @@ trait ClientLifecycleEventReceiver[TCP: TCPBackend ref = RuntimeBackend]
     """
     None
 
-  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+  fun ref _on_connection_failure(reason: ConnectionFailureReason)
     """
     Called when a connection fails to open. For SSL connections, this is
     also called when the SSL handshake fails before _on_connected would
@@ -36,7 +40,6 @@ trait ClientLifecycleEventReceiver[TCP: TCPBackend ref = RuntimeBackend]
     `ConnectionFailedTimerError` (the connect timer's ASIO event
     subscription failed).
     """
-    None
 
   fun ref _on_closed() =>
     """

--- a/lori/lori.pony
+++ b/lori/lori.pony
@@ -249,6 +249,9 @@ actor MyStartTLSClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
   fun ref _connection(): TCPConnection =>
     _tcp_connection
 
+  fun ref _on_connection_failure(reason: ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     // Send protocol-specific upgrade request over plaintext
     _tcp_connection.send("STARTTLS")


### PR DESCRIPTION
`ClientLifecycleEventReceiver._on_connection_failure` had a default no-op. An implementor that forgot the method compiled and silently discarded the failure. Removing the default makes it abstract — the compiler now forces every implementor to provide an explicit body.

`ClientTCPConnectionNotify.on_connect_failed` was already abstract, so the notifier API is unchanged.

Closes #378
