### PR TITLE
Fix pony-lint findings for ponyc 0.69.0

### DIFF
--- a/examples/backpressure/backpressure.pony
+++ b/examples/backpressure/backpressure.pony
@@ -104,8 +104,8 @@ actor Flood is (TCPConnectionActor & ClientLifecycleEventReceiver)
     _tcp_connection
 
   fun ref _on_connected() =>
-    _out.print("Flood: connected, sending " + _total_to_send.string()
-      + " chunks of " + _chunk.size().string() + " bytes...")
+    _out.print("Flood: connected, sending " + _total_to_send.string() +
+      " chunks of " + _chunk.size().string() + " bytes...")
     // Defer first send batch to a subsequent turn so backpressure goes
     // through the normal ASIO event path.
     _resume_sends()
@@ -135,9 +135,9 @@ actor Flood is (TCPConnectionActor & ClientLifecycleEventReceiver)
 
   fun ref _on_throttled() =>
     _throttle_count = _throttle_count + 1
-    _out.print("Flood: throttled (#" + _throttle_count.string()
-      + ") — " + _sends_accepted.string() + "/" + _total_to_send.string()
-      + " chunks accepted")
+    _out.print("Flood: throttled (#" + _throttle_count.string() +
+      ") — " + _sends_accepted.string() + "/" + _total_to_send.string() +
+      " chunks accepted")
 
   fun ref _on_unthrottled() =>
     _out.print("Flood: unthrottled, resuming sends")
@@ -155,9 +155,9 @@ actor Flood is (TCPConnectionActor & ClientLifecycleEventReceiver)
   fun ref _on_sent(token: SendToken) =>
     _sends_confirmed = _sends_confirmed + 1
     if _sends_confirmed == _total_to_send then
-      _out.print("Flood: all " + _total_to_send.string()
-        + " sends confirmed by OS. Throttled "
-        + _throttle_count.string() + " time(s).")
+      _out.print("Flood: all " + _total_to_send.string() +
+        " sends confirmed by OS. Throttled " +
+        _throttle_count.string() + " time(s).")
       _tcp_connection.close()
     end
 

--- a/examples/framed-protocol/framed_protocol.pony
+++ b/examples/framed-protocol/framed_protocol.pony
@@ -143,8 +143,8 @@ actor FramedClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
     _tcp_connection
 
   fun ref _on_connected() =>
-    _out.print("Client: connected, sending " + _messages.size().string()
-      + " framed messages...")
+    _out.print("Client: connected, sending " + _messages.size().string() +
+      " framed messages...")
     for msg in _messages.values() do
       _send_framed(msg)
     end
@@ -186,11 +186,11 @@ actor FramedClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
       try
         let expected = _messages(_messages_received - 1)?
         if payload == expected then
-          _out.print("Client: echo " + _messages_received.string()
-            + "/" + _messages.size().string() + ": \"" + payload + "\"")
+          _out.print("Client: echo " + _messages_received.string() +
+            "/" + _messages.size().string() + ": \"" + payload + "\"")
         else
-          _out.print("Client: mismatch! expected \"" + expected
-            + "\" got \"" + payload + "\"")
+          _out.print("Client: mismatch! expected \"" + expected +
+            "\" got \"" + payload + "\"")
         end
       end
 
@@ -200,8 +200,8 @@ actor FramedClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
       end
 
       if _messages_received == _messages.size() then
-        _out.print("Client: all " + _messages.size().string()
-          + " messages echoed successfully")
+        _out.print("Client: all " + _messages.size().string() +
+          " messages echoed successfully")
         _tcp_connection.close()
       end
     end

--- a/examples/read-buffer-size/read_buffer_size.pony
+++ b/examples/read-buffer-size/read_buffer_size.pony
@@ -96,8 +96,8 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
         _control_phase = false
       end
     else
-      _out.print("Server: received " + data.size().string()
-        + " bytes of bulk data")
+      _out.print("Server: received " + data.size().string() +
+        " bytes of bulk data")
       _tcp_connection.close()
     end
     KeepReading

--- a/examples/send-completion/send_completion.pony
+++ b/examples/send-completion/send_completion.pony
@@ -116,8 +116,8 @@ actor Sender is (TCPConnectionActor & ClientLifecycleEventReceiver)
     _tcp_connection
 
   fun ref _on_connected() =>
-    _out.print("Sender: connected, sending " + _messages.size().string()
-      + " messages")
+    _out.print("Sender: connected, sending " + _messages.size().string() +
+      " messages")
     for msg in _messages.values() do
       match \exhaustive\ _tcp_connection.send(msg)
       | SendAccepted => None
@@ -140,15 +140,15 @@ actor Sender is (TCPConnectionActor & ClientLifecycleEventReceiver)
       end
 
     _outstanding(token.id) = msg
-    _out.print("  sent '" + msg + "' (token " + token.id.string()
-      + "), awaiting _on_sent")
+    _out.print("  sent '" + msg + "' (token " + token.id.string() +
+      "), awaiting _on_sent")
 
   fun ref _on_sent(token: SendToken) =>
     try
       (_, let msg) = _outstanding.remove(token.id)?
-      _out.print("_on_sent: '" + msg + "' (token " + token.id.string()
-        + ") reached the OS; " + _outstanding.size().string()
-        + " still outstanding")
+      _out.print("_on_sent: '" + msg + "' (token " + token.id.string() +
+        ") reached the OS; " + _outstanding.size().string() +
+        " still outstanding")
     end
     _maybe_close()
 
@@ -167,8 +167,8 @@ actor Sender is (TCPConnectionActor & ClientLifecycleEventReceiver)
   fun ref _on_send_failed(token: SendToken) =>
     try
       (_, let msg) = _outstanding.remove(token.id)?
-      _out.print("_on_send_failed: '" + msg + "' (token " + token.id.string()
-        + ") did not reach the OS before the connection closed")
+      _out.print("_on_send_failed: '" + msg + "' (token " + token.id.string() +
+        ") did not reach the OS before the connection closed")
     end
 
   fun ref _on_connection_failure(reason: ConnectionFailureReason) =>

--- a/examples/socket-options/socket_options.pony
+++ b/examples/socket-options/socket_options.pony
@@ -95,8 +95,8 @@ actor SocketOptionsServer is (TCPConnectionActor & ServerLifecycleEventReceiver)
         OSSockOpt.sol_socket(), OSSockOpt.so_sndbuf())
 
     if (rcv_errno == 0) and (snd_errno == 0) then
-      _out.print("Server: rcvbuf=" + rcv_size.string()
-        + " sndbuf=" + snd_size.string())
+      _out.print("Server: rcvbuf=" + rcv_size.string() +
+        " sndbuf=" + snd_size.string())
     else
       _out.print("Server: failed to read buffer sizes")
     end

--- a/examples/yield-read/yield_read.pony
+++ b/examples/yield-read/yield_read.pony
@@ -80,8 +80,8 @@ actor Server is (TCPConnectionActor & ServerLifecycleEventReceiver)
     end
 
     if (_received_count % 10) == 0 then
-      _out.print("Server: received " + _received_count.string()
-        + " messages, yielding...")
+      _out.print("Server: received " + _received_count.string() +
+        " messages, yielding...")
       return YieldReading
     end
 

--- a/lori/_connection_state.pony
+++ b/lori/_connection_state.pony
@@ -378,8 +378,8 @@ class _Open[TCP: TCPBackend ref] is _ConnectionState[TCP]
     event: AsioEventID,
     flags: U32)
   =>
-    if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags)
-      or AsioEvent.readable(flags))
+    if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags) or
+      AsioEvent.readable(flags))
     then
       return
     end
@@ -491,8 +491,8 @@ class _Closing[TCP: TCPBackend ref] is _ConnectionState[TCP]
     event: AsioEventID,
     flags: U32)
   =>
-    if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags)
-      or AsioEvent.readable(flags))
+    if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags) or
+      AsioEvent.readable(flags))
     then
       return
     end
@@ -607,8 +607,8 @@ class _UnconnectedClosing[TCP: TCPBackend ref] is _ConnectionState[TCP]
     event: AsioEventID,
     flags: U32)
   =>
-    if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags)
-      or AsioEvent.readable(flags))
+    if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags) or
+      AsioEvent.readable(flags))
     then
       return
     end
@@ -717,8 +717,8 @@ class _Closed[TCP: TCPBackend ref] is _ConnectionState[TCP]
     event: AsioEventID,
     flags: U32)
   =>
-    if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags)
-      or AsioEvent.readable(flags))
+    if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags) or
+      AsioEvent.readable(flags))
     then
       return
     end
@@ -827,8 +827,8 @@ class _SSLHandshaking[TCP: TCPBackend ref] is _ConnectionState[TCP]
     event: AsioEventID,
     flags: U32)
   =>
-    if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags)
-      or AsioEvent.readable(flags))
+    if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags) or
+      AsioEvent.readable(flags))
     then
       return
     end
@@ -946,8 +946,8 @@ class _TLSUpgrading[TCP: TCPBackend ref] is _ConnectionState[TCP]
     event: AsioEventID,
     flags: U32)
   =>
-    if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags)
-      or AsioEvent.readable(flags))
+    if not (AsioEvent.errored(flags) or AsioEvent.writeable(flags) or
+      AsioEvent.readable(flags))
     then
       return
     end

--- a/lori/_test_backpressure_drain.pony
+++ b/lori/_test_backpressure_drain.pony
@@ -210,8 +210,8 @@ actor \nodoc\ _TestBackpressureDrainClient
       _h.complete_action("client receiving data")
     end
     _total_received = _total_received + data.size()
-    _h.log("client received " + _total_received.string() + " of "
-      + _payload_size.string())
+    _h.log("client received " + _total_received.string() + " of " +
+      _payload_size.string())
     if not _sent_ping and (_total_received >= _payload_size) then
       _sent_ping = true
       _h.complete_action("client sent ping")

--- a/lori/_test_flow_control.pony
+++ b/lori/_test_flow_control.pony
@@ -538,8 +538,8 @@ actor \nodoc\ _TestMuteWithFullReadBufferServer
     end
 
     if data.size() != 4 then
-      _h.fail("message was " + data.size().string()
-        + " bytes; buffer_until(4) is not framing")
+      _h.fail("message was " + data.size().string() +
+        " bytes; buffer_until(4) is not framing")
       _h.complete(false)
       return KeepReading
     end
@@ -552,8 +552,8 @@ actor \nodoc\ _TestMuteWithFullReadBufferServer
       // assumed — the test is worthless if it never built the state.
       let free = _tcp_connection._read_buffer_free_space()
       if free != 0 then
-        _h.fail("muting with " + free.string()
-          + " bytes free in the read buffer; wanted a full one")
+        _h.fail("muting with " + free.string() +
+          " bytes free in the read buffer; wanted a full one")
         _h.complete(false)
         return KeepReading
       end
@@ -580,8 +580,8 @@ actor \nodoc\ _TestMuteWithFullReadBufferServer
       let want = ((_bytes_received + i) % 256).u8()
       let got = try d(i)? else _Unreachable(); 0 end
       if got != want then
-        _h.fail("byte " + (_bytes_received + i).string() + " was "
-          + got.string() + ", wanted " + want.string())
+        _h.fail("byte " + (_bytes_received + i).string() + " was " +
+          got.string() + ", wanted " + want.string())
         _h.complete(false)
         return KeepReading
       end
@@ -591,8 +591,8 @@ actor \nodoc\ _TestMuteWithFullReadBufferServer
     _bytes_received = _bytes_received + d.size()
     if _bytes_received >= 1024 then
       if _bytes_received > 1024 then
-        _h.fail("received " + _bytes_received.string()
-          + " bytes, wanted 1024")
+        _h.fail("received " + _bytes_received.string() +
+          " bytes, wanted 1024")
         _h.complete(false)
       else
         _done = true
@@ -790,8 +790,8 @@ actor \nodoc\ _TestSSLMuteServer
     let got: String val = String.from_iso_array(consume data)
     let want = try _chunks(_received - 1)? else "" end
     if got != want then
-      _h.fail("message " + _received.string() + " was '" + got + "', wanted '"
-        + want + "'")
+      _h.fail("message " + _received.string() + " was '" + got + "', wanted '" +
+        want + "'")
       _h.complete(false)
       return KeepReading
     end
@@ -815,8 +815,8 @@ actor \nodoc\ _TestSSLMuteServer
       if _unmutes == _mute_on.size() then
         _h.complete(true)
       else
-        _h.fail("all messages arrived after " + _unmutes.string()
-          + " unmutes, wanted " + _mute_on.size().string())
+        _h.fail("all messages arrived after " + _unmutes.string() +
+          " unmutes, wanted " + _mute_on.size().string())
         _h.complete(false)
       end
     end
@@ -972,8 +972,8 @@ actor \nodoc\ _TestSSLMuteCloseServer
     _received = _received + 1
 
     if _received > 1 then
-      _h.fail("message " + _received.string()
-        + " was delivered; mute should have held it and close dropped it")
+      _h.fail("message " + _received.string() +
+        " was delivered; mute should have held it and close dropped it")
       return KeepReading
     end
 

--- a/lori/_test_read_buffer.pony
+++ b/lori/_test_read_buffer.pony
@@ -416,8 +416,8 @@ actor \nodoc\ _TestResizeReadBufferBelowBufferSizeServer is
       | let _: ReadBufferResizeBelowBufferSize => None
       | let _: ReadBufferResizeBelowUsed =>
         _h.fail(
-          "should be ReadBufferResizeBelowBufferSize, "
-          + "not ReadBufferResizeBelowUsed")
+          "should be ReadBufferResizeBelowBufferSize, " +
+          "not ReadBufferResizeBelowUsed")
       end
     | let _: ValidationFailure =>
       _h.fail("MakeReadBufferSize(100) should succeed")

--- a/lori/_test_send.pony
+++ b/lori/_test_send.pony
@@ -2738,14 +2738,14 @@ actor \nodoc\ _TestSendDeliveredServer
       end
       k = k + 1
     end
-    _h.log("peer=" + bytes.string() + " reached_os=" + reached_os.string()
-      + " on_sent=" + _sent_ids.size().string()
-      + " on_send_failed=" + _failed_ids.size().string())
+    _h.log("peer=" + bytes.string() + " reached_os=" + reached_os.string() +
+      " on_sent=" + _sent_ids.size().string() +
+      " on_send_failed=" + _failed_ids.size().string())
     _h.assert_true(
       _sent_ids.size() >= reached_os,
-      "the peer holds " + bytes.string() + " bytes, so " + reached_os.string()
-        + " sends reached the OS, but only " + _sent_ids.size().string()
-        + " reported _on_sent")
+      "the peer holds " + bytes.string() + " bytes, so " + reached_os.string() +
+        " sends reached the OS, but only " + _sent_ids.size().string() +
+        " reported _on_sent")
     _h.complete_action("split verified")
 
   be dispose() =>

--- a/lori/_test_socket_options.pony
+++ b/lori/_test_socket_options.pony
@@ -102,8 +102,8 @@ actor \nodoc\ _TestSocketOptionsServer is
       "getsockopt_u32 SO_RCVBUF errno should be 0")
     _h.assert_true(
       gen_get_size >= 16384,
-      "getsockopt_u32 SO_RCVBUF should return >= 16384, got "
-        + gen_get_size.string())
+      "getsockopt_u32 SO_RCVBUF should return >= 16384, got " +
+        gen_get_size.string())
 
     // setsockopt/getsockopt: set SO_SNDBUF via raw bytes, read back via
     // raw bytes.
@@ -127,8 +127,8 @@ actor \nodoc\ _TestSocketOptionsServer is
       let raw_get_size = (consume raw_get_bytes).read_u32(0)?
       _h.assert_true(
         raw_get_size >= 16384,
-        "getsockopt SO_SNDBUF should return >= 16384, got "
-          + raw_get_size.string())
+        "getsockopt SO_SNDBUF should return >= 16384, got " +
+          raw_get_size.string())
     else
       _h.fail("getsockopt SO_SNDBUF returned too few bytes")
     end

--- a/lori/_test_ssl.pony
+++ b/lori/_test_ssl.pony
@@ -1504,8 +1504,8 @@ actor \nodoc\ _TestSSLLargePayloadServer
 
   fun ref _on_received(data: Array[U8] iso): ReadAction =>
     if data.size() != 1000 then
-      _h.fail("frame " + _frames.string() + " was " + data.size().string()
-        + " bytes, wanted 1000")
+      _h.fail("frame " + _frames.string() + " was " + data.size().string() +
+        " bytes, wanted 1000")
       _h.complete(false)
       return KeepReading
     end
@@ -1513,8 +1513,8 @@ actor \nodoc\ _TestSSLLargePayloadServer
     let want = _frames.u8()
     for b in (consume data).values() do
       if b != want then
-        _h.fail("frame " + _frames.string() + " holds byte " + b.string()
-          + ", wanted " + want.string())
+        _h.fail("frame " + _frames.string() + " holds byte " + b.string() +
+          ", wanted " + want.string())
         _h.complete(false)
         return KeepReading
       end

--- a/lori/connection_timeout.pony
+++ b/lori/connection_timeout.pony
@@ -19,9 +19,9 @@ primitive ConnectionTimeoutValidator is Validator[U64]
     elseif value > _max_millis() then
       recover val
         ValidationFailure(
-          "connection timeout must be at most "
-            + _max_millis().string()
-            + " milliseconds")
+          "connection timeout must be at most " +
+            _max_millis().string() +
+            " milliseconds")
       end
     else
       ValidationSuccess

--- a/lori/idle_timeout.pony
+++ b/lori/idle_timeout.pony
@@ -19,9 +19,9 @@ primitive IdleTimeoutValidator is Validator[U64]
     elseif value > _max_millis() then
       recover val
         ValidationFailure(
-          "idle timeout must be at most "
-            + _max_millis().string()
-            + " milliseconds")
+          "idle timeout must be at most " +
+            _max_millis().string() +
+            " milliseconds")
       end
     else
       ValidationSuccess

--- a/lori/tcp_connection.pony
+++ b/lori/tcp_connection.pony
@@ -998,9 +998,9 @@ class TCPConnection[TCP: TCPBackend ref = RuntimeBackend]
     `_close_notify_then_shutdown()` sends the alert when the write queue
     drains, then calls back into this method for FIN.
     """
-    if _shutdown
-      or (_inflight_connections > 0)
-      or _has_pending_writes()
+    if _shutdown or
+      (_inflight_connections > 0) or
+      _has_pending_writes()
     then
       return
     end
@@ -1320,8 +1320,8 @@ class TCPConnection[TCP: TCPBackend ref = RuntimeBackend]
       end
     if needs_grow then
       _read_buffer.undefined(_read_buffer_size)
-    elseif (_bytes_in_read_buffer == 0)
-      and (_read_buffer_size > _read_buffer_min)
+    elseif (_bytes_in_read_buffer == 0) and
+      (_read_buffer_size > _read_buffer_min)
     then
       _read_buffer_size = _read_buffer_min
       _read_buffer =

--- a/lori/timer_duration.pony
+++ b/lori/timer_duration.pony
@@ -19,9 +19,9 @@ primitive TimerDurationValidator is Validator[U64]
     elseif value > _max_millis() then
       recover val
         ValidationFailure(
-          "timer duration must be at most "
-            + _max_millis().string()
-            + " milliseconds")
+          "timer duration must be at most " +
+            _max_millis().string() +
+            " milliseconds")
       end
     else
       ValidationSuccess

--- a/stress-tests/tcp-swarm/tcp_swarm.pony
+++ b/stress-tests/tcp-swarm/tcp_swarm.pony
@@ -310,8 +310,8 @@ primitive _MakeConfig
       else
         return recover val
           ValidationFailure(
-            "--write-shape must be 'write' or 'writev', got '" + write_shape
-              + "'")
+            "--write-shape must be 'write' or 'writev', got '" + write_shape +
+              "'")
         end
       end
 
@@ -324,15 +324,16 @@ primitive _MakeConfig
       if expect_frame > read_buffer_size then
         return recover val
           ValidationFailure(
-            "--expect (" + expect_frame.string() + ") must not exceed "
-              + "--read-buffer-size (" + read_buffer_size.string() + ")")
+            "--expect (" + expect_frame.string() + ") must not exceed " +
+              "--read-buffer-size (" + read_buffer_size.string() + ")")
         end
       end
       if (target_total % expect_frame) != 0 then
         return recover val
           ValidationFailure(
-            "--expect (" + expect_frame.string() + ") must divide payload-size "
-              + "* messages (" + target_total.string() + ")")
+            "--expect (" + expect_frame.string() +
+              ") must divide payload-size * messages (" +
+              target_total.string() + ")")
         end
       end
     end
@@ -554,9 +555,9 @@ actor Spawner
     _try_finish()
 
   fun ref _try_finish() =>
-    if (not _finished)
-      and (_spawned >= _config.connections)
-      and (_inflight == 0)
+    if (not _finished) and
+      (_spawned >= _config.connections) and
+      (_inflight == 0)
     then
       _finished = true
       // A final heartbeat with the true completed count before the timer stops:
@@ -583,8 +584,8 @@ actor Spawner
     // FAIL line below repeats `connect_failed=`, so a FAIL emitted first would
     // be misread. (orchestrate_tcp.py: parse_result)
     @printf(
-      ("RESULT connections=%zu spawned=%zu completed=%zu failed=%zu "
-        + "verified=%zu mismatched=%zu\n").cstring(),
+      ("RESULT connections=%zu spawned=%zu completed=%zu failed=%zu " +
+        "verified=%zu mismatched=%zu\n").cstring(),
       _config.connections,
       _spawned,
       _completed,
@@ -601,8 +602,8 @@ actor Spawner
     else
       let truncated = (_completed - _verified) - _mismatched
       @printf(
-        ("FAIL: %zu of %zu connections did not verify "
-          + "(connect_failed=%zu truncated=%zu mismatched=%zu)\n").cstring(),
+        ("FAIL: %zu of %zu connections did not verify " +
+          "(connect_failed=%zu truncated=%zu mismatched=%zu)\n").cstring(),
         _config.connections - _verified,
         _config.connections,
         _failed,
@@ -819,8 +820,8 @@ actor SwarmClient is (TCPConnectionActor & ClientLifecycleEventReceiver)
     if _closing then
       return
     end
-    while (_messages_sent < _config.messages)
-      and _tcp_connection.is_writeable()
+    while (_messages_sent < _config.messages) and
+      _tcp_connection.is_writeable()
     do
       if _config.use_writev then
         _tcp_connection.send(_Keystream.make_chunks(
@@ -952,8 +953,8 @@ primitive _Unreachable
   fun apply(loc: SourceLoc = __loc) =>
     @fprintf(
       @pony_os_stderr(),
-      ("Reached unreachable code at %s:%s\n"
-        + "Please open an issue at https://github.com/ponylang/lori/issues\n")
+      ("Reached unreachable code at %s:%s\n" +
+        "Please open an issue at https://github.com/ponylang/lori/issues\n")
         .cstring(),
       loc.file().cstring(),
       loc.line().string().cstring())


### PR DESCRIPTION
Fix pony-lint operator-spacing and line-length errors surfaced by ponyc 0.69.0 rules. Public API unchanged; no release note or CHANGELOG entry.