### PR TITLE
Require ponyc 0.69.1 or later

### DIFF
--- a/.release-notes/require-ponyc-0.69.1.md
+++ b/.release-notes/require-ponyc-0.69.1.md
@@ -1,0 +1,3 @@
+## Require ponyc 0.69.1 or later
+
+lori now requires ponyc 0.69.1 or later, up from 0.67.0. lori's TCP connection and listener types are generic with a default backend type argument, and ponyc before 0.69.1 cannot resolve that default when lori is imported under an alias — `use lori = "lori"` — so a program that imports lori that way fails to compile. ponyc 0.69.1 resolves it.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Please note that if this library encounters a state that the programmers thought
 - `use "lori"` to include this package
 - `corral run -- ponyc` to compile your application
 
-Requires ponyc 0.67.0 or later.
+Requires ponyc 0.69.1 or later.
 
 Note: The ssl transitive dependency requires a C SSL library to be installed. Please see the ssl installation instructions for more information.
 


### PR DESCRIPTION
lori 0.19.0's TCP types are generic with a default backend, and ponyc before 0.69.1 can't resolve that default when lori is imported under an alias (`use lori = "lori"`) — so a program that imports lori that way fails to compile. This bumps the stated minimum ponyc to 0.69.1.
